### PR TITLE
Fix dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ __pycache__/
 .pytest_cache/
 .coverage
 htmlcov/
+
+# Editors
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.8
 
 WORKDIR /srv/code
 
@@ -9,6 +9,6 @@ RUN pip install --no-cache-dir --requirement requirements_production.txt
 
 COPY gunicorn_conf.py .
 
-CMD [ "gunicorn", "--config=python:gunicorn_conf", "openslides_backend.wsgi:application" ]
+CMD [ "gunicorn", "--config=python:gunicorn_conf", "openslides_backend.main:application" ]
 
 COPY openslides_backend/ ./openslides_backend/

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ To start it run
 
 or
 
-    $ OPENSLIDES_BACKEND_DEBUG=1 gunicorn --config=python:gunicorn_conf openslides_backend.wsgi:application
+    $ OPENSLIDES_BACKEND_DEBUG=1 gunicorn --config=python:gunicorn_conf openslides_backend.main:application

--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -5,3 +5,4 @@ requests==2.22.0
 mypy-extensions==0.4.3
 dependency_injector==3.14.12
 gunicorn==20.0.4
+typing_extensions==3.7.4


### PR DESCRIPTION
The current Dockerfile has two problems.

1. It can not be build because some of your dependencies need gcc but there is not gcc installed in alpine-linux. I fixed it be using `python:3.8` as distribution, of curse, there are other possibilities. I think the best solution would be to use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/)

2. You changed the name of the "main" file from `wsgi.py` to `main.py`. I changed it in the README and the Dockerfile accordingly.

3. There where one requirement missing in the `requirements_production.txt`

Is it possible to test with travis or another tool, that the dockerfile can be build and started?