### PR TITLE
Add Curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.8.5-slim-buster
 
+RUN apt-get -y update && apt-get -y upgrade && \
+    apt-get install --no-install-recommends -y curl
+
 WORKDIR /app
 
 COPY requirements.txt .


### PR DESCRIPTION
This is needed as long as no management scripts are there. Curl is externally used in the container to gain access to the datastore to execute management commands