### PR TITLE
Fix GitHub actions with pytest

### DIFF
--- a/dev/run-tests.sh
+++ b/dev/run-tests.sh
@@ -6,4 +6,6 @@ $DC up --build --detach
 $DC exec -T backend dev/wait.sh writer 9011
 $DC exec -T backend dev/wait.sh reader 9010
 $DC exec -T backend pytest --cov
+error=$?
 $DC down --volumes
+exit $error


### PR DESCRIPTION
Probably since the changed introduced in #116, the tests in the GitHub actions have been silently broken. Since the `$(DC) down` command follows the `pytest` command, the exit code of the `run-tests.sh` was always 0, so the action would never fail.