### PR TITLE
Fix relation updates

### DIFF
--- a/tests/system/action/topic/test_update.py
+++ b/tests/system/action/topic/test_update.py
@@ -38,3 +38,28 @@ class TopicUpdateTest(BaseActionTestCase):
         self.assert_status_code(response, 200)
         topic = self.get_model("topic/1")
         self.assertEqual(topic.get("tag_ids"), [])
+
+    def test_update_multiple_with_tag(self) -> None:
+        self.create_model("meeting/1", {"name": "test"})
+        self.create_model(
+            "tag/1",
+            {"name": "tag", "meeting_id": 1, "tagged_ids": ["topic/1", "topic/2"]},
+        )
+        self.create_model("topic/1", {"title": "test", "meeting_id": 1, "tag_ids": [1]})
+        self.create_model("topic/2", {"title": "test", "meeting_id": 1, "tag_ids": [1]})
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "topic.update",
+                    "data": [{"id": 1, "tag_ids": []}, {"id": 2, "tag_ids": []}],
+                }
+            ],
+        )
+        self.assert_status_code(response, 200)
+        topic = self.get_model("topic/1")
+        self.assertEqual(topic.get("tag_ids"), [])
+        topic = self.get_model("topic/2")
+        self.assertEqual(topic.get("tag_ids"), [])
+        tag = self.get_model("tag/1")
+        self.assertEqual(tag.get("tagged_ids"), [])

--- a/tests/system/relations/test_generic_relations.py
+++ b/tests/system/relations/test_generic_relations.py
@@ -21,6 +21,7 @@ class GenericRelationsTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/2/fake_model_a_generic_oo"): {
                 "type": "add",
                 "value": get_fqid("fake_model_a/1"),
+                "modified_element": get_fqid("fake_model_a/1"),
             }
         }
         assert result == expected
@@ -44,6 +45,7 @@ class GenericRelationsTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/3/fake_model_a_generic_oo"): {
                 "type": "add",
                 "value": get_fqid("fake_model_a/1"),
+                "modified_element": get_fqid("fake_model_a/1"),
             }
         }
         assert result == expected
@@ -66,6 +68,7 @@ class GenericRelationsTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/2/fake_model_a_generic_oo"): {
                 "type": "remove",
                 "value": None,
+                "modified_element": get_fqid("fake_model_a/1"),
             }
         }
         assert result == expected
@@ -86,6 +89,7 @@ class GenericRelationsTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/2/fake_model_a_generic_mo"): {
                 "type": "add",
                 "value": [get_fqid("fake_model_a/1")],
+                "modified_element": get_fqid("fake_model_a/1"),
             }
         }
         assert result == expected
@@ -109,6 +113,7 @@ class GenericRelationsTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/3/fake_model_a_generic_mo"): {
                 "type": "add",
                 "value": [get_fqid("fake_model_a/1"), get_fqid("fake_model_a/2")],
+                "modified_element": get_fqid("fake_model_a/2"),
             }
         }
         assert result == expected
@@ -131,6 +136,7 @@ class GenericRelationsTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/2/fake_model_a_generic_mo"): {
                 "type": "remove",
                 "value": [],
+                "modified_element": get_fqid("fake_model_a/1"),
             }
         }
         assert result == expected
@@ -151,6 +157,7 @@ class GenericRelationsTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/2/fake_model_a_generic_mm"): {
                 "type": "add",
                 "value": [get_fqid("fake_model_a/1")],
+                "modified_element": get_fqid("fake_model_a/1"),
             }
         }
         assert result == expected
@@ -174,6 +181,7 @@ class GenericRelationsTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/3/fake_model_a_generic_mm"): {
                 "type": "add",
                 "value": [get_fqid("fake_model_a/1"), get_fqid("fake_model_a/2")],
+                "modified_element": get_fqid("fake_model_a/2"),
             }
         }
         assert result == expected
@@ -196,6 +204,7 @@ class GenericRelationsTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/2/fake_model_a_generic_mm"): {
                 "type": "remove",
                 "value": [],
+                "modified_element": get_fqid("fake_model_a/1"),
             }
         }
         assert result == expected

--- a/tests/system/relations/test_relations.py
+++ b/tests/system/relations/test_relations.py
@@ -18,7 +18,11 @@ class RelationHandlerTest(BaseRelationsTestCase):
         )
         result = handler.perform()
         expected = {
-            get_fqfield("fake_model_b/2/fake_model_a_oo"): {"type": "add", "value": 1}
+            get_fqfield("fake_model_b/2/fake_model_a_oo"): {
+                "type": "add",
+                "value": 1,
+                "modified_element": 1,
+            }
         }
         assert result == expected
 
@@ -36,7 +40,11 @@ class RelationHandlerTest(BaseRelationsTestCase):
         )
         result = handler.perform()
         expected = {
-            get_fqfield("fake_model_b/3/fake_model_a_oo"): {"type": "add", "value": 1}
+            get_fqfield("fake_model_b/3/fake_model_a_oo"): {
+                "type": "add",
+                "value": 1,
+                "modified_element": 1,
+            }
         }
         assert result == expected
 
@@ -56,6 +64,7 @@ class RelationHandlerTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/2/fake_model_a_oo"): {
                 "type": "remove",
                 "value": None,
+                "modified_element": 1,
             }
         }
         assert result == expected
@@ -73,7 +82,11 @@ class RelationHandlerTest(BaseRelationsTestCase):
         )
         result = handler.perform()
         expected = {
-            get_fqfield("fake_model_b/2/fake_model_a_mo"): {"type": "add", "value": [1]}
+            get_fqfield("fake_model_b/2/fake_model_a_mo"): {
+                "type": "add",
+                "value": [1],
+                "modified_element": 1,
+            }
         }
         assert result == expected
 
@@ -94,6 +107,7 @@ class RelationHandlerTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/3/fake_model_a_mo"): {
                 "type": "add",
                 "value": [1, 2],
+                "modified_element": 2,
             }
         }
         assert result == expected
@@ -114,6 +128,7 @@ class RelationHandlerTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/2/fake_model_a_mo"): {
                 "type": "remove",
                 "value": [],
+                "modified_element": 1,
             }
         }
         assert result == expected
@@ -131,7 +146,11 @@ class RelationHandlerTest(BaseRelationsTestCase):
         )
         result = handler.perform()
         expected = {
-            get_fqfield("fake_model_b/2/fake_model_a_mm"): {"type": "add", "value": [1]}
+            get_fqfield("fake_model_b/2/fake_model_a_mm"): {
+                "type": "add",
+                "value": [1],
+                "modified_element": 1,
+            }
         }
         assert result == expected
 
@@ -152,6 +171,7 @@ class RelationHandlerTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/3/fake_model_a_mm"): {
                 "type": "add",
                 "value": [1, 2],
+                "modified_element": 2,
             }
         }
         assert result == expected
@@ -172,6 +192,7 @@ class RelationHandlerTest(BaseRelationsTestCase):
             get_fqfield("fake_model_b/2/fake_model_a_mm"): {
                 "type": "remove",
                 "value": [],
+                "modified_element": 1,
             }
         }
         assert result == expected

--- a/tests/system/relations/test_structured_relations.py
+++ b/tests/system/relations/test_structured_relations.py
@@ -31,6 +31,7 @@ class StructuredRelationTester(BaseRelationsTestCase):
                 get_fqfield(f"fake_model_a/333/fake_model_b_{meeting_id}_ids"): {
                     "type": "add",
                     "value": [111],
+                    "modified_element": 111,
                 }
             },
         )
@@ -59,6 +60,7 @@ class StructuredRelationTester(BaseRelationsTestCase):
                 get_fqfield(f"fake_model_a/333/fake_model_c_{meeting_id}_ids"): {
                     "type": "add",
                     "value": [444],
+                    "modified_element": 444,
                 }
             },
         )


### PR DESCRIPTION
The relation handling had an error: If inside an action two different models updated the same field (see test), the updates were not applied correctly.