### PR TITLE
Fix filter method

### DIFF
--- a/openslides_backend/services/datastore/commands.py
+++ b/openslides_backend/services/datastore/commands.py
@@ -7,6 +7,7 @@ from ...shared.filters import Filter as FilterInterface
 from ...shared.filters import FilterData
 from ...shared.interfaces import Event, WriteRequestElement
 from ...shared.patterns import Collection, FullQualifiedId
+from .deleted_models_behaviour import DeletedModelsBehaviour
 
 GetManyRequestData = TypedDict(
     "GetManyRequestData",
@@ -91,7 +92,7 @@ class Get(Command):
         fqid: FullQualifiedId,
         mappedFields: List[str] = None,
         position: int = None,
-        get_deleted_models: int = None,
+        get_deleted_models: DeletedModelsBehaviour = None,
     ) -> None:
         self.fqid = fqid
         self.mappedFields = mappedFields
@@ -120,7 +121,7 @@ class GetMany(Command):
         get_many_requests: List[GetManyRequest],
         mapped_fields: List[str] = None,
         position: int = None,
-        get_deleted_models: int = None,
+        get_deleted_models: DeletedModelsBehaviour = None,
     ) -> None:
         self.get_many_requests = get_many_requests
         self.mapped_fields = mapped_fields
@@ -154,7 +155,7 @@ class GetAll(Command):
         self,
         collection: Collection,
         mapped_fields: List[str] = None,
-        get_deleted_models: int = None,
+        get_deleted_models: DeletedModelsBehaviour = None,
     ) -> None:
         self.collection = collection
         self.mapped_fields = mapped_fields

--- a/openslides_backend/services/datastore/deleted_models_behaviour.py
+++ b/openslides_backend/services/datastore/deleted_models_behaviour.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class DeletedModelsBehaviour(int, Enum):
+    NO_DELETED = 1
+    ONLY_DELETED = 2
+    ALL_MODELS = 3

--- a/openslides_backend/services/datastore/interface.py
+++ b/openslides_backend/services/datastore/interface.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Any, Dict, List, Sequence, Tuple
 
 from mypy_extensions import TypedDict
@@ -8,17 +7,12 @@ from ...shared.filters import Filter
 from ...shared.interfaces import WriteRequestElement
 from ...shared.patterns import Collection, FullQualifiedId
 from .commands import GetManyRequest
+from .deleted_models_behaviour import DeletedModelsBehaviour
 
 PartialModel = Dict[str, Any]
 Found = TypedDict("Found", {"exists": bool})
 Count = TypedDict("Count", {"count": int})
 Aggregate = Dict[str, Any]  # TODO: This interface seams to be wrong.
-
-
-class DeletedModelsBehaviour(Enum):
-    NO_DELETED = 1
-    ONLY_DELETED = 2
-    ALL_MODELS = 3
 
 
 class Datastore(Protocol):
@@ -34,7 +28,7 @@ class Datastore(Protocol):
         fqid: FullQualifiedId,
         mapped_fields: List[str] = None,
         position: int = None,
-        get_deleted_models: int = None,
+        get_deleted_models: DeletedModelsBehaviour = None,
         lock_result: bool = False,
     ) -> PartialModel:
         ...
@@ -44,7 +38,7 @@ class Datastore(Protocol):
         get_many_requests: List[GetManyRequest],
         mapped_fields: List[str] = None,
         position: int = None,
-        get_deleted_models: int = None,
+        get_deleted_models: DeletedModelsBehaviour = None,
         lock_result: bool = False,
     ) -> Dict[Collection, Dict[int, PartialModel]]:
         ...
@@ -53,7 +47,7 @@ class Datastore(Protocol):
         self,
         collection: Collection,
         mapped_fields: List[str] = None,
-        get_deleted_models: int = None,
+        get_deleted_models: DeletedModelsBehaviour = None,
         lock_result: bool = False,
     ) -> Dict[int, PartialModel]:
         ...
@@ -63,6 +57,7 @@ class Datastore(Protocol):
         collection: Collection,
         filter: Filter,
         mapped_fields: List[str] = None,
+        get_deleted_models: DeletedModelsBehaviour = None,
         lock_result: bool = False,
     ) -> Dict[int, PartialModel]:
         ...


### PR DESCRIPTION
fixes #207 

Added the `get_deleted_models` argument to the `filter` method to ony filter for existing models by default.