### PR TITLE
Implementing new presenter interface.

### DIFF
--- a/openslides_backend/actions/actions.py
+++ b/openslides_backend/actions/actions.py
@@ -30,9 +30,9 @@ def register_action(name: str) -> Callable[[Type[Action]], Type[Action]]:
     be found by the handler.
     """
 
-    def wrapper(action: Type[Action]) -> Type[Action]:
-        actions_map[name] = action
-        return action
+    def wrapper(clazz: Type[Action]) -> Type[Action]:
+        actions_map[name] = clazz
+        return clazz
 
     return wrapper
 

--- a/openslides_backend/actions/actions_interface.py
+++ b/openslides_backend/actions/actions_interface.py
@@ -3,8 +3,6 @@ from typing import Any, Dict, List, Union
 from mypy_extensions import TypedDict
 from typing_extensions import Protocol
 
-from ..shared.interfaces import LoggingModule, Services
-
 ActionPayload = Union[List[Dict[str, Any]], Dict[str, Any]]
 ActionPayloadWithLabel = TypedDict(
     "ActionPayloadWithLabel", {"action": str, "data": ActionPayload}
@@ -22,11 +20,5 @@ class Actions(Protocol):  # pragma: no cover
     the request fails.
     """
 
-    def handle_request(
-        self,
-        payload: Payload,
-        user_id: int,
-        logging: LoggingModule,
-        services: Services,
-    ) -> List[ActionResult]:
+    def handle_request(self, payload: Payload, user_id: int,) -> List[ActionResult]:
         ...

--- a/openslides_backend/http/views.py
+++ b/openslides_backend/http/views.py
@@ -33,10 +33,15 @@ class BaseView:
         self.logger = logging.getLogger(__name__)
 
     def get_user_id_from_headers(self, headers: Headers) -> int:
+        """
+        Returns user id from authentication service using HTTP headers.
+        """
         try:
-            return self.services.authentication().get_user(headers)
+            user_id = self.services.authentication().get_user(headers)
         except AuthenticationException as exception:
             raise ViewException(exception.message, status_code=400)
+        self.logger.debug(f"User id is {user_id}.")
+        return user_id
 
 
 class ActionsView(BaseView):
@@ -52,8 +57,11 @@ class ActionsView(BaseView):
         Dispatches request to the viewpoint.
         """
         self.logger.debug("Start dispatching actions request.")
+
+        # Get user id.
         user_id = self.get_user_id_from_headers(headers)
-        # Setup payload
+
+        # Setup payload.
         payload: ActionsPayload = body
 
         # Handle request.
@@ -83,14 +91,16 @@ class PresenterView(BaseView):
         """
         self.logger.debug("Start dispatching presenter request.")
 
-        # Setup payload
+        # Get user_id.
+        user_id = self.get_user_id_from_headers(headers)
+
+        # Setup payload.
         payload: PresenterPayload = body
 
         # Handle request.
         handler: Presenter = PresenterHandler(
             logging=self.logging, services=self.services,
         )
-        user_id = self.get_user_id_from_headers(headers)
         try:
             presenter_response = handler.handle_request(payload, user_id)
         except PresenterException as exception:

--- a/openslides_backend/presenter/__init__.py
+++ b/openslides_backend/presenter/__init__.py
@@ -1,1 +1,3 @@
+from . import initial_data  # noqa
+from . import whoami  # noqa
 from .presenter_interface import *  # noqa

--- a/openslides_backend/presenter/base.py
+++ b/openslides_backend/presenter/base.py
@@ -1,33 +1,19 @@
-from typing import Any
-
-presenters = {}
+from typing import Any, Dict
 
 
-def register_presenter(name: str) -> Any:
-    """Decoratorfunction
-       @register_presenter is used for
-       automagic adding presenters to the registry (presenters)
-    Arguments:
-        name {string} -- registry the decorated class
+class PresenterBase:  # pragma: no cover
+    """
+    Abstract base class for presenters.
     """
 
-    def wrapper(clazz: object) -> object:
-        """Wrapper / inner function of decorator
-
-        Arguments:
-            clazz {object} -- The actual decorated class
-
-        Returns:
-            [object] -- The decorated class
-        """
-        presenters[name] = clazz
-        return clazz
-
-    return wrapper
+    @property
+    def data(self) -> Dict[Any, Any]:
+        ...
 
 
-class PresenterBase:
-    """Baseclass for Presenters
+class Presenter(PresenterBase):
+    """
+    Base clase for presenters.
     """
 
     pass

--- a/openslides_backend/presenter/base.py
+++ b/openslides_backend/presenter/base.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+presenters = {}
+
+
+def register_presenter(name: str) -> Any:
+    """Decoratorfunction
+       @register_presenter is used for
+       automagic adding presenters to the registry (presenters)
+    Arguments:
+        name {string} -- registry the decorated class
+    """
+
+    def wrapper(clazz: object) -> object:
+        """Wrapper / inner function of decorator
+
+        Arguments:
+            clazz {object} -- The actual decorated class
+
+        Returns:
+            [object] -- The decorated class
+        """
+        presenters[name] = clazz
+        return clazz
+
+    return wrapper
+
+
+class PresenterBase:
+    """Baseclass for Presenters
+    """
+
+    pass

--- a/openslides_backend/presenter/initial_data.py
+++ b/openslides_backend/presenter/initial_data.py
@@ -1,0 +1,18 @@
+from .base import PresenterBase, register_presenter
+
+
+@register_presenter("initial-data")
+class InitialData(PresenterBase):
+    """Initial Data for setup
+    """
+
+    @property
+    def data(self) -> object:
+        return {
+            "privacy_policy": "The PP",
+            "legal_notice": "The LN",
+            "theme": "openslides-default",
+            "logo_web_header_path": None,
+            "login_info_text": None,
+            "saml_settings": None,
+        }

--- a/openslides_backend/presenter/initial_data.py
+++ b/openslides_backend/presenter/initial_data.py
@@ -1,13 +1,17 @@
-from .base import PresenterBase, register_presenter
+from typing import Any, Dict
+
+from .base import Presenter
+from .presenter import register_presenter
 
 
 @register_presenter("initial-data")
-class InitialData(PresenterBase):
-    """Initial Data for setup
+class InitialData(Presenter):
+    """
+    Initial data for setup
     """
 
     @property
-    def data(self) -> object:
+    def data(self) -> Dict[Any, Any]:
         return {
             "privacy_policy": "The PP",
             "legal_notice": "The LN",

--- a/openslides_backend/presenter/presenter_interface.py
+++ b/openslides_backend/presenter/presenter_interface.py
@@ -3,9 +3,7 @@ from typing import Any, Dict, List
 from mypy_extensions import TypedDict
 from typing_extensions import Protocol
 
-from ..shared.interfaces import LoggingModule, Services
-
-PresenterBlob = TypedDict("PresenterBlob", {"user_id": int, "presentation": str})
+PresenterBlob = TypedDict("PresenterBlob", {"presenter": str, "data": Any})
 Payload = List[PresenterBlob]
 PresenterResponse = List[Dict[Any, Any]]
 
@@ -17,7 +15,5 @@ class Presenter(Protocol):  # pragma: no cover
     The handle_request method raises PresenterException if the request fails.
     """
 
-    def handle_request(
-        self, payload: Payload, logging: LoggingModule, services: Services,
-    ) -> PresenterResponse:
+    def handle_request(self, payload: Payload, user_id: int) -> PresenterResponse:
         ...

--- a/openslides_backend/presenter/presenter_interface.py
+++ b/openslides_backend/presenter/presenter_interface.py
@@ -3,7 +3,9 @@ from typing import Any, Dict, List
 from mypy_extensions import TypedDict
 from typing_extensions import Protocol
 
-PresenterBlob = TypedDict("PresenterBlob", {"presenter": str, "data": Any})
+PresenterBlob = TypedDict(
+    "PresenterBlob", {"presenter": str, "data": Any}
+)  # TODO: Check if Any is correct here.
 Payload = List[PresenterBlob]
 PresenterResponse = List[Dict[Any, Any]]
 

--- a/openslides_backend/presenter/whoami.py
+++ b/openslides_backend/presenter/whoami.py
@@ -1,13 +1,17 @@
-from .base import PresenterBase, register_presenter
+from typing import Any, Dict
+
+from .base import Presenter
+from .presenter import register_presenter
 
 
 @register_presenter("whoami")
-class Whoami(PresenterBase):
-    """Whoami represents the users identity
+class Whoami(Presenter):
+    """
+    Whoami represents the users identity
     """
 
     @property
-    def data(self) -> object:
+    def data(self) -> Dict[Any, Any]:
         return {
             "auth_type": "default",
             "permissions": [],

--- a/openslides_backend/presenter/whoami.py
+++ b/openslides_backend/presenter/whoami.py
@@ -1,0 +1,18 @@
+from .base import PresenterBase, register_presenter
+
+
+@register_presenter("whoami")
+class Whoami(PresenterBase):
+    """Whoami represents the users identity
+    """
+
+    @property
+    def data(self) -> object:
+        return {
+            "auth_type": "default",
+            "permissions": [],
+            "user_id": 1,
+            "guest_enabled": True,
+            "groups_id": [2],
+            "short_name": "username",
+        }

--- a/openslides_backend/shared/handlers/__init__.py
+++ b/openslides_backend/shared/handlers/__init__.py
@@ -1,0 +1,13 @@
+from ..interfaces import LoggingModule, Services
+
+
+class Base:
+    """Baseclass for handlers
+    """
+
+    def __init__(self, services: Services, logging: LoggingModule):
+        self.services = services
+        self.logging = logging
+        self.logger = logging.getLogger(__name__)
+        self.permission = self.services.permission
+        self.database = self.services.database

--- a/openslides_backend/shared/handlers/__init__.py
+++ b/openslides_backend/shared/handlers/__init__.py
@@ -2,10 +2,11 @@ from ..interfaces import LoggingModule, Services
 
 
 class Base:
-    """Baseclass for handlers
+    """
+    Base class for handlers
     """
 
-    def __init__(self, services: Services, logging: LoggingModule):
+    def __init__(self, services: Services, logging: LoggingModule) -> None:
         self.services = services
         self.logging = logging
         self.logger = logging.getLogger(__name__)

--- a/tests/presenter/test_base.py
+++ b/tests/presenter/test_base.py
@@ -11,30 +11,54 @@ from ..utils import Client, ResponseWrapper, create_test_application
 
 class PresenterBaseUnitTester(TestCase):
     def setUp(self) -> None:
-        self.presenter_handler = PresenterHandler()
+        self.presenter_handler = PresenterHandler(
+            logging=MagicMock(), services=MagicMock(),
+        )
         self.user_id = 0
 
     def test_with_bad_key(self) -> None:
-        payload = [
-            PresenterBlob(
-                user_id=self.user_id, presentation="non_existing_presentation",
-            )
-        ]
+        payload = [PresenterBlob(presenter="non_existing_presentation", data={})]
         with self.assertRaises(PresenterException) as context_manager:
             self.presenter_handler.handle_request(
-                payload=payload, logging=MagicMock(), services=MagicMock(),
+                payload=payload, user_id=self.user_id,
             )
         self.assertEqual(
             context_manager.exception.message,
             f"Presentation non_existing_presentation does not exist.",
         )
 
-    def test_presenter_handler(self) -> None:
-        payload = [PresenterBlob(user_id=self.user_id, presentation="dummy",)]
+    def test_initial_data(self) -> None:
+        payload = [PresenterBlob(presenter="initial-data", data={})]
         response = self.presenter_handler.handle_request(
-            payload=payload, logging=MagicMock(), services=MagicMock(),
+            payload=payload, user_id=self.user_id,
         )
-        expected = [{"dummy": "dummy"}]
+        expected = [
+            {
+                "privacy_policy": "The PP",
+                "legal_notice": "The LN",
+                "theme": "openslides-default",
+                "logo_web_header_path": None,
+                "login_info_text": None,
+                "saml_settings": None,
+            }
+        ]
+        self.assertEqual(response, expected)
+
+    def test_whoami(self) -> None:
+        payload = [PresenterBlob(presenter="whoami", data={})]
+        response = self.presenter_handler.handle_request(
+            payload=payload, user_id=self.user_id,
+        )
+        expected = [
+            {
+                "auth_type": "default",
+                "permissions": [],
+                "user_id": 1,
+                "guest_enabled": True,
+                "groups_id": [2],
+                "short_name": "username",
+            }
+        ]
         self.assertEqual(response, expected)
 
 
@@ -47,21 +71,16 @@ class PresenterBaseWSGITester(TestCase):
 
     def test_wsgi_request_empty(self) -> None:
         client = Client(self.application, ResponseWrapper)
-        response = client.get("/", json=[{"user_id": self.user_id, "presentation": ""}])
+        response = client.get("/", json=[{"presenter": ""}])
         self.assertEqual(response.status_code, 400)
         self.assertIn(
-            "data[0].presentation must be longer than or equal to 1 characters",
+            "data[0].presenter must be longer than or equal to 1 characters",
             str(response.data),
         )
 
     def test_wsgi_request_fuzzy(self) -> None:
         client = Client(self.application, ResponseWrapper)
-        response = client.get(
-            "/",
-            json=[
-                {"user_id": self.user_id, "presentation": "non_existing_presentation"}
-            ],
-        )
+        response = client.get("/", json=[{"presenter": "non_existing_presentation"}],)
         self.assertEqual(response.status_code, 400)
         self.assertIn(
             "Presentation non_existing_presentation does not exist.",
@@ -70,9 +89,32 @@ class PresenterBaseWSGITester(TestCase):
 
     def test_wsgi_request_correct_1(self) -> None:
         client = Client(self.application, ResponseWrapper)
-        response = client.get(
-            "/", json=[{"user_id": self.user_id, "presentation": "dummy"}],
-        )
+        response = client.get("/", json=[{"presenter": "initial-data"}],)
         self.assertEqual(response.status_code, 200)
-        expected = [{"dummy": "dummy"}]
+        expected = [
+            {
+                "privacy_policy": "The PP",
+                "legal_notice": "The LN",
+                "theme": "openslides-default",
+                "logo_web_header_path": None,
+                "login_info_text": None,
+                "saml_settings": None,
+            }
+        ]
+        self.assertEqual(json.loads(response.data), expected)
+
+    def test_wsgi_whoami(self) -> None:
+        client = Client(self.application, ResponseWrapper)
+        response = client.get("/", json=[{"presenter": "whoami"}],)
+        self.assertEqual(response.status_code, 200)
+        expected = [
+            {
+                "auth_type": "default",
+                "permissions": [],
+                "user_id": 1,
+                "guest_enabled": True,
+                "groups_id": [2],
+                "short_name": "username",
+            }
+        ]
         self.assertEqual(json.loads(response.data), expected)

--- a/tests/presenter/test_base.py
+++ b/tests/presenter/test_base.py
@@ -17,14 +17,14 @@ class PresenterBaseUnitTester(TestCase):
         self.user_id = 0
 
     def test_with_bad_key(self) -> None:
-        payload = [PresenterBlob(presenter="non_existing_presentation", data={})]
+        payload = [PresenterBlob(presenter="non_existing_presenter", data={})]
         with self.assertRaises(PresenterException) as context_manager:
             self.presenter_handler.handle_request(
                 payload=payload, user_id=self.user_id,
             )
         self.assertEqual(
             context_manager.exception.message,
-            f"Presentation non_existing_presentation does not exist.",
+            f"Presenter non_existing_presenter does not exist.",
         )
 
     def test_initial_data(self) -> None:
@@ -80,11 +80,10 @@ class PresenterBaseWSGITester(TestCase):
 
     def test_wsgi_request_fuzzy(self) -> None:
         client = Client(self.application, ResponseWrapper)
-        response = client.get("/", json=[{"presenter": "non_existing_presentation"}],)
+        response = client.get("/", json=[{"presenter": "non_existing_presenter"}],)
         self.assertEqual(response.status_code, 400)
         self.assertIn(
-            "Presentation non_existing_presentation does not exist.",
-            str(response.data),
+            "Presenter non_existing_presenter does not exist.", str(response.data),
         )
 
     def test_wsgi_request_correct_1(self) -> None:


### PR DESCRIPTION
Implementation according to
https://github.com/OpenSlides/OpenSlides/blob/openslides4-dev/docs/interfaces/presenter-service.txt

I added the "initial-data"-presenter and the "whomai"-presenter (which may be dropped as @FinnStutzenstein mentioned).

Regarding the registry pattern, I had a look into 
https://stackoverflow.com/questions/5189232/how-to-auto-register-a-class-when-its-defined
which looks like a nice alternatice to the decorator. But I decided against it because one is in need of a class variable which looks more magical than a simple argument in a decorator.

I improved the construct found in https://github.com/OpenSlides/openslides-backend/blob/master/openslides_backend/actions/actions.py to the extent, that I placed the registry alongside the base class https://github.com/ThomasJunk/openslides-backend/blob/new_presenter/openslides_backend/presenter/base.py and did the import in the module entry https://github.com/ThomasJunk/openslides-backend/blob/new_presenter/openslides_backend/presenter/__init__.py

so no extra call to a "register" function is needed. Only the python module loading.

Tests were added too

Please review.