### PR TITLE
Update schema for optional text fields

### DIFF
--- a/openslides_backend/models/fields.py
+++ b/openslides_backend/models/fields.py
@@ -82,10 +82,9 @@ class BooleanField(Field):
 
 class TextField(Field):
     def get_schema(self) -> Schema:
-        schema = self.extend_schema(super().get_schema(), type="string")
         if self.required:
-            schema = self.extend_schema(schema, minLength=1)
-        return schema
+            return self.extend_schema(super().get_schema(), type="string", minLength=1)
+        return self.extend_schema(super().get_schema(), type=["string", "null"])
 
 
 class CharField(TextField):
@@ -131,9 +130,12 @@ class DecimalField(Field):
     """
 
     def get_schema(self) -> Schema:
-        return self.extend_schema(
+        schema = self.extend_schema(
             super().get_schema(), type="string", pattern=r"^-?(\d|[1-9]\d+)\.\d{6}$"
         )
+        if not self.required:
+            schema["type"] = ["string", "null"]
+        return schema
 
 
 class TimestampField(IntegerField):
@@ -154,7 +156,9 @@ class ArrayField(Field):
         self.in_array_constraints = in_array_constraints
 
     def get_schema(self) -> Schema:
-        return self.extend_schema(super().get_schema(), type="array", default=[])
+        if self.required:
+            return self.extend_schema(super().get_schema(), type="array", default=[])
+        return self.extend_schema(super().get_schema(), type=["array", "null"])
 
 
 class CharArrayField(ArrayField):

--- a/tests/system/action/motion_category/test_create.py
+++ b/tests/system/action/motion_category/test_create.py
@@ -107,3 +107,25 @@ class MotionCategorySystemTest(BaseActionTestCase):
             "Model \\'meeting/222\\' does not exist",
             str(response.data),
         )
+
+    def test_create_prefix_none(self) -> None:
+        self.create_model("meeting/222")
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "motion_category.create",
+                    "data": [
+                        {
+                            "name": "test_Xcdfgee",
+                            "meeting_id": 222,
+                            "prefix": None,
+                        }
+                    ],
+                }
+            ],
+        )
+        self.assert_status_code(response, 200)
+        model = self.get_model("motion_category/1")
+        assert model.get("name") == "test_Xcdfgee"
+        assert "prefix" not in model

--- a/tests/system/action/motion_category/test_update.py
+++ b/tests/system/action/motion_category/test_update.py
@@ -37,6 +37,30 @@ class MotionCategorySystemTest(BaseActionTestCase):
         assert model.get("prefix") == "prefix_sthyAKrW"
         assert model.get("motion_ids") == [89]
 
+    def test_update_delete_prefix(self) -> None:
+        self.create_model("meeting/222")
+        self.create_model(
+            "motion_category/111",
+            {"name": "name_srtgb123", "prefix": "prefix_JmDHFgvH", "meeting_id": 222},
+        )
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "motion_category.update",
+                    "data": [
+                        {
+                            "id": 111,
+                            "prefix": None,
+                        }
+                    ],
+                }
+            ],
+        )
+        self.assert_status_code(response, 200)
+        model = self.get_model("motion_category/111")
+        assert "prefix" not in model
+
     def test_update_wrong_id(self) -> None:
         self.create_model("meeting/222", {"name": "name_xQyvfmsS"})
         self.create_model(

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -74,7 +74,7 @@ class BaseSystemTestCase(TestCase):
         self.assertEqual(response.status_code, code)
 
     def create_model(
-        self, fqid: str, data: Dict[str, Any], deleted: bool = False
+        self, fqid: str, data: Dict[str, Any] = {}, deleted: bool = False
     ) -> None:
         data["id"] = get_id_from_fqid(fqid)
         self.validate_fields(fqid, data)


### PR DESCRIPTION
Use the `required` attribute consistently. Fixes #395 