### PR TITLE
Add permission service

### DIFF
--- a/dev/cleanup.sh
+++ b/dev/cleanup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 printf "Black:\n"
-black openslides_backend tests cli
+black openslides_backend tests cli --exclude tests/integration/old
 printf "\nIsort:\n"
 isort openslides_backend tests cli
 printf "\nFlake8:\n"

--- a/openslides_backend/environment.py
+++ b/openslides_backend/environment.py
@@ -16,7 +16,7 @@ DEFAULTS = {
     "PERMISSION_PROTOCOL": "http",
     "PERMISSION_HOST": "localhost",
     "PERMISSION_PORT": "9005",
-    "PERMISSION_PATH": "",
+    "PERMISSION_PATH": "/internal/permission",
     "MEDIA_PROTOCOL": "http",
     "MEDIA_HOST": "localhost",
     "MEDIA_PORT": "9006",

--- a/openslides_backend/services/permission/adapter.py
+++ b/openslides_backend/services/permission/adapter.py
@@ -18,10 +18,10 @@ class PermissionHTTPAdapter(PermissionService):
         self.logger = logging.getLogger(__name__)
 
     def is_allowed(
-        self, name: str, user_id: int, dataList: List[Dict[str, Any]]
+        self, name: str, user_id: int, data_list: List[Dict[str, Any]]
     ) -> List[Dict[str, Any]]:
         payload = json.dumps(
-            {"name": name, "user_id": user_id, "data": dataList}, separators=(",", ":")
+            {"name": name, "user_id": user_id, "data": data_list}, separators=(",", ":")
         )
 
         try:
@@ -56,7 +56,7 @@ class PermissionHTTPAdapter(PermissionService):
                 self.logger.warning(
                     f"Action {name} has no permission check. Return a default-true."
                 )
-                return [{} for _ in dataList]
+                return [{} for _ in data_list]
 
             raise NotAllowed(reason, error_index)
 

--- a/openslides_backend/services/permission/adapter.py
+++ b/openslides_backend/services/permission/adapter.py
@@ -1,6 +1,11 @@
-from typing import Any
+import json
+from typing import Any, Dict, List
 
-from .interface import PermissionService
+import requests
+
+from ...shared.exceptions import PermissionException
+from ...shared.interfaces.logging import LoggingModule
+from .interface import NotAllowed, PermissionService
 
 
 class PermissionHTTPAdapter(PermissionService):
@@ -8,11 +13,61 @@ class PermissionHTTPAdapter(PermissionService):
     Adapter to connect to permission service.
     """
 
-    def __init__(self, permission_url: str) -> None:
-        self.url = permission_url
-        # self.headers = {"Content-Type": "application/json"}
+    def __init__(self, permission_url: str, logging: LoggingModule) -> None:
+        self.endpoint = permission_url + "/is_allowed"
+        self.logger = logging.getLogger(__name__)
 
-    def check_action(self, user_id: int, action: str, data: Any) -> bool:
-        # TODO: Do not use hardcoded value here but send request to
-        # permission service.
-        return True
+    def is_allowed(
+        self, name: str, user_id: int, dataList: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        payload = json.dumps(
+            {"name": name, "user_id": user_id, "data": dataList}, separators=(",", ":")
+        )
+
+        try:
+            response = requests.post(
+                url=self.endpoint,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+            )
+        except requests.exceptions.ConnectionError as e:
+            raise PermissionException(
+                f"Cannot reach the permission service on {self.endpoint}. Error: {e}"
+            )
+
+        content = response.json()
+        self.logger.debug(f"Permission service response: {str(content)}")
+
+        if "error" in content:
+            type = content["error"]["type"]
+            msg = content["error"]["msg"]
+            raise PermissionException(f"Error in permission service. {type}: {msg}")
+
+        allowed = content.get("allowed", False)
+
+        if not allowed:
+            reason = content.get("reason")
+            error_index = content.get("error_index")
+            if error_index < 0:
+                error_index = None
+
+            # TODO: dev only. Log about missing perms check
+            if "no such query" in reason:
+                self.logger.warning(
+                    f"Action {name} has no permission check. Return a default-true."
+                )
+                return [{} for _ in dataList]
+
+            raise NotAllowed(reason, error_index)
+
+        additions = content.get("additions")
+        if not isinstance(additions, list):
+            raise PermissionException("additions must be a list")
+
+        for i in range(len(additions)):
+            if additions[i] is None:
+                additions[i] = {}
+            if not isinstance(additions[i], dict):
+                raise PermissionError(f"Addition {i} is not a dict")
+
+        return additions

--- a/openslides_backend/services/permission/interface.py
+++ b/openslides_backend/services/permission/interface.py
@@ -14,7 +14,7 @@ class PermissionService(Protocol):
     """
 
     def is_allowed(
-        self, name: str, user_id: int, dataList: List[Dict[str, Any]]
+        self, name: str, user_id: int, data_list: List[Dict[str, Any]]
     ) -> List[Dict[str, Any]]:
         """
         Checks, if the user is allowed to execute the `name` with the list of data.

--- a/openslides_backend/services/permission/interface.py
+++ b/openslides_backend/services/permission/interface.py
@@ -1,4 +1,11 @@
-from typing import Any, Protocol
+from typing import Any, Dict, List, Optional, Protocol
+
+
+class NotAllowed(Exception):
+    def __init__(self, reason: str, error_index: Optional[int]):
+        self.reason = reason
+        self.error_index = error_index
+        super().__init__(reason)
 
 
 class PermissionService(Protocol):
@@ -6,7 +13,11 @@ class PermissionService(Protocol):
     Interface of the permission service.
     """
 
-    def check_action(self, user_id: int, action: str, data: Any) -> bool:
+    def is_allowed(
+        self, name: str, user_id: int, dataList: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
         """
-        Check if the given action with the given data is allowed for the fiven user.
+        Checks, if the user is allowed to execute the `name` with the list of data.
+        If it is allowed, additional information will be returned for each data. If not, NotAllowed
+        will be thrown providing more information.
         """

--- a/openslides_backend/shared/exceptions.py
+++ b/openslides_backend/shared/exceptions.py
@@ -35,6 +35,10 @@ class DatastoreException(ServiceException):
     pass
 
 
+class PermissionException(ServiceException):
+    pass
+
+
 class EventStoreException(View400Exception):
     pass
 

--- a/openslides_backend/wsgi.py
+++ b/openslides_backend/wsgi.py
@@ -22,7 +22,9 @@ class OpenSlidesBackendServices(containers.DeclarativeContainer):
     config = providers.Configuration("config")
     logging = providers.Object(0)
     authentication = providers.Singleton(AuthenticationHTTPAdapter, logging)
-    permission = providers.Singleton(PermissionHTTPAdapter, config.permission_url)
+    permission = providers.Singleton(
+        PermissionHTTPAdapter, config.permission_url, logging
+    )
     media = providers.Singleton(MediaServiceAdapter, config.media_url, logging)
     engine = providers.Singleton(
         HTTPEngine, config.datastore_reader_url, config.datastore_writer_url, logging

--- a/tests/integration/old/fake_services/permission.py
+++ b/tests/integration/old/fake_services/permission.py
@@ -1,4 +1,6 @@
-from typing import Any
+from typing import Any, Dict, List
+
+from openslides_backend.services.permission.interface import NotAllowed
 
 
 class PermissionTestAdapter:
@@ -8,8 +10,13 @@ class PermissionTestAdapter:
     implementation.
     """
 
-    def __init__(self, superuser: int, *args: Any, **kwargs: Any) -> None:
-        self.superuser = superuser
+    def __init__(self, superuser_id: int, *args: Any, **kwargs: Any) -> None:
+        self.superuser_id = superuser_id
 
-    def check_action(self, user_id: int, action: str, data: Any) -> bool:
-        return user_id == self.superuser
+    def is_allowed(
+        self, name: str, user_id: int, data: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        if user_id == self.superuser_id:
+            return [{} for _ in data]
+        else:
+            raise NotAllowed("Not the superuser")

--- a/tests/system/util.py
+++ b/tests/system/util.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, Mock
 from openslides_backend.environment import get_environment
 from openslides_backend.http.views import ActionView, PresenterView
 from openslides_backend.services.media.interface import MediaService
+from openslides_backend.services.permission.interface import PermissionService
 from openslides_backend.shared.interfaces.wsgi import View, WSGIApplication
 from openslides_backend.wsgi import OpenSlidesBackendServices, OpenSlidesBackendWSGI
 
@@ -28,6 +29,9 @@ def create_test_application(view: Type[View]) -> WSGIApplication:
     )
     mock_media_service = Mock(MediaService)
     services.media = MagicMock(return_value=mock_media_service)
+    mock_permission_service = Mock(PermissionService)
+    mock_permission_service.is_allowed = MagicMock(return_value=True)
+    services.permission = MagicMock(return_value=mock_permission_service)
 
     # Create WSGI application instance. Inject logging module, view class and services container.
     application_factory = OpenSlidesBackendWSGI(


### PR DESCRIPTION
@jsangmeister @normanjaeckel Can someone fix the tests? I think most of them relied on the actual HTTP-Adapter and not the test service. I do not have the overview to change this.

Also: Black formatted old tests again, but now I branched from master. Can someone run `./cleanup.sh` again and see, if it changes back?

This PR does only work in combination with https://github.com/OpenSlides/OpenSlides/pull/5646 in the main repo, if the complete setup is started there. With the complete setup, it can be seen in action. In [this file](https://github.com/OpenSlides/openslides-permission-service/blob/master/internal/core/queries.go) the current implemented queries are listed.