### PR TITLE
Completing the implementation of the datastore interface

### DIFF
--- a/openslides_backend/main.py
+++ b/openslides_backend/main.py
@@ -13,7 +13,7 @@ from .environment import get_environment
 from .http.application import OpenSlidesBackendWSGIApplication
 from .http.views import ActionsView, PresenterView
 from .services.authentication import AuthenticationHTTPAdapter
-from .services.database import DatabaseHTTPAdapter
+from .services.database import DatabaseAdapter, HTTPEngine
 from .services.event_store import EventStoreHTTPAdapter
 from .services.permission import PermissionHTTPAdapter
 from .shared.interfaces import View, WSGIApplication
@@ -33,7 +33,8 @@ class OpenSlidesBackendServices(containers.DeclarativeContainer):
         AuthenticationHTTPAdapter, config.authentication_url, logging
     )
     permission = providers.Singleton(PermissionHTTPAdapter, config.permission_url)
-    database = providers.Singleton(DatabaseHTTPAdapter, config.database_url, logging)
+    engine = providers.Singleton(HTTPEngine, config.database_url, logging)
+    database = providers.Singleton(DatabaseAdapter, engine, logging)
     event_store = providers.Singleton(EventStoreHTTPAdapter, config.event_store_url)
 
 

--- a/openslides_backend/services/database.py
+++ b/openslides_backend/services/database.py
@@ -2,10 +2,16 @@ from typing import Any, Dict, List, Tuple
 
 import requests
 import simplejson as json
+from mypy_extensions import TypedDict
 
 from ..shared.exceptions import DatabaseException
 from ..shared.interfaces import Filter, LoggingModule
 from ..shared.patterns import Collection, FullQualifiedId
+
+PartialModel = Dict[str, Any]
+Found = TypedDict("Found", {"exists": bool, "position": int})
+Count = TypedDict("Count", {"count": int, "position": int})
+Aggregate = TypedDict("Aggregate", {"value": object, "position": int})
 
 
 class DatabaseHTTPAdapter:
@@ -18,9 +24,12 @@ class DatabaseHTTPAdapter:
         self.logger = logging.getLogger(__name__)
         self.headers = {"Content-Type": "application/json"}
 
+    def getIds(self, collection: Collection, range: int) -> Tuple[int]:
+        raise
+
     def get(
         self, fqid: FullQualifiedId, mapped_fields: List[str] = None
-    ) -> Tuple[Dict[str, Any], int]:
+    ) -> Tuple[PartialModel, int]:
         data = {
             "command": "get",
             "parameters": {"fqid": str(fqid), "mapped_fields": mapped_fields},
@@ -42,7 +51,7 @@ class DatabaseHTTPAdapter:
 
     def getMany(
         self, collection: Collection, ids: List[int], mapped_fields: List[str] = None
-    ) -> Tuple[Dict[int, Dict[str, Any]], int]:
+    ) -> Tuple[Dict[int, PartialModel], int]:
         data = {
             "command": "getMany",
             "parameters": {
@@ -56,14 +65,9 @@ class DatabaseHTTPAdapter:
         print(response)  # TODO: Use response
         return ({42: {"foo": "bar"}}, 0)
 
-    def getId(self, collection: Collection) -> Tuple[int, int]:
-        data = {"command": "getId", "parameters": {"collection": str(collection)}}
-        self.logger.debug(f"Start request to database with the following data: {data}")
-        response = requests.get(self.url, data=json.dumps(data), headers=self.headers)
-        print(response)  # TODO: Use response
-        return (0, 0)
-
-    def exists(self, collection: Collection, ids: List[int]) -> Tuple[bool, int]:
+    def getAll(
+        self, collection: Collection, mapped_fields: List[str] = None
+    ) -> Tuple[object]:
         raise
 
     def filter(
@@ -72,5 +76,24 @@ class DatabaseHTTPAdapter:
         filter: Filter,
         meeting_id: int = None,
         mapped_fields: List[str] = None,
-    ) -> Tuple[Dict[int, Dict[str, Any]], int]:
+    ) -> Tuple[Dict[int, PartialModel], int]:
         raise
+
+    def exists(self, collection: Collection, filter: Filter) -> Found:
+        raise
+
+    def count(self, collection: Collection, filter: Filter) -> Count:
+        raise
+
+    def min(self, collection: Collection, filter: Filter, type: str) -> Aggregate:
+        raise
+
+    def max(self, collection: Collection, filter: Filter, type: str) -> Aggregate:
+        raise
+
+    def getId(self, collection: Collection) -> Tuple[int, int]:
+        data = {"command": "getId", "parameters": {"collection": str(collection)}}
+        self.logger.debug(f"Start request to database with the following data: {data}")
+        response = requests.get(self.url, data=json.dumps(data), headers=self.headers)
+        print(response)  # TODO: Use response
+        return (0, 0)

--- a/openslides_backend/services/database/__init__.py
+++ b/openslides_backend/services/database/__init__.py
@@ -1,0 +1,2 @@
+from .database import DatabaseAdapter  # noqa
+from .engine import HTTPEngine  # noqa

--- a/openslides_backend/services/database/database.py
+++ b/openslides_backend/services/database/database.py
@@ -1,28 +1,21 @@
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
-import requests
-import simplejson as json
-from mypy_extensions import TypedDict
+from openslides_backend.shared.exceptions import DatabaseException
+from openslides_backend.shared.interfaces import Filter, LoggingModule
+from openslides_backend.shared.patterns import Collection, FullQualifiedId
 
-from ..shared.exceptions import DatabaseException
-from ..shared.interfaces import Filter, LoggingModule
-from ..shared.patterns import Collection, FullQualifiedId
-
-PartialModel = Dict[str, Any]
-Found = TypedDict("Found", {"exists": bool, "position": int})
-Count = TypedDict("Count", {"count": int, "position": int})
-Aggregate = TypedDict("Aggregate", {"value": object, "position": int})
+from .engine import HTTPEngine
+from .interface import Aggregate, Count, Found, PartialModel
 
 
-class DatabaseHTTPAdapter:
+class DatabaseAdapter:
     """
     Adapter to connect to (read-only) database.
     """
 
-    def __init__(self, database_url: str, logging: LoggingModule) -> None:
-        self.url = database_url
+    def __init__(self, adapter: HTTPEngine, logging: LoggingModule) -> None:
         self.logger = logging.getLogger(__name__)
-        self.headers = {"Content-Type": "application/json"}
+        self.adapter = adapter
 
     def getIds(self, collection: Collection, range: int) -> Tuple[int]:
         raise
@@ -35,7 +28,7 @@ class DatabaseHTTPAdapter:
             "parameters": {"fqid": str(fqid), "mapped_fields": mapped_fields},
         }
         self.logger.debug(f"Start request to database with the following data: {data}")
-        response = requests.get(self.url, data=json.dumps(data), headers=self.headers)
+        response = self.adapter.get(data)
         if not response.ok:
             if response.status_code >= 500:
                 raise DatabaseException("Connection to database failed.")
@@ -61,7 +54,7 @@ class DatabaseHTTPAdapter:
             },
         }
         self.logger.debug(f"Start request to database with the following data: {data}")
-        response = requests.get(self.url, data=json.dumps(data), headers=self.headers)
+        response = self.adapter.get(data)
         print(response)  # TODO: Use response
         return ({42: {"foo": "bar"}}, 0)
 
@@ -94,6 +87,6 @@ class DatabaseHTTPAdapter:
     def getId(self, collection: Collection) -> Tuple[int, int]:
         data = {"command": "getId", "parameters": {"collection": str(collection)}}
         self.logger.debug(f"Start request to database with the following data: {data}")
-        response = requests.get(self.url, data=json.dumps(data), headers=self.headers)
+        response = self.adapter.get(data)
         print(response)  # TODO: Use response
         return (0, 0)

--- a/openslides_backend/services/database/engine.py
+++ b/openslides_backend/services/database/engine.py
@@ -1,0 +1,14 @@
+import requests
+import simplejson as json
+
+from openslides_backend.shared.interfaces import LoggingModule
+
+
+class HTTPEngine:
+    def __init__(self, database_url: str, logging: LoggingModule):
+        self.logger = logging.getLogger(__name__)
+        self.url = database_url
+        self.headers = {"Content-Type": "application/json"}
+
+    def get(self, data: object) -> requests.Response:
+        return requests.get(self.url, data=json.dumps(data), headers=self.headers)

--- a/openslides_backend/services/database/interface.py
+++ b/openslides_backend/services/database/interface.py
@@ -1,0 +1,59 @@
+from typing import Any, Dict, List, Tuple
+
+from mypy_extensions import TypedDict
+from typing_extensions import Protocol
+
+from openslides_backend.shared.interfaces import Filter
+from openslides_backend.shared.patterns import Collection, FullQualifiedId
+
+PartialModel = Dict[str, Any]
+Found = TypedDict("Found", {"exists": bool, "position": int})
+Count = TypedDict("Count", {"count": int, "position": int})
+Aggregate = TypedDict("Aggregate", {"value": object, "position": int})
+
+
+class Datastore(Protocol):
+    """Datastore defines the interface to the datastore
+    """
+
+    def getIds(self, collection: Collection, range: int) -> Tuple[int]:
+        ...
+
+    def get(
+        self, fqid: FullQualifiedId, mapped_fields: List[str] = None
+    ) -> Tuple[PartialModel, int]:
+        ...
+
+    def getMany(
+        self, collection: Collection, ids: List[int], mapped_fields: List[str] = None
+    ) -> Tuple[Dict[int, PartialModel], int]:
+        ...
+
+    def getAll(
+        self, collection: Collection, mapped_fields: List[str] = None
+    ) -> Tuple[object]:
+        ...
+
+    def filter(
+        self,
+        collection: Collection,
+        filter: Filter,
+        meeting_id: int = None,
+        mapped_fields: List[str] = None,
+    ) -> Tuple[Dict[int, PartialModel], int]:
+        ...
+
+    def exists(self, collection: Collection, filter: Filter) -> Found:
+        ...
+
+    def count(self, collection: Collection, filter: Filter) -> Count:
+        ...
+
+    def min(self, collection: Collection, filter: Filter, type: str) -> Aggregate:
+        ...
+
+    def max(self, collection: Collection, filter: Filter, type: str) -> Aggregate:
+        ...
+
+    def getId(self, collection: Collection) -> Tuple[int, int]:
+        ...

--- a/tests/services/test_database.py
+++ b/tests/services/test_database.py
@@ -1,0 +1,23 @@
+from unittest.mock import Mock
+
+from openslides_backend.services.database import DatabaseAdapter
+from openslides_backend.shared.patterns import Collection, FullQualifiedId
+
+engine = Mock()
+log = Mock()
+
+db = DatabaseAdapter(engine, log)
+
+
+def test_get() -> None:
+    fqid = FullQualifiedId(Collection("fakeModel"), 1)
+    fields = ["a", "b", "c"]
+    data = {
+        "command": "get",
+        "parameters": {"fqid": str(fqid), "mapped_fields": fields},
+    }
+    partial_model, num = db.get(fqid, fields)
+    assert num is not None
+    assert partial_model is not None
+    assert partial_model["foo"] == "bar"
+    engine.get.assert_called_with(data)


### PR DESCRIPTION
I encountered several problems which I do not know how to address correctly. In some cases the implementation does not conform the interface definition, which I think is a result of the interface definition being more recent. In one case there is a field missing in the definition where it may be sensible to include or maybe it's the same drift.

For some things there were no types defined in the definition though being used. 
For `PartialModel` a type was missing on the python side of things.

For the course of the further review:

* get: Incompatible return types
[interface](https://github.com/OpenSlides/OpenSlides/blob/openslides4-dev/docs/interfaces/datastore-service.txt#L154)
[implementation](https://github.com/ThomasJunk/openslides-backend/blob/master/openslides_backend/services/database.py#L21)

* getMany: different implementation(?)
[interface](https://github.com/OpenSlides/OpenSlides/blob/openslides4-dev/docs/interfaces/datastore-service.txt#L168)
[implementation](https://github.com/ThomasJunk/openslides-backend/blob/master/openslides_backend/services/database.py#L43)

* getId: found no interface definition
  [implementation](https://github.com/ThomasJunk/openslides-backend/blob/master/openslides_backend/services/database.py#L59)

* filter: parameter `meeting_id` is missing in the interface definition. Incompatible return type
[interface](https://github.com/OpenSlides/OpenSlides/blob/openslides4-dev/docs/interfaces/datastore-service.txt#L190)
[implementation](https://github.com/ThomasJunk/openslides-backend/blob/master/openslides_backend/services/database.py#L69)


*   exists: differences in implementation-stub and interface
[interface](https://github.com/OpenSlides/OpenSlides/blob/openslides4-dev/docs/interfaces/datastore-service.txt#L198)
[implementation](https://github.com/ThomasJunk/openslides-backend/blob/master/openslides_backend/services/database.py#L66)

Additionally:
* I ordered the methods in the implementation accordingly which makes comparing interface and implementation much easier

* I suggest adding a new custom type 
  * for `PartialModel = Dict[str, Any]` 
  * for `Found` as a result of the `exists` operation ```Found = TypedDict("Found", {"exists": bool, "position": int})``` 
  *  for `Count` like `Count = TypedDict("Count", {"count": int, "position": int})`
  * for `Aggregates` like `Aggregate = TypedDict("Aggregate", {"value": object, "position": int})` leaving out the separation from the interface of `min` and `max`, since that should be clear from the method chosen

In a first draft, I wrote only stubs to better compare interface definition and implementation. 
Concrete implementation will of course follow.