### PR TITLE
Added created and last_modified to motion.create.

### DIFF
--- a/openslides_backend/action/actions/motion/create.py
+++ b/openslides_backend/action/actions/motion/create.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any, Dict
 
 from ....models.models import Motion
@@ -166,4 +167,9 @@ class MotionCreate(
             )
 
         instance["sequence_number"] = self.get_sequence_number(instance["meeting_id"])
+        # set created and last_modified
+        timestamp = round(time.time())
+        instance["created"] = timestamp
+        instance["last_modified"] = timestamp
+
         return instance

--- a/tests/system/action/motion/test_create.py
+++ b/tests/system/action/motion/test_create.py
@@ -32,6 +32,8 @@ class MotionCreateActionTest(BaseActionTestCase):
         model = self.get_model("motion/1")
         assert model.get("title") == "test_Xcdfgee"
         assert model.get("meeting_id") == 222
+        assert model.get("created") is not None
+        assert model.get("created") == model.get("last_modified")
         agenda_item = self.get_model("agenda_item/1")
         self.assertEqual(agenda_item.get("meeting_id"), 222)
         self.assertEqual(agenda_item.get("content_object_id"), "motion/1")


### PR DESCRIPTION
In motion.create these automatic generated values were missing. Included them.
Timestamp is an integer, so use round(time.time()) for it.
Added some asserts to check it.