### PR TITLE
run-tests wait for auth, too.

### DIFF
--- a/dev/run-tests.sh
+++ b/dev/run-tests.sh
@@ -5,6 +5,7 @@ DC="docker-compose -f dev/docker-compose.dev.yml"
 $DC up --build --detach
 $DC exec -T backend dev/wait.sh writer 9011
 $DC exec -T backend dev/wait.sh reader 9010
+$DC exec -T backend dev/wait.sh auth 9004
 $DC exec -T backend pytest --cov
 error=$?
 $DC down --volumes


### PR DESCRIPTION
If auth is not completly up, you will see failures in the first tests. cascading delete.
So wait for the auth service, before testing.