### PR TITLE
Add Dockerfile-dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ __pycache__/
 .pytest_cache/
 .coverage
 htmlcov/
+
+# Include when developing application packages.
+.vscode/launch.json
+.vscode/settings.json
+.vscode/tasks.json
+.vimrc

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,16 @@
+FROM python:3.8-alpine
+
+RUN apk add build-base
+
+WORKDIR /srv/code
+
+EXPOSE 8000
+
+COPY requirements.txt .
+COPY requirements_production.txt .
+RUN pip install -U -r requirements.txt
+
+COPY gunicorn_conf.py .
+COPY openslides_backend/ ./openslides_backend/
+
+CMD [ "gunicorn", "--config=python:gunicorn_conf", "--reload", "openslides_backend.wsgi:application" ]

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,9 @@ test:
 
 test_all:
 	OPENSLIDES_BACKEND_RUN_ALL_TESTS=1 pytest
+
+docker-build-dev:
+	docker build -f Dockerfile-dev . -t os4-backend
+
+docker-run-dev:
+	docker run -it -v ${PWD}/openslides_backend:/srv/code/openslides_backend -p 8000:8000 --rm os4-backend


### PR DESCRIPTION
Adds the Dockerfile-dev which executes the developing starting commands
in a docker container.
Required to attach other services using docker environment.

Adds the docker building instructions to the makefile