### PR TITLE
Fix reset_state

### DIFF
--- a/tests/system/action/motion/test_reset_state.py
+++ b/tests/system/action/motion/test_reset_state.py
@@ -5,12 +5,20 @@ class MotionResetStateActionTest(BaseActionTestCase):
     def test_reset_state_correct(self) -> None:
         self.create_model("meeting/222", {"name": "name_SNLGsvIV"})
         self.create_model(
-            "motion_state/76",
-            {"name": "test0", "motion_ids": [], "first_state_of_workflow_id": 76},
+            "motion_workflow/1",
+            {"name": "test1", "state_ids": [76, 77], "first_state_id": 76},
         )
         self.create_model(
-            "motion_state/77",
-            {"name": "test1", "motion_ids": [22], "first_state_of_workflow_id": 76},
+            "motion_state/76",
+            {
+                "name": "test0",
+                "motion_ids": [],
+                "workflow_id": 1,
+                "first_state_of_workflow_id": 1,
+            },
+        )
+        self.create_model(
+            "motion_state/77", {"name": "test1", "motion_ids": [22], "workflow_id": 1},
         )
         self.create_model(
             "motion/22", {"meeting_id": 222, "title": "test1", "state_id": 77}
@@ -25,11 +33,13 @@ class MotionResetStateActionTest(BaseActionTestCase):
     def test_reset_state_missing_first_state(self) -> None:
         self.create_model("meeting/222", {"name": "name_SNLGsvIV"})
         self.create_model(
-            "motion_state/76",
-            {"name": "test0", "motion_ids": [22], "first_state_of_workflow_id": 76},
+            "motion_workflow/1", {"name": "test1", "state_ids": [76, 77]},
         )
         self.create_model(
-            "motion_state/77", {"name": "test1", "motion_ids": [22]},
+            "motion_state/76", {"name": "test0", "motion_ids": [], "workflow_id": 1},
+        )
+        self.create_model(
+            "motion_state/77", {"name": "test1", "motion_ids": [22], "workflow_id": 1},
         )
         self.create_model(
             "motion/22", {"meeting_id": 222, "title": "test1", "state_id": 77}
@@ -38,4 +48,4 @@ class MotionResetStateActionTest(BaseActionTestCase):
             "/", json=[{"action": "motion.reset_state", "data": [{"id": 22}]}]
         )
         self.assert_status_code(response, 400)
-        self.assertIn("State need a first_state_of_workflow_id.", str(response.data))
+        self.assertIn(" has no first_state_id.", str(response.data))


### PR DESCRIPTION
@reiterl I misunderstood how `motion_state.first_state_of_workflow_id` works: it does not point to the first state, but is the backwards relation of `motion_workflow.first_state_id` and therefor points to a workflow and may be empty (it's only filled for the first state in a workflow). Fixed the handling for reset_state here.