### PR TITLE
Added test.

### DIFF
--- a/openslides_backend/action/relations.py
+++ b/openslides_backend/action/relations.py
@@ -7,7 +7,6 @@ from ..models.fields import (
     BaseRelationField,
     GenericRelationField,
     GenericRelationListField,
-    OnDelete,
     RelationField,
     RelationListField,
     TemplateRelationField,
@@ -390,16 +389,6 @@ class RelationsHandler:
                 )
             else:
                 assert rel_id in remove
-                if (
-                    self.type in ("1:1", "m:1")
-                    and self.reverse_field.on_delete == OnDelete.PROTECT
-                ):
-                    # Hint: There is no on_delete behavior in m:n cases. The reverse
-                    # field is always nullable. We just modifiy the related field list.
-                    raise ActionException(
-                        f"You are not allowed to delete {self.model} {self.id} as "
-                        "long as there are some required related objects."
-                    )
                 if self.type in ("1:1", "m:1"):
                     new_value = None
                 else:
@@ -458,17 +447,6 @@ class RelationsHandler:
                     type="add", value=new_value, modified_element=value_to_be_added
                 )
             else:
-                assert rel_id in remove
-                if (
-                    self.type in ("1:1", "m:1")
-                    and self.reverse_field.on_delete == OnDelete.PROTECT
-                ):
-                    # Hint: There is no on_delete behavior in m:n cases. The reverse
-                    # field is always nullable. We just modifiy the related field list.
-                    raise ActionException(
-                        f"You are not allowed to delete {self.model} {self.id} as "
-                        "long as there are some required related objects."
-                    )
                 assert rel_id in remove
                 value_to_be_removed = FullQualifiedId(
                     collection=self.field.own_collection, id=self.id

--- a/openslides_backend/action/relations.py
+++ b/openslides_backend/action/relations.py
@@ -26,7 +26,7 @@ from ..shared.patterns import (
     FullQualifiedId,
     string_to_fqid,
 )
-from ..shared.typing import ModelMap
+from ..shared.typing import DeletedModel, ModelMap
 
 RelationsElement = TypedDict(
     "RelationsElement",
@@ -404,9 +404,12 @@ class RelationsHandler:
                     new_value = None
                 else:
                     assert self.type in ("1:m", "m:n")
-                    new_value = rel[related_name]
-                    assert isinstance(new_value, list)
-                    new_value.remove(self.id)
+                    if isinstance(rel, DeletedModel):
+                        new_value = []
+                    else:
+                        new_value = rel[related_name]
+                        assert isinstance(new_value, list)
+                        new_value.remove(self.id)
                 rel_element = RelationsElement(
                     type="remove", value=new_value, modified_element=self.id
                 )

--- a/openslides_backend/shared/typing.py
+++ b/openslides_backend/shared/typing.py
@@ -9,3 +9,6 @@ Schema = Dict[str, Any]
 
 class DeletedModel(Dict):
     """ Used to mark deleted models which return None for each field """
+
+    def __repr__(self) -> str:
+        return "DeletedModel"

--- a/tests/system/action/motion_state/test_delete.py
+++ b/tests/system/action/motion_state/test_delete.py
@@ -47,6 +47,7 @@ class MotionStateActionTest(BaseActionTestCase):
             json=[{"action": "motion_state.delete", "data": [{"id": 111}]}],
         )
         self.assert_status_code(response, 400)
-        assert "you have to delete the related motion_workflow first." in str(
-            response.data
+        assert (
+            "You can not delete motion state with id 111, because you have to delete the related model motion_workflow/1112 first."
+            in str(response.data)
         )

--- a/tests/system/action/motion_workflow/test_delete.py
+++ b/tests/system/action/motion_workflow/test_delete.py
@@ -125,3 +125,20 @@ class MotionWorkflowSystemTest(BaseActionTestCase):
         )
         self.assert_status_code(response, 400)
         self.assert_model_exists("motion_workflow/1")
+
+    def test_example_data(self) -> None:
+        self.load_example_data()
+        self.update_model(
+            "motion_workflow/2", {"default_statute_amendment_workflow_meeting_id": None}
+        )
+        self.update_model(
+            "motion_workflow/1", {"default_statute_amendment_workflow_meeting_id": 1}
+        )
+        self.update_model(
+            "meeting/1", {"motions_default_statute_amendment_workflow_id": 1}
+        )
+        response = self.client.post(
+            "/",
+            json=[{"action": "motion_workflow.delete", "data": [{"id": 2}]}],
+        )
+        self.assert_status_code(response, 200)

--- a/tests/system/action/topic/test_delete.py
+++ b/tests/system/action/topic/test_delete.py
@@ -67,3 +67,11 @@ class TopicDeleteActionTest(BaseActionTestCase):
         self.assert_status_code(response, 200)
         self.assert_model_deleted("topic/1")
         self.assert_model_deleted("list_of_speakers/1")
+
+    def test_example_data(self) -> None:
+        self.load_example_data()
+        response = self.client.post(
+            "/",
+            json=[{"action": "topic.delete", "data": [{"id": 1}]}],
+        )
+        self.assert_status_code(response, 200)

--- a/tests/system/action/topic/test_delete.py
+++ b/tests/system/action/topic/test_delete.py
@@ -68,10 +68,42 @@ class TopicDeleteActionTest(BaseActionTestCase):
         self.assert_model_deleted("topic/1")
         self.assert_model_deleted("list_of_speakers/1")
 
-    def test_example_data(self) -> None:
-        self.load_example_data()
+    def test_delete_with_agenda_item_and_filled_los(self) -> None:
+        self.create_model(
+            "meeting/1",
+            {
+                "agenda_item_ids": [3, 14],
+                "list_of_speakers_ids": [3],
+                "topic_ids": [1],
+            },
+        )
+        self.create_model(
+            "topic/1", {"agenda_item_id": 3, "list_of_speakers_id": 3, "meeting_id": 1}
+        )
+        self.create_model(
+            "agenda_item/3",
+            {"content_object_id": "topic/1", "meeting_id": 1},
+        )
+        self.create_model(
+            "list_of_speakers/3",
+            {"content_object_id": "topic/1", "speaker_ids": [1, 2], "meeting_id": 1},
+        )
+        self.create_model(
+            "speaker/1",
+            {"list_of_speakers_id": 3, "user_id": 1},
+        )
+        self.create_model(
+            "speaker/2",
+            {"list_of_speakers_id": 3, "user_id": 2},
+        )
+        self.create_model("user/2", {})
         response = self.client.post(
             "/",
             json=[{"action": "topic.delete", "data": [{"id": 1}]}],
         )
         self.assert_status_code(response, 200)
+        self.assert_model_deleted("topic/1")
+        self.assert_model_deleted("agenda_item/3")
+        self.assert_model_deleted("list_of_speakers/3")
+        self.assert_model_deleted("speaker/1")
+        self.assert_model_deleted("speaker/2")

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -27,7 +27,7 @@ class BaseSystemTestCase(TestCase):
     auth: AuthenticationService
     datastore: DatastoreService
     client: Client
-    media: Any  # needed because it is mocked and has magic methods
+    media: Any  # Any is needed because it is mocked and has magic methods
     EXAMPLE_DATA = "https://raw.githubusercontent.com/OpenSlides/OpenSlides/openslides4-dev/docs/example-data.json"
 
     def setUp(self) -> None:
@@ -45,12 +45,15 @@ class BaseSystemTestCase(TestCase):
         self.client = self.create_client(ADMIN_USERNAME, ADMIN_PASSWORD)
 
     def load_example_data(self) -> None:
+        """
+        Useful for debug purposes when an action fails with the example data.
+        Do NOT use in final tests since it takes a long time.
+        """
         self.datastore.truncate_db()
         example_data = json.loads(requests.get(self.EXAMPLE_DATA).content)
         for collection, models in example_data.items():
             for model in models:
-                fields = {k: v for k, v in model.items() if k != "id"}
-                self.create_model(f"{collection}/{model['id']}", fields)
+                self.create_model(f"{collection}/{model['id']}", model)
 
     def create_client(self, username: str, password: str) -> Client:
         return Client(self.app, username, password)

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict
 from unittest import TestCase
 
+import requests
+import simplejson as json
 from werkzeug.wrappers import Response
 
 from openslides_backend.services.auth.interface import AuthenticationService
@@ -26,6 +28,7 @@ class BaseSystemTestCase(TestCase):
     datastore: DatastoreService
     client: Client
     media: Any  # needed because it is mocked and has magic methods
+    EXAMPLE_DATA = "https://raw.githubusercontent.com/OpenSlides/OpenSlides/openslides4-dev/docs/example-data.json"
 
     def setUp(self) -> None:
         self.app = self.get_application()
@@ -40,6 +43,14 @@ class BaseSystemTestCase(TestCase):
             {"username": ADMIN_USERNAME, "password": self.auth.hash(ADMIN_PASSWORD)},
         )
         self.client = self.create_client(ADMIN_USERNAME, ADMIN_PASSWORD)
+
+    def load_example_data(self) -> None:
+        self.datastore.truncate_db()
+        example_data = json.loads(requests.get(self.EXAMPLE_DATA).content)
+        for collection, models in example_data.items():
+            for model in models:
+                fields = {k: v for k, v in model.items() if k != "id"}
+                self.create_model(f"{collection}/{model['id']}", fields)
 
     def create_client(self, username: str, password: str) -> Client:
         return Client(self.app, username, password)


### PR DESCRIPTION
@jsangmeister Can you please fix this test?

Maybe it is related to https://github.com/OpenSlides/openslides-backend-coordination/issues/48 but I am not sure. The problem is a cascade deletion with a reverse reference: Workflow -> State -> Workflow.

Maybe the solution is to put the deleted model also to `additional_related_models` here https://github.com/OpenSlides/openslides-backend/blob/master/openslides_backend/action/generics.py#L412 and not only models of related fields.