### PR TITLE
Update motion_workflow.create. Set the first_state of workflow.

### DIFF
--- a/openslides_backend/action/motion_state/create_update_delete.py
+++ b/openslides_backend/action/motion_state/create_update_delete.py
@@ -58,6 +58,7 @@ class MotionStateActionSet(ActionSet):
             "show_state_extension_field",
             "merge_amendment_into_final",
             "show_recommendation_extension_field",
+            "first_state_of_workflow_id",
         ],
     )
     update_schema = DefaultSchema(MotionState()).get_update_schema(

--- a/openslides_backend/action/motion_workflow/create.py
+++ b/openslides_backend/action/motion_workflow/create.py
@@ -26,4 +26,5 @@ class MotionWorkflowCreateAction(CreateActionWithDependencies):
         return {
             "name": MOTION_STATE_DEFAULT_NAME,
             "workflow_id": element["new_id"],
+            "first_state_of_workflow_id": element["new_id"],
         }

--- a/tests/system/action/motion_workflow/test_create.py
+++ b/tests/system/action/motion_workflow/test_create.py
@@ -16,8 +16,10 @@ class MotionWorkflowSystemTest(BaseActionTestCase):
         self.assert_status_code(response, 200)
         workflow = self.get_model("motion_workflow/1")
         assert workflow.get("name") == "test_Xcdfgee"
+        assert workflow.get("first_state_id") == 1
         state = self.get_model("motion_state/1")
         assert state.get("workflow_id") == 1
+        assert state.get("first_state_of_workflow_id") == 1
 
     def test_create_empty_data(self) -> None:
         response = self.client.post(


### PR DESCRIPTION
Add the created new state to the first state.
Use first_state_of_workflow_id property of the motion_state.