### PR TITLE
Reset locked fields before getting them (again)

### DIFF
--- a/openslides_backend/action/action_handler.py
+++ b/openslides_backend/action/action_handler.py
@@ -78,6 +78,7 @@ class ActionHandler(BaseHandler):
         retried = 0
         payload_copy = deepcopy(payload)
         while True:
+            self.datastore.reset_locked_fields()
             # Parse actions and creates events
             write_request_element, results = self.parse_actions(payload)
 

--- a/openslides_backend/services/datastore/adapter.py
+++ b/openslides_backend/services/datastore/adapter.py
@@ -222,6 +222,7 @@ class DatastoreAdapter(DatastoreService):
                 fqid = FullQualifiedId(collection=collection, id=instance_id)
                 self.update_locked_fields(fqid, instance_position)
             # TODO: collection_position should come from response: from collection or collection/meeting or collection/filter-criteria
+            # Replace and delete method get_lock_position_for_collection_id
             if len(response.items()):
                 collection_position = self.get_lock_position_for_collection_id(
                     collection, filter
@@ -356,6 +357,10 @@ class DatastoreAdapter(DatastoreService):
     def get_lock_position_for_collection_id(
         self, collection: Collection, filter: Filter
     ) -> int:
+        """
+        Use this temporary to fix tests. Needs to be replaced in DatastorerFilter.filter
+        when datastore-command retrieves the correct collection_position
+        """
         command = commands.Max(collection=collection, filter=filter, field="id")
         self.logger.debug(
             f"Start MAX request for collection to datastore with the following data: {command.data}"

--- a/openslides_backend/services/datastore/interface.py
+++ b/openslides_backend/services/datastore/interface.py
@@ -99,6 +99,9 @@ class DatastoreService(Protocol):
     def truncate_db(self) -> None:
         ...
 
+    def reset_locked_fields(self) -> None:
+        ...
+
 
 class Engine(Protocol):
     """


### PR DESCRIPTION
Choose smallest position value in locking fields, but reset locked_fields, before getting them (again)