### PR TITLE
Add back auth commit to force rebuild

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ Werkzeug==1.0.1
 gunicorn==20.0.4
 bleach==3.2.1
 PyPDF2==1.26.0
-git+git://github.com/OpenSlides/openslides-auth-service#egg=authlib&subdirectory=auth/libraries/pip-auth # authlib
+git+git://github.com/OpenSlides/openslides-auth-service@6e3a2a3b5d71334a273cb2fc39cc376e8e7290d6#egg=authlib&subdirectory=auth/libraries/pip-auth # authlib


### PR DESCRIPTION
When just the master branch is set in the `requirements.txt`, the pip library is not rebuild when it changes in upstream because of the docker caching mechanisms. Because of this we have to go back to the explicit definition of the commit. If this changes, the requirements file must be updated and therefor the package is rebuild. @GabrielInTheWorld this means that the backend breaks again if the auth service gets an unexpected update, so please open a pull request here when you change anything in the auth service so that the backend is always up to date.