### PR TITLE
Move pytest params to setup.cfg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ pip-check:
 	pip-check
 
 coverage:
-	pytest --cov openslides_backend --cov-report html:openslides_backend/htmlcov
+	pytest --cov --cov-report html
 
 
 # Build and run production docker container (not usable inside the docker container)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,11 @@ exclude_lines =
     pragma: no cover
     raise NotImplementedError
     return NotImplemented
-fail_under = 97
+fail_under = 96
+omit = tests/*
+
+[coverage:html]
+directory = openslides_backend/htmlcov
 
 [mypy-fastjsonschema]
 ignore_missing_imports = true


### PR DESCRIPTION
This way, they apply to all pytest commands (e.g. in `run-tests.sh`, which distorted the coverage percentage).