### PR TITLE
Reorder Dockerfile-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,18 +40,18 @@ run-prod: | build-prod
 # Build and run development docker container setup with docker compose (not usable inside docker container)
 
 start-dev:
-	docker-compose -f dev/docker-compose.dev.yml up --build --detach
+	USER_ID=$$(id -u $${USER}) GROUP_ID=$$(id -g $${USER}) docker-compose -f dev/docker-compose.dev.yml up --build --detach
 
 stop-dev:
 	docker-compose -f dev/docker-compose.dev.yml down --volumes
 
 start-dev-interactive:
-	docker-compose -f dev/docker-compose.dev.yml up  --build
+	USER_ID=$$(id -u $${USER}) GROUP_ID=$$(id -g $${USER}) docker-compose -f dev/docker-compose.dev.yml up --build
 
-run-dev-standalone:
+run-dev-standalone: | start-dev
 	docker-compose -f dev/docker-compose.dev.yml exec backend bash
 
-run-dev run-bash: | start-dev run-dev-standalone
+run-dev run-bash: | run-dev-standalone
 
 run-tests:
 	dev/run-tests.sh

--- a/dev/Dockerfile-dev
+++ b/dev/Dockerfile-dev
@@ -3,12 +3,19 @@ FROM python:3.8.5-slim-buster
 RUN apt-get update && apt-get install --yes make git curl ncat
 
 WORKDIR /srv/code
+RUN mkdir dev
+
 COPY requirements.txt .
-COPY setup.cfg .
-COPY Makefile Makefile
-COPY dev dev
+COPY dev/requirements_development.txt dev/.
 
 RUN pip install --no-cache-dir --requirement dev/requirements_development.txt
+
+COPY dev/wait.sh dev/.
+COPY dev/run-tests.sh dev/.
+COPY dev/cleanup.sh .
+
+COPY Makefile Makefile
+COPY setup.cfg .
 
 EXPOSE 9002
 EXPOSE 9003

--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -5,6 +5,7 @@ services:
             context: ..
             dockerfile: dev/Dockerfile-dev
         image: openslides-backend-dev
+        user: $USER_ID:$GROUP_ID
         ports:
             - "9002:9002"
             - "9003:9003"


### PR DESCRIPTION
The problem with running `make` inside the docker container is that then docker takes ownership of all edited files, so I want to have the cleanup script back on root level for easier access. Also, I recently changed some things in the `setup.cfg`, which led to the pip packages being installed every time, so I moved it behind the requirements section.