### PR TITLE
Allow only special values in the special fields in motion_state

### DIFF
--- a/openslides_backend/models/motion_state.py
+++ b/openslides_backend/models/motion_state.py
@@ -22,9 +22,21 @@ class MotionState(Model):
     recommendation_label = fields.CharField(
         description="The recommendation label of this motion state."
     )
-    css_class = fields.CharField(description="The css class of this motion state.")
+    css_class = fields.CharField(
+        description="The css class of this motion state.",
+        enum=["gray", "red", "green", "lightblue", "yellow"],
+    )
     restrictions = fields.ArrayField(
-        description="The restrictions of this motion state.", items={"type": "string"}
+        description="The restrictions of this motion state.",
+        items={
+            "type": "string",
+            "enum": [
+                "motions.can_see_internal",
+                "motions.can_manage_metadata",
+                "motions.can_manage",
+                "is_submitter",
+            ],
+        },
     )
     allow_support = fields.BooleanField(
         description="If this motion state allows supporting motions."
@@ -41,8 +53,8 @@ class MotionState(Model):
     show_state_extension_field = fields.BooleanField(
         description="If in this motion state the state extension field is visable."
     )
-    merge_amendment_into_final = fields.PositiveIntegerField(
-        description="Unknown description."
+    merge_amendment_into_final = fields.IntegerField(
+        description="Unknown description.", enum=[-1, 0, 1]
     )
     show_recommendation_extension_field = fields.BooleanField(
         description="If in this motion state the recommendation extension field is visable."

--- a/tests/system/action/motion_state/test_create.py
+++ b/tests/system/action/motion_state/test_create.py
@@ -18,6 +18,34 @@ class MotionStateActionTest(BaseActionTestCase):
         model = self.get_model("motion_state/1")
         assert model.get("name") == "test_Xcdfgee"
 
+    def test_create_enum_fields(self) -> None:
+        self.create_model("motion_workflow/42", {"name": "test_name_fjwnq8d8tje8"})
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "motion_state.create",
+                    "data": [
+                        {
+                            "name": "test_Xcdfgee",
+                            "workflow_id": 42,
+                            "css_class": "red",
+                            "restrictions": ["is_submitter"],
+                            "merge_amendment_into_final": -1,
+                        }
+                    ],
+                }
+            ],
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists("motion_state/1")
+        model = self.get_model("motion_state/1")
+        assert model.get("name") == "test_Xcdfgee"
+        assert model.get("workflow_id") == 42
+        assert model.get("css_class") == "red"
+        assert model.get("restrictions") == ["is_submitter"]
+        assert model.get("merge_amendment_into_final") == -1
+
     def test_create_empty_data(self) -> None:
         response = self.client.post(
             "/", json=[{"action": "motion_state.create", "data": [{}]}],
@@ -41,5 +69,45 @@ class MotionStateActionTest(BaseActionTestCase):
         self.assert_status_code(response, 400)
         self.assertIn(
             "data[0] must contain [\\'name\\', \\'workflow_id\\'] properties",
+            str(response.data),
+        )
+
+    def test_create_forbidden_value_1(self) -> None:
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "motion_state.create",
+                    "data": [
+                        {"name": "test_Xcdfgee", "workflow_id": 42, "css_class": "pink"}
+                    ],
+                }
+            ],
+        )
+        self.assert_status_code(response, 400)
+        self.assertIn(
+            "data[0].css_class must be one of [\\'gray\\', \\'red\\', \\'green\\', \\'lightblue\\', \\'yellow\\']",
+            str(response.data),
+        )
+
+    def test_create_forbidden_value_2(self) -> None:
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "motion_state.create",
+                    "data": [
+                        {
+                            "name": "test_Xcdfgee",
+                            "workflow_id": 42,
+                            "restrictions": ["is__XXXX__submitter"],
+                        }
+                    ],
+                }
+            ],
+        )
+        self.assert_status_code(response, 400)
+        self.assertIn(
+            "data[0].restrictions[0] must be one of [\\'motions.can_see_internal\\', \\'motions.can_manage_metadata\\', \\'motions.can_manage\\', \\'is_submitter\\']",
             str(response.data),
         )


### PR DESCRIPTION
The fields css_class, restrictions and merge_amendment_into_final can only have special values.
Add some tests to check this.