### PR TITLE
Race condition tests and base work, see related Issue #351

### DIFF
--- a/openslides_backend/services/datastore/adapter.py
+++ b/openslides_backend/services/datastore/adapter.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Sequence, Union
 import simplejson as json
 from simplejson.errors import JSONDecodeError
 
+from ...shared.env import is_dev_mode
 from ...shared.exceptions import DatastoreException, DatastoreModelLockedException
 from ...shared.filters import And, Filter, FilterOperator, filter_visitor
 from ...shared.interfaces.logging import LoggingModule
@@ -327,6 +328,9 @@ class DatastoreAdapter(DatastoreService):
         return self.reserve_ids(collection=collection, amount=1)[0]
 
     def write(self, write_request_element: WriteRequestElement) -> None:
+        if is_dev_mode:
+            for e in write_request_element.events:
+                print(f"ID: {e['fqid']} Type:{e['type']} Fields: {e['fields']}")
         command = commands.Write(
             write_request_element=write_request_element,
             locked_fields=self.locked_fields,
@@ -341,7 +345,6 @@ class DatastoreAdapter(DatastoreService):
         """
         Dummy for monkeypatching the write
         """
-        pass
 
     def truncate_db(self) -> None:
         command = commands.TruncateDb()

--- a/openslides_backend/services/datastore/interface.py
+++ b/openslides_backend/services/datastore/interface.py
@@ -99,6 +99,9 @@ class DatastoreService(Protocol):
     def truncate_db(self) -> None:
         ...
 
+    def reset_locked_fields(self) -> None:
+        ...
+
 
 class Engine(Protocol):
     """

--- a/openslides_backend/shared/exceptions.py
+++ b/openslides_backend/shared/exceptions.py
@@ -50,6 +50,10 @@ class DatastoreException(ServiceException):
     pass
 
 
+class DatastoreModelLockedException(ServiceException):
+    pass
+
+
 class PermissionException(ServiceException):
     pass
 

--- a/tests/system/action/agenda_item/test_sort.py
+++ b/tests/system/action/agenda_item/test_sort.py
@@ -171,7 +171,9 @@ class AgendaItemSortActionTest(BaseActionTestCase):
         assert model_12.get("level") == 1
 
     def test_tree_sort_delete_race_condition(self) -> None:
-        self.create_model("meeting/222", {"name": "meeting222", "agenda_item_ids": [1, 11, 12]})
+        self.create_model(
+            "meeting/222", {"name": "meeting222", "agenda_item_ids": [1, 11, 12]}
+        )
         self.create_model("agenda_item/1", {"meeting_id": 222, "comment": "test_root"})
         self.create_model("agenda_item/11", {"meeting_id": 222, "comment": "test_1_1"})
         self.create_model("agenda_item/12", {"meeting_id": 222, "comment": "test_1_2"})

--- a/tests/system/action/lock.py
+++ b/tests/system/action/lock.py
@@ -1,8 +1,11 @@
 import threading
 from contextlib import contextmanager
-from typing import Iterator
+from typing import Any, Callable, Iterator, Union, cast
+
+from werkzeug.wrappers import Response
 
 from openslides_backend.services.datastore.adapter import DatastoreAdapter
+from openslides_backend.shared.exceptions import DatastoreModelLockedException
 from openslides_backend.shared.interfaces.write_request_element import (
     WriteRequestElement,
 )
@@ -16,27 +19,58 @@ def monkeypatch_datastore_adapter_write() -> Iterator[None]:
     Use a patched DatastoreAdapter.write in this context,
     which wraps the write with an optional lock from pytest_thread_local.testlock
     """
+    write_original: Callable = DatastoreAdapter.write_original
     DatastoreAdapter.write_original = DatastoreAdapter.write  # type: ignore
     DatastoreAdapter.write = write  # type: ignore
     try:
         yield
     finally:
         DatastoreAdapter.write = DatastoreAdapter.write_original  # type: ignore
-        delattr(DatastoreAdapter, "write_original")
+        DatastoreAdapter.write_original = write_original  # type: ignore
 
 
-def write(self, write_request_element: WriteRequestElement) -> None:  # type: ignore
+def write(self: DatastoreAdapter, write_request_element: WriteRequestElement) -> None:
     """
-    Wraps the write of the datastore.adapter and stops a thread, if the testlock attribute is set thread-local.
+    Wraps the write of the datastore.adapter and
+    - acquires the lock, if the testlock attribute is set thread-local
+    - set the event, if the event_sync attribute is set in thread-local
+    - counts the model_locked_counter with the DatastoreModelLockedException
     See example in test_create_sequence_numbers_race_condition
     """
-    if hasattr(pytest_thread_local, "testlock") and pytest_thread_local.testlock:
+
+    def do_write_original(write_request_element: WriteRequestElement) -> None:
         if (
-            hasattr(pytest_thread_local, "sync_event")
-            and pytest_thread_local.sync_event
+            hasattr(pytest_thread_local, "count_model_locked")
+            and pytest_thread_local.count_model_locked
         ):
-            pytest_thread_local.sync_event.set()
-        with pytest_thread_local.testlock:
+            try:
+                self.write_original(write_request_element)
+            except DatastoreModelLockedException:
+                cast(OSTestThread, threading.currentThread()).model_locked_counter += 1
+                raise
+        else:
             self.write_original(write_request_element)
+
+    if hasattr(pytest_thread_local, "sync_event") and pytest_thread_local.sync_event:
+        pytest_thread_local.sync_event.set()
+    if hasattr(pytest_thread_local, "testlock") and pytest_thread_local.testlock:
+        with pytest_thread_local.testlock:
+            do_write_original(write_request_element)
     else:
-        self.write_original(write_request_element)
+        do_write_original(write_request_element)
+
+
+class OSTestThread(threading.Thread):
+    exc: Union[None, Exception]
+    model_locked_counter: int
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        threading.Thread.__init__(self, *args, **kwargs)
+        self.exc = None
+        self.model_locked_counter = 0
+
+    def check_response(self, response: Response) -> None:
+        if response.status_code >= 400:
+            self.exc = Exception(
+                f"Exception in Thread {self.name}: Status: {response.status_code} {str(response.data)}"
+            )

--- a/tests/system/action/motion_category/test_sort.py
+++ b/tests/system/action/motion_category/test_sort.py
@@ -1,8 +1,16 @@
+import threading
+from typing import cast
+
 from tests.system.action.base import BaseActionTestCase
+from tests.system.action.lock import (
+    OSTestThread,
+    monkeypatch_datastore_adapter_write,
+    pytest_thread_local,
+)
 
 
 class MotionCategorySortActionTest(BaseActionTestCase):
-    def test_sort_singe_node_correct(self) -> None:
+    def test_sort_single_node_correct(self) -> None:
         self.create_model("meeting/222", {"name": "name_SNLGsvIV"})
         self.create_model("motion_category/22", {"meeting_id": 222})
         response = self.client.post(
@@ -184,3 +192,88 @@ class MotionCategorySortActionTest(BaseActionTestCase):
         assert category_2.get("weight") == 2
         category_3 = self.get_model("motion_category/3")
         assert category_3.get("weight") == 4
+
+    def test_sort_single_node_race_condition(self) -> None:
+        self.create_model("meeting/222", {"name": "name_SNLGsvIV"})
+        self.create_model("motion_category/22", {"meeting_id": 222})
+
+        with monkeypatch_datastore_adapter_write():
+            testlock = threading.Lock()
+            sync_event = threading.Event()
+            thread1 = OSTestThread(
+                target=thread_method_sorting,
+                kwargs={
+                    "test_instance": self,
+                    "testlock": testlock,
+                    "name": "Interrupted Sorting Thread",
+                    "sync_event": sync_event,
+                },
+            )
+            thread2 = OSTestThread(
+                target=thread_method_extra_category,
+                kwargs={
+                    "test_instance": self,
+                    "name": "Passing extra category-Thread",
+                },
+            )
+
+            testlock.acquire()
+            thread1.start()
+            sync_event.wait()
+            thread2.start()
+            thread2.join()
+            testlock.release()
+            thread1.join()
+
+        self.assert_model_locked_thrown_in_thread(thread1)
+        self.assert_no_thread_exception(thread2)
+        self.assert_thread_exception(thread1, "Did not recieve 2 ids, got 1")
+
+
+def thread_method_sorting(
+    test_instance: MotionCategorySortActionTest,
+    testlock: threading.Lock,
+    name: str,
+    sync_event: threading.Event = None,
+) -> None:
+    if testlock:
+        pytest_thread_local.testlock = testlock
+    if sync_event:
+        pytest_thread_local.sync_event = sync_event
+    pytest_thread_local.count_model_locked = True
+    pytest_thread_local.name = name
+
+    response = test_instance.client.post(
+        "/",
+        json=[
+            {
+                "action": "motion_category.sort",
+                "data": [{"meeting_id": 222, "tree": [{"id": 22}]}],
+            }
+        ],
+    )
+
+    cast(OSTestThread, threading.current_thread()).check_response(response)
+
+
+def thread_method_extra_category(
+    test_instance: MotionCategorySortActionTest,
+    name: str,
+) -> None:
+    pytest_thread_local.name = name
+    response = test_instance.client.post(
+        "/",
+        json=[
+            {
+                "action": "motion_category.create",
+                "data": [
+                    {
+                        "name": "test_Xcdfgee",
+                        "prefix": "prefix_niqCxoXA",
+                        "meeting_id": 222,
+                    }
+                ],
+            }
+        ],
+    )
+    cast(OSTestThread, threading.current_thread()).check_response(response)

--- a/tests/system/action/motion_category/test_sort_motions_in_categories.py
+++ b/tests/system/action/motion_category/test_sort_motions_in_categories.py
@@ -1,4 +1,12 @@
+import threading
+from typing import cast
+
 from tests.system.action.base import BaseActionTestCase
+from tests.system.action.lock import (
+    OSTestThread,
+    monkeypatch_datastore_adapter_write,
+    pytest_thread_local,
+)
 
 
 class MotionCategorySortMotionsInCategoriesActionTest(BaseActionTestCase):
@@ -52,3 +60,98 @@ class MotionCategorySortMotionsInCategoriesActionTest(BaseActionTestCase):
         )
         self.assert_status_code(response, 400)
         assert "Additional db_instances found." in str(response.data)
+
+    def test_sort_extra_motion_race_condition(self) -> None:
+        self.create_model("meeting/222", {"name": "meeting222"})
+        self.create_model(
+            "motion_workflow/12",
+            {"name": "name_workflow1", "first_state_id": 34, "state_ids": [34]},
+        )
+        self.create_model(
+            "motion_state/34", {"name": "name_state34", "meeting_id": 222}
+        )
+        self.create_model("motion_category/222", {"meeting_id": 222})
+        self.create_model("motion/31", {"category_id": 222})
+        self.create_model("motion/32", {"category_id": 222})
+
+        with monkeypatch_datastore_adapter_write():
+            testlock = threading.Lock()
+            sync_event = threading.Event()
+            thread1 = OSTestThread(
+                target=thread_method_sorting,
+                kwargs={
+                    "test_instance": self,
+                    "testlock": testlock,
+                    "name": "Interrupted Sorting Thread",
+                    "sync_event": sync_event,
+                },
+            )
+            thread2 = OSTestThread(
+                target=thread_method_extra_motion,
+                kwargs={
+                    "test_instance": self,
+                    "name": "Passing extra motion-Thread",
+                },
+            )
+
+            testlock.acquire()
+            thread1.start()
+            sync_event.wait()
+            thread2.start()
+            thread2.join()
+            testlock.release()
+            thread1.join()
+
+        self.assert_model_locked_thrown_in_thread(thread1)
+        self.assert_no_thread_exception(thread2)
+        self.assert_thread_exception(thread1, "Additional db_instances found")
+
+
+def thread_method_sorting(
+    test_instance: MotionCategorySortMotionsInCategoriesActionTest,
+    testlock: threading.Lock,
+    name: str,
+    sync_event: threading.Event = None,
+) -> None:
+    if testlock:
+        pytest_thread_local.testlock = testlock
+    if sync_event:
+        pytest_thread_local.sync_event = sync_event
+    pytest_thread_local.count_model_locked = True
+    pytest_thread_local.name = name
+
+    response = test_instance.client.post(
+        "/",
+        json=[
+            {
+                "action": "motion_category.sort_motions_in_category",
+                "data": [{"id": 222, "motion_ids": [32, 31]}],
+            }
+        ],
+    )
+    cast(OSTestThread, threading.current_thread()).check_response(response)
+
+
+def thread_method_extra_motion(
+    test_instance: MotionCategorySortMotionsInCategoriesActionTest,
+    name: str,
+) -> None:
+    pytest_thread_local.name = name
+    response = test_instance.client.post(
+        "/",
+        json=[
+            {
+                "action": "motion.create",
+                "data": [
+                    {
+                        "title": "test_title",
+                        "meeting_id": 222,
+                        "category_id": 222,
+                        "text": "test text",
+                        "workflow_id": 12,
+                    }
+                ],
+            }
+        ],
+    )
+    cast(OSTestThread, threading.current_thread()).check_response(response)

--- a/tests/system/action/motion_submitter/test_sort.py
+++ b/tests/system/action/motion_submitter/test_sort.py
@@ -1,4 +1,12 @@
+import threading
+from typing import cast
+
 from tests.system.action.base import BaseActionTestCase
+from tests.system.action.lock import (
+    OSTestThread,
+    monkeypatch_datastore_adapter_write,
+    pytest_thread_local,
+)
 
 
 class MotionSubmitterSortActionTest(BaseActionTestCase):
@@ -52,3 +60,194 @@ class MotionSubmitterSortActionTest(BaseActionTestCase):
         )
         self.assert_status_code(response, 400)
         assert "Additional db_instances found." in str(response.data)
+
+    def test_sort_delete_submitter_correct(self) -> None:
+        self.create_model("meeting/98", {"motion_submitter_ids": [31, 32, 33]})
+        self.create_model(
+            "motion/222",
+            {
+                "submitter_ids": [31, 32, 33],
+                "meeting_id": 98,
+            },
+        )
+        self.create_model(
+            "motion_submitter/31",
+            {
+                "motion_id": 222,
+                "meeting_id": 98,
+            },
+        )
+        self.create_model(
+            "motion_submitter/32",
+            {
+                "motion_id": 222,
+                "meeting_id": 98,
+            },
+        )
+        self.create_model(
+            "motion_submitter/33",
+            {
+                "motion_id": 222,
+                "meeting_id": 98,
+            },
+        )
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "motion_submitter.sort",
+                    "data": [{"motion_id": 222, "motion_submitter_ids": [33, 32, 31]}],
+                },
+                {
+                    "action": "motion_submitter.delete",
+                    "data": [{"id": 32}],
+                },
+            ],
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists("motion/222", {"submitter_ids": [31, 33]})
+
+    def test_sort_delete_submitter_fail(self) -> None:
+        self.create_model("meeting/98", {"motion_submitter_ids": [31, 32, 33]})
+        self.create_model(
+            "motion/222",
+            {
+                "submitter_ids": [31, 32, 33],
+                "meeting_id": 98,
+            },
+        )
+        self.create_model(
+            "motion_submitter/31",
+            {
+                "motion_id": 222,
+                "meeting_id": 98,
+            },
+        )
+        self.create_model(
+            "motion_submitter/32",
+            {
+                "motion_id": 222,
+                "meeting_id": 98,
+            },
+        )
+        self.create_model(
+            "motion_submitter/33",
+            {
+                "motion_id": 222,
+                "meeting_id": 98,
+            },
+        )
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "motion_submitter.delete",
+                    "data": [{"id": 32}],
+                },
+                {
+                    "action": "motion_submitter.sort",
+                    "data": [{"motion_id": 222, "motion_submitter_ids": [33, 32, 31]}],
+                },
+            ],
+        )
+        self.assert_status_code(response, 400)
+        self.assertIn(
+            "Model \\'motion_submitter/32\\' does not exist", str(response.data)
+        )
+
+    def test_sort_delete_race_condition(self) -> None:
+        self.create_model("meeting/98", {"motion_submitter_ids": [31, 32]})
+        self.create_model(
+            "motion/222",
+            {
+                "submitter_ids": [31, 32],
+                "meeting_id": 98,
+            },
+        )
+        self.create_model(
+            "motion_submitter/31",
+            {
+                "motion_id": 222,
+                "meeting_id": 98,
+            },
+        )
+        self.create_model(
+            "motion_submitter/32",
+            {
+                "motion_id": 222,
+                "meeting_id": 98,
+            },
+        )
+
+        with monkeypatch_datastore_adapter_write():
+            testlock = threading.Lock()
+            sync_event = threading.Event()
+            thread1 = OSTestThread(
+                target=thread_method_sorting,
+                kwargs={
+                    "test_instance": self,
+                    "testlock": testlock,
+                    "name": "Interrupted Sorting Thread",
+                    "sync_event": sync_event,
+                },
+            )
+            thread2 = OSTestThread(
+                target=thread_method_delete,
+                kwargs={
+                    "test_instance": self,
+                    "name": "Passing Delete Thread",
+                },
+            )
+
+            testlock.acquire()
+            thread1.start()
+            sync_event.wait()
+            thread2.start()
+            thread2.join()
+            testlock.release()
+            thread1.join()
+
+        self.assert_model_locked_thrown_in_thread(thread1)
+        self.assert_no_thread_exception(thread2)
+        self.assert_thread_exception(thread1, "Id 32 not in db_instances")
+
+
+def thread_method_sorting(
+    test_instance: MotionSubmitterSortActionTest,
+    testlock: threading.Lock,
+    name: str,
+    sync_event: threading.Event = None,
+) -> None:
+    if testlock:
+        pytest_thread_local.testlock = testlock
+    if sync_event:
+        pytest_thread_local.sync_event = sync_event
+    pytest_thread_local.count_model_locked = True
+    pytest_thread_local.name = name
+    response = test_instance.client.post(
+        "/",
+        json=[
+            {
+                "action": "motion_submitter.sort",
+                "data": [{"motion_id": 222, "motion_submitter_ids": [32, 31]}],
+            },
+        ],
+    )
+    cast(OSTestThread, threading.current_thread()).check_response(response)
+
+
+def thread_method_delete(
+    test_instance: MotionSubmitterSortActionTest,
+    name: str,
+) -> None:
+    pytest_thread_local.name = name
+    response = test_instance.client.post(
+        "/",
+        json=[
+            {
+                "action": "motion_submitter.delete",
+                "data": [{"id": 32}],
+            },
+        ],
+    )
+    cast(OSTestThread, threading.current_thread()).check_response(response)

--- a/tests/system/action/race_condition_mixin_test.py
+++ b/tests/system/action/race_condition_mixin_test.py
@@ -1,0 +1,77 @@
+import threading
+from typing import Any, Dict, cast, List
+
+from werkzeug.wrappers import Response
+
+from tests.system.action.base import BaseActionTestCase
+from openslides_backend.models import fields
+from openslides_backend.models.base import Model
+from openslides_backend.shared.patterns import Collection
+from tests.system.action.lock import OSTestThread, pytest_thread_local, monkeypatch_datastore_adapter_write
+
+
+class RaceConditionMixinTest(BaseActionTestCase):
+    def setup_test(self):
+        ...
+
+    def run_threads(self, post1, post2) -> (OSTestThread):
+        self.setup_test()
+        with monkeypatch_datastore_adapter_write():
+            testlock = threading.Lock()
+            sync_event = threading.Event()
+            thread1 = OSTestThread(
+                target=thread_method_interrupted,
+                kwargs={
+                    "post_data": post1,
+                    "test_instance": self,
+                    "testlock": testlock,
+                    "name": "Interrupted Thread",
+                    "sync_event": sync_event,
+                },
+            )
+            thread2 = OSTestThread(
+                target=thread_method_passing,
+                kwargs={
+                    "post_data": post2,
+                    "test_instance": self,
+                    "name": "Passing Thread",
+                },
+            )
+
+            testlock.acquire()
+            thread1.start()
+            sync_event.wait()
+            thread2.start()
+            thread2.join()
+            testlock.release()
+            thread1.join()
+
+        return thread1, thread2
+
+
+def thread_method_interrupted(
+    post_data: List[Dict[str, Any]],
+    test_instance: Any,
+    testlock: threading.Lock,
+    name: str,
+    sync_event: threading.Event = None,
+) -> None:
+    if testlock:
+        pytest_thread_local.testlock = testlock
+    if sync_event:
+        pytest_thread_local.sync_event = sync_event
+    pytest_thread_local.count_model_locked = True
+    pytest_thread_local.name = name
+
+    response = test_instance.client.post("/", json=post_data)
+    cast(OSTestThread, threading.current_thread()).check_response(response)
+
+
+def thread_method_passing(
+    post_data: List[Dict[str, Any]],
+    test_instance: Any,
+    name: str,
+) -> None:
+    pytest_thread_local.name = name
+    response = test_instance.client.post("/", json=post_data)
+    cast(OSTestThread, threading.current_thread()).check_response(response)

--- a/tests/system/action/race_condition_mixin_test.py
+++ b/tests/system/action/race_condition_mixin_test.py
@@ -1,20 +1,21 @@
 import threading
-from typing import Any, Dict, cast, List
-
-from werkzeug.wrappers import Response
+from typing import Any, Dict, List, Tuple, cast
 
 from tests.system.action.base import BaseActionTestCase
-from openslides_backend.models import fields
-from openslides_backend.models.base import Model
-from openslides_backend.shared.patterns import Collection
-from tests.system.action.lock import OSTestThread, pytest_thread_local, monkeypatch_datastore_adapter_write
+from tests.system.action.lock import (
+    OSTestThread,
+    monkeypatch_datastore_adapter_write,
+    pytest_thread_local,
+)
 
 
 class RaceConditionMixinTest(BaseActionTestCase):
-    def setup_test(self):
+    def setup_test(self) -> None:
         ...
 
-    def run_threads(self, post1, post2) -> (OSTestThread):
+    def run_threads(
+        self, post1: List[Dict[str, Any]], post2: List[Dict[str, Any]]
+    ) -> Tuple[OSTestThread, OSTestThread]:
         self.setup_test()
         with monkeypatch_datastore_adapter_write():
             testlock = threading.Lock()

--- a/tests/system/action/test_relations_race_conditions.py
+++ b/tests/system/action/test_relations_race_conditions.py
@@ -1,6 +1,6 @@
 from openslides_backend.action.generics.create import CreateAction
-from openslides_backend.action.generics.update import UpdateAction
 from openslides_backend.action.generics.delete import DeleteAction
+from openslides_backend.action.generics.update import UpdateAction
 from openslides_backend.action.util.register import register_action
 from openslides_backend.models import fields
 from openslides_backend.models.base import Model
@@ -19,12 +19,18 @@ class FakeModelRRCA(Model):
     r1n_a_id = fields.RelationField(to={Collection("fake_model_rrc_a"): "rn_a_ids"})
     rn_a_ids = fields.RelationListField(to={Collection("fake_model_rrc_a"): "r1n_a_id"})
 
-    rnm_a_ids = fields.RelationListField(to={Collection("fake_model_rrc_a"): "rnn_a_ids"})
-    rnn_a_ids = fields.RelationListField(to={Collection("fake_model_rrc_a"): "rnm_a_ids"})
+    rnm_a_ids = fields.RelationListField(
+        to={Collection("fake_model_rrc_a"): "rnn_a_ids"}
+    )
+    rnn_a_ids = fields.RelationListField(
+        to={Collection("fake_model_rrc_a"): "rnm_a_ids"}
+    )
 
     r1_b_id = fields.RelationField(to={Collection("fake_model_rrc_b"): "r1_a_id"})
     rn_b_ids = fields.RelationListField(to={Collection("fake_model_rrc_b"): "r1n_a_id"})
-    rnn_b_ids = fields.RelationListField(to={Collection("fake_model_rrc_b"): "rnn_a_ids"})
+    rnn_b_ids = fields.RelationListField(
+        to={Collection("fake_model_rrc_b"): "rnn_a_ids"}
+    )
 
 
 class FakeModelRRCB(Model):
@@ -34,7 +40,9 @@ class FakeModelRRCB(Model):
 
     r1_a_id = fields.RelationField(to={Collection("fake_model_rrc_a"): "r1_b_id"})
     r1n_a_id = fields.RelationField(to={Collection("fake_model_rrc_a"): "rn_b_ids"})
-    rnn_a_ids = fields.RelationListField(to={Collection("fake_model_rrc_a"): "rnn_b_ids"})
+    rnn_a_ids = fields.RelationListField(
+        to={Collection("fake_model_rrc_a"): "rnn_b_ids"}
+    )
 
 
 @register_action("fake_model_rrc_a.create")
@@ -48,15 +56,18 @@ class FakeModelRRCAUpdateAction(UpdateAction):
     model = FakeModelRRCA()
     schema = {}  # type: ignore
 
+
 @register_action("fake_model_rrc_a.delete")
 class FakeModelRRCADeleteAction(DeleteAction):
     model = FakeModelRRCA()
     schema = {}  # type: ignore
 
+
 @register_action("fake_model_rrc_b.update")
 class FakeModelRRCBUpdateAction(UpdateAction):
     model = FakeModelRRCB()
     schema = {}  # type: ignore
+
 
 @register_action("fake_model_rrc_b.delete")
 class FakeModelRRCBDeleteAction(DeleteAction):
@@ -67,41 +78,44 @@ class FakeModelRRCBDeleteAction(DeleteAction):
 class TestRelationComplexAndRaceCondition(RaceConditionMixinTest):
     def test_create_rel_1_to_1_AA_delete(self) -> None:
         self.create_model("fake_model_rrc_a/1", {})
-        a2_create_data = [{
-            "action": "fake_model_rrc_a.create",
-            "data": [
-                {"r1_a_id": 1}
-            ],
-        }]
-        a1_delete_data = [{
-            "action": "fake_model_rrc_a.delete",
-            "data": [
-                {"id": 1},
-            ],
-        }]
+        a2_create_data = [
+            {
+                "action": "fake_model_rrc_a.create",
+                "data": [{"r1_a_id": 1}],
+            }
+        ]
+        a1_delete_data = [
+            {
+                "action": "fake_model_rrc_a.delete",
+                "data": [
+                    {"id": 1},
+                ],
+            }
+        ]
 
         thread1, thread2 = self.run_threads(a2_create_data, a1_delete_data)
         self.assert_no_thread_exception(thread2)
-        self.assert_thread_exception(thread1, "fake_model_rrc_a/1\\\' does not exist")
+        self.assert_thread_exception(thread1, "fake_model_rrc_a/1\\' does not exist")
         self.assert_model_locked_thrown_in_thread(thread1)
 
     def test_create_rel_1_to_n_AA_delete(self) -> None:
         self.create_model("fake_model_rrc_a/1", {})
         self.create_model("fake_model_rrc_a/2", {})
-        a3_create_data = [{
-            "action": "fake_model_rrc_a.create",
-            "data": [{"rn_a_ids": [1, 2]}]
-        }]
-        a1_delete_data = [{
-            "action": "fake_model_rrc_a.delete",
-            "data": [
-                {"id": 1},
-            ],
-        }]
+        a3_create_data = [
+            {"action": "fake_model_rrc_a.create", "data": [{"rn_a_ids": [1, 2]}]}
+        ]
+        a1_delete_data = [
+            {
+                "action": "fake_model_rrc_a.delete",
+                "data": [
+                    {"id": 1},
+                ],
+            }
+        ]
 
         thread1, thread2 = self.run_threads(a3_create_data, a1_delete_data)
         self.assert_no_thread_exception(thread2)
-        self.assert_thread_exception(thread1, "fake_model_rrc_a/1\\\' does not exist")
+        self.assert_thread_exception(thread1, "fake_model_rrc_a/1\\' does not exist")
         self.assert_model_locked_thrown_in_thread(thread1)
 
     def test_create_rel_n_to_m_AA_okay(self) -> None:
@@ -110,17 +124,12 @@ class TestRelationComplexAndRaceCondition(RaceConditionMixinTest):
         action_create_data = [
             {
                 "action": "fake_model_rrc_a.create",
-                "data": [
-                    {"rnn_a_ids": [1, 2]}
-                ],
+                "data": [{"rnn_a_ids": [1, 2]}],
             },
             {
                 "action": "fake_model_rrc_a.update",
-                "data": [
-                    {"id": 1, "rnn_a_ids": [2, 3]}
-                ],
+                "data": [{"id": 1, "rnn_a_ids": [2, 3]}],
             },
-
         ]
         response = self.client.post("/", json=action_create_data)
 
@@ -141,69 +150,70 @@ class TestRelationComplexAndRaceCondition(RaceConditionMixinTest):
         action_create_data = [
             {
                 "action": "fake_model_rrc_a.create",
-                "data": [
-                    {"rnn_a_ids": [1, 2]}
-                ],
+                "data": [{"rnn_a_ids": [1, 2]}],
             },
             {
                 "action": "fake_model_rrc_a.update",
-                "data": [
-                    {"id": 1, "rnn_a_ids": [2, 3]}
-                ],
+                "data": [{"id": 1, "rnn_a_ids": [2, 3]}],
             },
-
         ]
-        a1_delete_data = [{
-            "action": "fake_model_rrc_a.delete",
-            "data": [
-                {"id": 1},
-            ],
-        }]
+        a1_delete_data = [
+            {
+                "action": "fake_model_rrc_a.delete",
+                "data": [
+                    {"id": 1},
+                ],
+            }
+        ]
 
         thread1, thread2 = self.run_threads(action_create_data, a1_delete_data)
         self.assert_no_thread_exception(thread2)
-        self.assert_thread_exception(thread1, "fake_model_rrc_a/1\\\' does not exist")
+        self.assert_thread_exception(thread1, "fake_model_rrc_a/1\\' does not exist")
         self.assert_model_locked_thrown_in_thread(thread1)
 
     def test_create_rel_1_to_1_AB_delete(self) -> None:
         self.create_model("fake_model_rrc_b/1", {})
-        a1_create_data = [{
-            "action": "fake_model_rrc_a.create",
-            "data": [
-                {"r1_b_id": 1}
-            ],
-        }]
-        b1_delete_data = [{
-            "action": "fake_model_rrc_b.delete",
-            "data": [
-                {"id": 1},
-            ],
-        }]
+        a1_create_data = [
+            {
+                "action": "fake_model_rrc_a.create",
+                "data": [{"r1_b_id": 1}],
+            }
+        ]
+        b1_delete_data = [
+            {
+                "action": "fake_model_rrc_b.delete",
+                "data": [
+                    {"id": 1},
+                ],
+            }
+        ]
 
         thread1, thread2 = self.run_threads(a1_create_data, b1_delete_data)
         self.assert_no_thread_exception(thread2)
-        self.assert_thread_exception(thread1, "fake_model_rrc_b/1\\\' does not exist")
+        self.assert_thread_exception(thread1, "fake_model_rrc_b/1\\' does not exist")
         self.assert_model_locked_thrown_in_thread(thread1)
 
     def test_create_rel_1_to_n_AB_delete(self) -> None:
         self.create_model("fake_model_rrc_b/1", {})
         self.create_model("fake_model_rrc_b/2", {})
-        a1_create_data = [{
-            "action": "fake_model_rrc_a.create",
-            "data": [
-                {"rn_b_ids": [1, 2]}
-            ],
-        }]
-        b1_delete_data = [{
-            "action": "fake_model_rrc_b.delete",
-            "data": [
-                {"id": 1},
-            ],
-        }]
+        a1_create_data = [
+            {
+                "action": "fake_model_rrc_a.create",
+                "data": [{"rn_b_ids": [1, 2]}],
+            }
+        ]
+        b1_delete_data = [
+            {
+                "action": "fake_model_rrc_b.delete",
+                "data": [
+                    {"id": 1},
+                ],
+            }
+        ]
 
         thread1, thread2 = self.run_threads(a1_create_data, b1_delete_data)
         self.assert_no_thread_exception(thread2)
-        self.assert_thread_exception(thread1, "fake_model_rrc_b/1\\\' does not exist")
+        self.assert_thread_exception(thread1, "fake_model_rrc_b/1\\' does not exist")
         self.assert_model_locked_thrown_in_thread(thread1)
 
     def test_create_rel_1_to_n_AB_error(self) -> None:
@@ -228,7 +238,11 @@ class TestRelationComplexAndRaceCondition(RaceConditionMixinTest):
         model_b1 = self.get_model("fake_model_rrc_b/1")
         model_b2 = self.get_model("fake_model_rrc_b/2")
         self.assertCountEqual(model1.get("rn_b_ids", []), [2])
-        self.assertEqual(model_b1.get("r1n_a_id"), None, "Should be None, but is still 1, because not removed by 2nd action")
+        self.assertEqual(
+            model_b1.get("r1n_a_id"),
+            None,
+            "Should be None, but is still 1, because not removed by 2nd action",
+        )
         self.assertEqual(model_b2.get("r1n_a_id"), 1)
 
     def test_create_rel_n_to_m_AB_okay1(self) -> None:
@@ -248,9 +262,7 @@ class TestRelationComplexAndRaceCondition(RaceConditionMixinTest):
         action_create_data = [
             {
                 "action": "fake_model_rrc_a.update",
-                "data": [
-                    {"id": 1, "rnn_b_ids": [1, 2]}
-                ],
+                "data": [{"id": 1, "rnn_b_ids": [1, 2]}],
             },
         ]
 
@@ -277,11 +289,8 @@ class TestRelationComplexAndRaceCondition(RaceConditionMixinTest):
         action_create_data = [
             {
                 "action": "fake_model_rrc_b.update",
-                "data": [
-                    {"id": 1, "rnn_a_ids": [1, 2]}
-                ],
+                "data": [{"id": 1, "rnn_a_ids": [1, 2]}],
             },
-
         ]
 
         response = self.client.post("/", json=action_create_data)
@@ -307,17 +316,12 @@ class TestRelationComplexAndRaceCondition(RaceConditionMixinTest):
         action_create_data = [
             {
                 "action": "fake_model_rrc_a.update",
-                "data": [
-                    {"id": 1, "rnn_b_ids": [1, 2]}
-                ],
+                "data": [{"id": 1, "rnn_b_ids": [1, 2]}],
             },
             {
                 "action": "fake_model_rrc_b.update",
-                "data": [
-                    {"id": 1, "rnn_a_ids": [1, 2]}
-                ],
+                "data": [{"id": 1, "rnn_a_ids": [1, 2]}],
             },
-
         ]
 
         response = self.client.post("/", json=action_create_data)
@@ -327,7 +331,11 @@ class TestRelationComplexAndRaceCondition(RaceConditionMixinTest):
         model3 = self.get_model("fake_model_rrc_a/3")
         model_b1 = self.get_model("fake_model_rrc_b/1")
         model_b2 = self.get_model("fake_model_rrc_b/2")
-        self.assertCountEqual(model1.get("rnn_b_ids", []), [1, 2], "Fails , because 2 is removed by 2nd Action")
+        self.assertCountEqual(
+            model1.get("rnn_b_ids", []),
+            [1, 2],
+            "Fails , because 2 is removed by 2nd Action",
+        )
         self.assertCountEqual(model2.get("rnn_b_ids", []), [1])
         self.assertCountEqual(model3.get("rnn_b_ids", []), [])
         self.assertCountEqual(model_b1.get("rnn_a_ids", []), [1, 2])
@@ -343,9 +351,7 @@ class TestRelationComplexAndRaceCondition(RaceConditionMixinTest):
         action_create_data = [
             {
                 "action": "fake_model_rrc_a.update",
-                "data": [
-                    {"id": 1, "rnn_b_ids": [1, 2]}
-                ],
+                "data": [{"id": 1, "rnn_b_ids": [1, 2]}],
             },
         ]
 
@@ -360,9 +366,7 @@ class TestRelationComplexAndRaceCondition(RaceConditionMixinTest):
         action_create_data = [
             {
                 "action": "fake_model_rrc_b.update",
-                "data": [
-                    {"id": 1, "rnn_a_ids": [1, 2]}
-                ],
+                "data": [{"id": 1, "rnn_a_ids": [1, 2]}],
             },
         ]
 
@@ -379,6 +383,62 @@ class TestRelationComplexAndRaceCondition(RaceConditionMixinTest):
         self.assertCountEqual(model3.get("rnn_b_ids", []), [])
         self.assertCountEqual(model_b1.get("rnn_a_ids", []), [1, 2])
         self.assertCountEqual(model_b2.get("rnn_a_ids", []), [1])
+
+    def test_create_threaded_rel_1_to_n_AB_ok1(self) -> None:
+        self.create_model("fake_model_rrc_a/1", {})
+        self.create_model("fake_model_rrc_b/1", {})
+        self.create_model("fake_model_rrc_b/2", {})
+        a1_update1 = [
+            {
+                "action": "fake_model_rrc_a.update",
+                "data": [{"id": 1, "rn_b_ids": [1, 2]}],
+            },
+        ]
+        a1_update2 = [
+            {
+                "action": "fake_model_rrc_a.update",
+                "data": [{"id": 1, "rn_b_ids": [2]}],
+            },
+        ]
+
+        thread1, thread2 = self.run_threads(a1_update1, a1_update2)
+        self.assert_no_thread_exception(thread1)
+        self.assert_no_thread_exception(thread2)
+        self.assert_model_locked_thrown_in_thread(thread1)
+        model_a1 = self.get_model("fake_model_rrc_a/1")
+        model_b1 = self.get_model("fake_model_rrc_b/1")
+        model_b2 = self.get_model("fake_model_rrc_b/2")
+        self.assertCountEqual(model_a1.get("rn_b_ids", []), [1, 2])
+        self.assertEqual(model_b1.get("r1n_a_id"), 1)
+        self.assertEqual(model_b2.get("r1n_a_id"), 1)
+
+    def test_create_threaded_rel_1_to_n_AB_ok2(self) -> None:
+        self.create_model("fake_model_rrc_a/1", {})
+        self.create_model("fake_model_rrc_b/1", {})
+        self.create_model("fake_model_rrc_b/2", {})
+        a1_update1 = [
+            {
+                "action": "fake_model_rrc_a.update",
+                "data": [{"id": 1, "rn_b_ids": [1, 2]}],
+            },
+        ]
+        a1_update2 = [
+            {
+                "action": "fake_model_rrc_a.update",
+                "data": [{"id": 1, "rn_b_ids": [2]}],
+            },
+        ]
+
+        thread1, thread2 = self.run_threads(a1_update2, a1_update1)
+        self.assert_no_thread_exception(thread1)
+        self.assert_no_thread_exception(thread2)
+        self.assert_model_locked_thrown_in_thread(thread1)
+        model_a1 = self.get_model("fake_model_rrc_a/1")
+        model_b1 = self.get_model("fake_model_rrc_b/1")
+        model_b2 = self.get_model("fake_model_rrc_b/2")
+        self.assertCountEqual(model_a1.get("rn_b_ids", []), [2])
+        self.assertEqual(model_b1.get("r1n_a_id"), None)
+        self.assertEqual(model_b2.get("r1n_a_id"), 1)
 
     # def test_create_rel_n_to_m_AB_delete(self) -> None:
     #     self.create_model("fake_model_rrc_a/1", {})
@@ -417,14 +477,17 @@ class TestRelationComplexAndRaceCondition(RaceConditionMixinTest):
     def test_create_A2_replace_b_id(self) -> None:
         self.create_model("fake_model_rrc_a/1", {"r1_b_id": 1})
         self.create_model("fake_model_rrc_b/1", {"r1_a_id": 1})
-        a2_create_data = [{
-            "action": "fake_model_rrc_a.create",
-            "data": [
-                {"r1_b_id": 1}
-            ],
-        }]
+        a2_create_data = [
+            {
+                "action": "fake_model_rrc_a.create",
+                "data": [{"r1_b_id": 1}],
+            }
+        ]
         response = self.client.post("/", json=a2_create_data)
 
         self.assert_status_code(response, 400)
         # TODO: Is this correct? Why not?
-        self.assertIn("You can not set fake_model_rrc_b/1/r1_a_id to a new value because this field is not empty.", str(response.data))
+        self.assertIn(
+            "You can not set fake_model_rrc_b/1/r1_a_id to a new value because this field is not empty.",
+            str(response.data),
+        )

--- a/tests/system/action/test_relations_race_conditions.py
+++ b/tests/system/action/test_relations_race_conditions.py
@@ -1,0 +1,430 @@
+from openslides_backend.action.generics.create import CreateAction
+from openslides_backend.action.generics.update import UpdateAction
+from openslides_backend.action.generics.delete import DeleteAction
+from openslides_backend.action.util.register import register_action
+from openslides_backend.models import fields
+from openslides_backend.models.base import Model
+from openslides_backend.shared.patterns import Collection
+
+from .race_condition_mixin_test import RaceConditionMixinTest
+
+
+class FakeModelRRCA(Model):
+    collection = Collection("fake_model_rrc_a")
+    verbose_name = "fake model for relation race condition field check a"
+    id = fields.IntegerField()
+
+    r1_a_id = fields.RelationField(to={Collection("fake_model_rrc_a"): "r1_a_id"})
+
+    r1n_a_id = fields.RelationField(to={Collection("fake_model_rrc_a"): "rn_a_ids"})
+    rn_a_ids = fields.RelationListField(to={Collection("fake_model_rrc_a"): "r1n_a_id"})
+
+    rnm_a_ids = fields.RelationListField(to={Collection("fake_model_rrc_a"): "rnn_a_ids"})
+    rnn_a_ids = fields.RelationListField(to={Collection("fake_model_rrc_a"): "rnm_a_ids"})
+
+    r1_b_id = fields.RelationField(to={Collection("fake_model_rrc_b"): "r1_a_id"})
+    rn_b_ids = fields.RelationListField(to={Collection("fake_model_rrc_b"): "r1n_a_id"})
+    rnn_b_ids = fields.RelationListField(to={Collection("fake_model_rrc_b"): "rnn_a_ids"})
+
+
+class FakeModelRRCB(Model):
+    collection = Collection("fake_model_rrc_b")
+    verbose_name = "fake model for  relation race condition field check b"
+    id = fields.IntegerField()
+
+    r1_a_id = fields.RelationField(to={Collection("fake_model_rrc_a"): "r1_b_id"})
+    r1n_a_id = fields.RelationField(to={Collection("fake_model_rrc_a"): "rn_b_ids"})
+    rnn_a_ids = fields.RelationListField(to={Collection("fake_model_rrc_a"): "rnn_b_ids"})
+
+
+@register_action("fake_model_rrc_a.create")
+class FakeModelRRCACreateAction(CreateAction):
+    model = FakeModelRRCA()
+    schema = {}  # type: ignore
+
+
+@register_action("fake_model_rrc_a.update")
+class FakeModelRRCAUpdateAction(UpdateAction):
+    model = FakeModelRRCA()
+    schema = {}  # type: ignore
+
+@register_action("fake_model_rrc_a.delete")
+class FakeModelRRCADeleteAction(DeleteAction):
+    model = FakeModelRRCA()
+    schema = {}  # type: ignore
+
+@register_action("fake_model_rrc_b.update")
+class FakeModelRRCBUpdateAction(UpdateAction):
+    model = FakeModelRRCB()
+    schema = {}  # type: ignore
+
+@register_action("fake_model_rrc_b.delete")
+class FakeModelRRCBDeleteAction(DeleteAction):
+    model = FakeModelRRCB()
+    schema = {}  # type: ignore
+
+
+class TestRelationComplexAndRaceCondition(RaceConditionMixinTest):
+    def test_create_rel_1_to_1_AA_delete(self) -> None:
+        self.create_model("fake_model_rrc_a/1", {})
+        a2_create_data = [{
+            "action": "fake_model_rrc_a.create",
+            "data": [
+                {"r1_a_id": 1}
+            ],
+        }]
+        a1_delete_data = [{
+            "action": "fake_model_rrc_a.delete",
+            "data": [
+                {"id": 1},
+            ],
+        }]
+
+        thread1, thread2 = self.run_threads(a2_create_data, a1_delete_data)
+        self.assert_no_thread_exception(thread2)
+        self.assert_thread_exception(thread1, "fake_model_rrc_a/1\\\' does not exist")
+        self.assert_model_locked_thrown_in_thread(thread1)
+
+    def test_create_rel_1_to_n_AA_delete(self) -> None:
+        self.create_model("fake_model_rrc_a/1", {})
+        self.create_model("fake_model_rrc_a/2", {})
+        a3_create_data = [{
+            "action": "fake_model_rrc_a.create",
+            "data": [{"rn_a_ids": [1, 2]}]
+        }]
+        a1_delete_data = [{
+            "action": "fake_model_rrc_a.delete",
+            "data": [
+                {"id": 1},
+            ],
+        }]
+
+        thread1, thread2 = self.run_threads(a3_create_data, a1_delete_data)
+        self.assert_no_thread_exception(thread2)
+        self.assert_thread_exception(thread1, "fake_model_rrc_a/1\\\' does not exist")
+        self.assert_model_locked_thrown_in_thread(thread1)
+
+    def test_create_rel_n_to_m_AA_okay(self) -> None:
+        self.create_model("fake_model_rrc_a/1", {})
+        self.create_model("fake_model_rrc_a/2", {})
+        action_create_data = [
+            {
+                "action": "fake_model_rrc_a.create",
+                "data": [
+                    {"rnn_a_ids": [1, 2]}
+                ],
+            },
+            {
+                "action": "fake_model_rrc_a.update",
+                "data": [
+                    {"id": 1, "rnn_a_ids": [2, 3]}
+                ],
+            },
+
+        ]
+        response = self.client.post("/", json=action_create_data)
+
+        self.assert_status_code(response, 200)
+        model = self.get_model("fake_model_rrc_a/1")
+        self.assertCountEqual(model["rnn_a_ids"], [2, 3])
+        self.assertCountEqual(model["rnm_a_ids"], [3])
+        model = self.get_model("fake_model_rrc_a/2")
+        self.assertIsNone(model.get("rnn_a_ids"))
+        self.assertCountEqual(model["rnm_a_ids"], [1, 3])
+        model = self.get_model("fake_model_rrc_a/3")
+        self.assertCountEqual(model["rnn_a_ids"], [1, 2])
+        self.assertCountEqual(model["rnm_a_ids"], [1])
+
+    def test_create_rel_n_to_m_AA_delete(self) -> None:
+        self.create_model("fake_model_rrc_a/1", {})
+        self.create_model("fake_model_rrc_a/2", {})
+        action_create_data = [
+            {
+                "action": "fake_model_rrc_a.create",
+                "data": [
+                    {"rnn_a_ids": [1, 2]}
+                ],
+            },
+            {
+                "action": "fake_model_rrc_a.update",
+                "data": [
+                    {"id": 1, "rnn_a_ids": [2, 3]}
+                ],
+            },
+
+        ]
+        a1_delete_data = [{
+            "action": "fake_model_rrc_a.delete",
+            "data": [
+                {"id": 1},
+            ],
+        }]
+
+        thread1, thread2 = self.run_threads(action_create_data, a1_delete_data)
+        self.assert_no_thread_exception(thread2)
+        self.assert_thread_exception(thread1, "fake_model_rrc_a/1\\\' does not exist")
+        self.assert_model_locked_thrown_in_thread(thread1)
+
+    def test_create_rel_1_to_1_AB_delete(self) -> None:
+        self.create_model("fake_model_rrc_b/1", {})
+        a1_create_data = [{
+            "action": "fake_model_rrc_a.create",
+            "data": [
+                {"r1_b_id": 1}
+            ],
+        }]
+        b1_delete_data = [{
+            "action": "fake_model_rrc_b.delete",
+            "data": [
+                {"id": 1},
+            ],
+        }]
+
+        thread1, thread2 = self.run_threads(a1_create_data, b1_delete_data)
+        self.assert_no_thread_exception(thread2)
+        self.assert_thread_exception(thread1, "fake_model_rrc_b/1\\\' does not exist")
+        self.assert_model_locked_thrown_in_thread(thread1)
+
+    def test_create_rel_1_to_n_AB_delete(self) -> None:
+        self.create_model("fake_model_rrc_b/1", {})
+        self.create_model("fake_model_rrc_b/2", {})
+        a1_create_data = [{
+            "action": "fake_model_rrc_a.create",
+            "data": [
+                {"rn_b_ids": [1, 2]}
+            ],
+        }]
+        b1_delete_data = [{
+            "action": "fake_model_rrc_b.delete",
+            "data": [
+                {"id": 1},
+            ],
+        }]
+
+        thread1, thread2 = self.run_threads(a1_create_data, b1_delete_data)
+        self.assert_no_thread_exception(thread2)
+        self.assert_thread_exception(thread1, "fake_model_rrc_b/1\\\' does not exist")
+        self.assert_model_locked_thrown_in_thread(thread1)
+
+    def test_create_rel_1_to_n_AB_error(self) -> None:
+        self.create_model("fake_model_rrc_a/1", {})
+        self.create_model("fake_model_rrc_b/1", {})
+        self.create_model("fake_model_rrc_b/2", {})
+        a1_update = [
+            {
+                "action": "fake_model_rrc_a.update",
+                "data": [{"id": 1, "rn_b_ids": [1, 2]}],
+            },
+            {
+                "action": "fake_model_rrc_a.update",
+                "data": [{"id": 1, "rn_b_ids": [2]}],
+            },
+        ]
+
+        response = self.client.post("/", json=a1_update)
+        self.assert_status_code(response, 200)
+
+        model1 = self.get_model("fake_model_rrc_a/1")
+        model_b1 = self.get_model("fake_model_rrc_b/1")
+        model_b2 = self.get_model("fake_model_rrc_b/2")
+        self.assertCountEqual(model1.get("rn_b_ids", []), [2])
+        self.assertEqual(model_b1.get("r1n_a_id"), None, "Should be None, but is still 1, because not removed by 2nd action")
+        self.assertEqual(model_b2.get("r1n_a_id"), 1)
+
+    def test_create_rel_n_to_m_AB_okay1(self) -> None:
+        """
+        okay/fail 1 to 4 series to compare:
+        okay1: Only first action => okay
+        okay2: Only second action => okay
+        fail3: Both actions in one post => fails
+        okay4: Both actions, but each in it own post => okay
+        """
+        self.create_model("fake_model_rrc_a/1", {})
+        self.create_model("fake_model_rrc_a/2", {})
+        self.create_model("fake_model_rrc_a/3", {"rnn_b_ids": [1]})
+        self.create_model("fake_model_rrc_b/1", {"rnn_a_ids": [3]})
+        self.create_model("fake_model_rrc_b/2", {})
+
+        action_create_data = [
+            {
+                "action": "fake_model_rrc_a.update",
+                "data": [
+                    {"id": 1, "rnn_b_ids": [1, 2]}
+                ],
+            },
+        ]
+
+        response = self.client.post("/", json=action_create_data)
+        self.assert_status_code(response, 200)
+        model1 = self.get_model("fake_model_rrc_a/1")
+        model2 = self.get_model("fake_model_rrc_a/2")
+        model3 = self.get_model("fake_model_rrc_a/3")
+        model_b1 = self.get_model("fake_model_rrc_b/1")
+        model_b2 = self.get_model("fake_model_rrc_b/2")
+        self.assertCountEqual(model1["rnn_b_ids"], [1, 2])
+        self.assertCountEqual(model2.get("rnn_b_ids", []), [])
+        self.assertCountEqual(model3["rnn_b_ids"], [1])
+        self.assertCountEqual(model_b1["rnn_a_ids"], [3, 1])
+        self.assertCountEqual(model_b2["rnn_a_ids"], [1])
+
+    def test_create_rel_n_to_m_AB_okay2(self) -> None:
+        self.create_model("fake_model_rrc_a/1", {})
+        self.create_model("fake_model_rrc_a/2", {})
+        self.create_model("fake_model_rrc_a/3", {"rnn_b_ids": [1]})
+        self.create_model("fake_model_rrc_b/1", {"rnn_a_ids": [3]})
+        self.create_model("fake_model_rrc_b/2", {})
+
+        action_create_data = [
+            {
+                "action": "fake_model_rrc_b.update",
+                "data": [
+                    {"id": 1, "rnn_a_ids": [1, 2]}
+                ],
+            },
+
+        ]
+
+        response = self.client.post("/", json=action_create_data)
+        self.assert_status_code(response, 200)
+        model1 = self.get_model("fake_model_rrc_a/1")
+        model2 = self.get_model("fake_model_rrc_a/2")
+        model3 = self.get_model("fake_model_rrc_a/3")
+        model_b1 = self.get_model("fake_model_rrc_b/1")
+        model_b2 = self.get_model("fake_model_rrc_b/2")
+        self.assertCountEqual(model1["rnn_b_ids"], [1])
+        self.assertCountEqual(model2["rnn_b_ids"], [1])
+        self.assertCountEqual(model3.get("rnn_b_ids", []), [])
+        self.assertCountEqual(model_b1["rnn_a_ids"], [1, 2])
+        self.assertCountEqual(model_b2.get("rnn_a_ids", []), [])
+
+    def test_create_rel_n_to_m_AB_fail3(self) -> None:
+        self.create_model("fake_model_rrc_a/1", {})
+        self.create_model("fake_model_rrc_a/2", {})
+        self.create_model("fake_model_rrc_a/3", {"rnn_b_ids": [1]})
+        self.create_model("fake_model_rrc_b/1", {"rnn_a_ids": [3]})
+        self.create_model("fake_model_rrc_b/2", {})
+
+        action_create_data = [
+            {
+                "action": "fake_model_rrc_a.update",
+                "data": [
+                    {"id": 1, "rnn_b_ids": [1, 2]}
+                ],
+            },
+            {
+                "action": "fake_model_rrc_b.update",
+                "data": [
+                    {"id": 1, "rnn_a_ids": [1, 2]}
+                ],
+            },
+
+        ]
+
+        response = self.client.post("/", json=action_create_data)
+        self.assert_status_code(response, 200)
+        model1 = self.get_model("fake_model_rrc_a/1")
+        model2 = self.get_model("fake_model_rrc_a/2")
+        model3 = self.get_model("fake_model_rrc_a/3")
+        model_b1 = self.get_model("fake_model_rrc_b/1")
+        model_b2 = self.get_model("fake_model_rrc_b/2")
+        self.assertCountEqual(model1.get("rnn_b_ids", []), [1, 2], "Fails , because 2 is removed by 2nd Action")
+        self.assertCountEqual(model2.get("rnn_b_ids", []), [1])
+        self.assertCountEqual(model3.get("rnn_b_ids", []), [])
+        self.assertCountEqual(model_b1.get("rnn_a_ids", []), [1, 2])
+        self.assertCountEqual(model_b2.get("rnn_a_ids", []), [1])
+
+    def test_create_rel_n_to_m_AB_okay4(self) -> None:
+        self.create_model("fake_model_rrc_a/1", {})
+        self.create_model("fake_model_rrc_a/2", {})
+        self.create_model("fake_model_rrc_a/3", {"rnn_b_ids": [1]})
+        self.create_model("fake_model_rrc_b/1", {"rnn_a_ids": [3]})
+        self.create_model("fake_model_rrc_b/2", {})
+
+        action_create_data = [
+            {
+                "action": "fake_model_rrc_a.update",
+                "data": [
+                    {"id": 1, "rnn_b_ids": [1, 2]}
+                ],
+            },
+        ]
+
+        response = self.client.post("/", json=action_create_data)
+        self.assert_status_code(response, 200)
+        model1 = self.get_model("fake_model_rrc_a/1")
+        model2 = self.get_model("fake_model_rrc_a/2")
+        model3 = self.get_model("fake_model_rrc_a/3")
+        model_b1 = self.get_model("fake_model_rrc_b/1")
+        model_b2 = self.get_model("fake_model_rrc_b/2")
+
+        action_create_data = [
+            {
+                "action": "fake_model_rrc_b.update",
+                "data": [
+                    {"id": 1, "rnn_a_ids": [1, 2]}
+                ],
+            },
+        ]
+
+        response = self.client.post("/", json=action_create_data)
+        self.assert_status_code(response, 200)
+
+        model1 = self.get_model("fake_model_rrc_a/1")
+        model2 = self.get_model("fake_model_rrc_a/2")
+        model3 = self.get_model("fake_model_rrc_a/3")
+        model_b1 = self.get_model("fake_model_rrc_b/1")
+        model_b2 = self.get_model("fake_model_rrc_b/2")
+        self.assertCountEqual(model1.get("rnn_b_ids", []), [1, 2])
+        self.assertCountEqual(model2.get("rnn_b_ids", []), [1])
+        self.assertCountEqual(model3.get("rnn_b_ids", []), [])
+        self.assertCountEqual(model_b1.get("rnn_a_ids", []), [1, 2])
+        self.assertCountEqual(model_b2.get("rnn_a_ids", []), [1])
+
+    # def test_create_rel_n_to_m_AB_delete(self) -> None:
+    #     self.create_model("fake_model_rrc_a/1", {})
+    #     self.create_model("fake_model_rrc_a/2", {})
+    #     self.create_model("fake_model_rrc_a/3", {"rnn_b_ids": [1]})
+    #     self.create_model("fake_model_rrc_b/1", {"rnn_a_ids": [3]})
+    #     self.create_model("fake_model_rrc_b/2", {})
+
+    #     action_create_data = [
+    #         {
+    #             "action": "fake_model_rrc_a.update",
+    #             "data": [
+    #                 {"id": 1, "rnn_b_ids": [1, 2]}
+    #             ],
+    #         },
+    #         {
+    #             "action": "fake_model_rrc_b.update",
+    #             "data": [
+    #                 {"id": 1, "rnn_a_ids": [1, 2]}
+    #             ],
+    #         },
+
+    #     ]
+    #     a1_delete_data = [{
+    #         "action": "fake_model_rrc_a.delete",
+    #         "data": [
+    #             {"id": 1},
+    #         ],
+    #     }]
+
+    #     thread1, thread2 = self.run_threads(action_create_data, a1_delete_data)
+    #     self.assert_no_thread_exception(thread2)
+    #     self.assert_thread_exception(thread1, "fake_model_rrc_a/1\\\' does not exist")
+    #     self.assert_model_locked_thrown_in_thread(thread1)
+
+    def test_create_A2_replace_b_id(self) -> None:
+        self.create_model("fake_model_rrc_a/1", {"r1_b_id": 1})
+        self.create_model("fake_model_rrc_b/1", {"r1_a_id": 1})
+        a2_create_data = [{
+            "action": "fake_model_rrc_a.create",
+            "data": [
+                {"r1_b_id": 1}
+            ],
+        }]
+        response = self.client.post("/", json=a2_create_data)
+
+        self.assert_status_code(response, 400)
+        # TODO: Is this correct? Why not?
+        self.assertIn("You can not set fake_model_rrc_b/1/r1_a_id to a new value because this field is not empty.", str(response.data))

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -21,6 +21,8 @@ from openslides_backend.shared.interfaces.write_request_element import (
 from openslides_backend.shared.interfaces.wsgi import WSGIApplication
 from tests.util import Client, get_collection_from_fqid, get_fqid, get_id_from_fqid
 
+from .action.lock import OSTestThread
+
 ADMIN_USERNAME = "admin"
 ADMIN_PASSWORD = "admin"
 
@@ -133,3 +135,24 @@ class BaseSystemTestCase(TestCase):
     def assert_model_deleted(self, fqid: str) -> None:
         model = self.get_model(fqid)
         self.assertTrue(model.get("meta_deleted"))
+
+    def assert_thread_exception(self, thread: OSTestThread, text: str) -> None:
+        if hasattr(thread, "exc") and isinstance(thread.exc, Exception):
+            message = str(thread.exc)
+            if text not in message:
+                standardMsg = f"Exception with '{text}' expected, but Exception with '{message}' found"
+                self.fail(self._formatMessage(None, standardMsg))
+        else:
+            raise Exception(f"Thread {thread.name}: Exception with '{text}' not raised")
+
+    def assert_no_thread_exception(self, thread: OSTestThread) -> None:
+        if hasattr(thread, "exc") and isinstance(thread.exc, Exception):
+            raise thread.exc
+
+    def assert_model_locked_thrown_in_thread(self, thread: OSTestThread) -> None:
+        if thread.model_locked_counter == 0:
+            raise (
+                Exception(
+                    f"Thread {thread.name}: The DatastoreModelLockedException has never been thrown"
+                )
+            )

--- a/tests/unit/services/test_database_adapter.py
+++ b/tests/unit/services/test_database_adapter.py
@@ -236,3 +236,8 @@ class DatastoreAdapterTester(TestCase):
             command.data
             == '{"events": [], "information": {}, "user_id": 42, "locked_fields": {}}'
         )
+
+    def test_reset_locked_fields(self) -> None:
+        self.db.locked_fields = {"a": 1}
+        self.db.reset_locked_fields()
+        assert not self.db.locked_fields


### PR DESCRIPTION
- Reset locked_fields on retry in handle_request
- adapter:update_locked_fields takes again min of positions
- adapter:filter uses temporary get_lock_position_for_collection_id
- Race Condition Tests for motion_category sort and sort motion in category
- General assert for retry exception in race conditions
- Test linear and tree sort deleting element in race condition
- Tests for adapter method reset_locked_fields
- Issue #351 Some relation tests and thread-test-mixin: Stop work, see related Issue