### PR TITLE
Issue397 Adjust WR to per-action base with locked-fields

### DIFF
--- a/openslides_backend/services/datastore/adapter.py
+++ b/openslides_backend/services/datastore/adapter.py
@@ -313,14 +313,13 @@ class DatastoreAdapter(DatastoreService):
     def reserve_id(self, collection: Collection) -> int:
         return self.reserve_ids(collection=collection, amount=1)[0]
 
-    def write(self, write_request: WriteRequest) -> None:
-        command = commands.Write(
-            write_request=write_request,
-            locked_fields=self.locked_fields,
-        )
+    def write(self, write_requests: Union[List[WriteRequest], WriteRequest]) -> None:
+        if isinstance(write_requests, WriteRequest):
+            write_requests = [write_requests]
+        command = commands.Write(write_requests=write_requests)
         self.logger.debug(
             f"Start WRITE request to datastore with the following data: "
-            f"Write request: {write_request}"
+            f"Write request: {write_requests}"
         )
         self.retrieve(command)
 

--- a/openslides_backend/services/datastore/interface.py
+++ b/openslides_backend/services/datastore/interface.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Sequence, Tuple
+from typing import Any, Dict, List, Sequence, Tuple, Union
 
 from mypy_extensions import TypedDict
 from typing_extensions import Protocol
@@ -93,7 +93,7 @@ class DatastoreService(Protocol):
     def reserve_id(self, collection: Collection) -> int:
         ...
 
-    def write(self, write_request: WriteRequest) -> None:
+    def write(self, write_requests: Union[List[WriteRequest], WriteRequest]) -> None:
         ...
 
     def truncate_db(self) -> None:

--- a/openslides_backend/shared/interfaces/write_request.py
+++ b/openslides_backend/shared/interfaces/write_request.py
@@ -16,3 +16,4 @@ class WriteRequest:
     events: List[Event]
     information: Information
     user_id: int
+    locked_fields: Dict[str, int]

--- a/tests/system/action/test_action_command_format.py
+++ b/tests/system/action/test_action_command_format.py
@@ -1,0 +1,291 @@
+from unittest.mock import Mock
+
+from openslides_backend.action.action_handler import ActionHandler
+from openslides_backend.action.util.typing import Payload
+
+from .base import BaseActionTestCase
+
+# TODO: parse_action Tests als UnitTests zum Action Handler, die anderen, die das schreib format testen mal schauen
+
+
+class GeneralActionCommandFormat(BaseActionTestCase):
+    """
+    Tests the interface to datastore-command with one WriteRequest
+    per payload-action and it's own locked_fields
+    """
+
+    def get_action_handler(self) -> ActionHandler:
+        logger = Mock()
+        handler = ActionHandler(self.services, logger)
+        handler.user_id = 1
+        return handler
+
+    def test_parse_actions_create_2_actions(self) -> None:
+        self.create_model("committee/1", {"name": "test_committee"})
+        payload: Payload = [
+            {
+                "action": "meeting.create",
+                "data": [
+                    {
+                        "name": "name1",
+                        "welcome_title": "title1",
+                        "committee_id": 1,
+                    }
+                ],
+            },
+            {
+                "action": "meeting.create",
+                "data": [
+                    {
+                        "name": "name2",
+                        "welcome_title": "title2",
+                        "committee_id": 1,
+                    }
+                ],
+            },
+        ]
+
+        action_handler = self.get_action_handler()
+        write_requests, _ = action_handler.parse_actions(payload)
+        self.assertEqual(len(write_requests), 2)
+        self.assertEqual(len(write_requests[0].events), 2)
+        self.assertEqual(write_requests[0].locked_fields, {"committee/1": 2})
+        self.assertEqual(write_requests[0].events[0]["type"], "create")
+        self.assertEqual(write_requests[0].events[1]["type"], "update")
+        self.assertEqual(str(write_requests[0].events[0]["fqid"]), "meeting/1")
+        self.assertEqual(str(write_requests[0].events[1]["fqid"]), "committee/1")
+        self.assertEqual(len(write_requests[1].events), 2)
+        self.assertEqual(write_requests[1].locked_fields, {"committee/1": 2})
+
+    def test_parse_actions_create_1_2_events(self) -> None:
+        self.create_model("committee/1", {"name": "test_committee"})
+        payload: Payload = [
+            {
+                "action": "meeting.create",
+                "data": [
+                    {
+                        "name": "name1",
+                        "welcome_title": "title1",
+                        "committee_id": 1,
+                    },
+                    {
+                        "name": "name2",
+                        "welcome_title": "title2",
+                        "committee_id": 1,
+                    },
+                ],
+            },
+        ]
+
+        action_handler = self.get_action_handler()
+        write_requests, _ = action_handler.parse_actions(payload)
+        self.assertEqual(len(write_requests), 1)
+        self.assertEqual(len(write_requests[0].events), 4)
+        self.assertEqual(write_requests[0].locked_fields, {"committee/1": 2})
+        self.assertEqual(write_requests[0].events[0]["type"], "create")
+        self.assertEqual(write_requests[0].events[1]["type"], "create")
+        self.assertEqual(write_requests[0].events[2]["type"], "update")
+        self.assertEqual(write_requests[0].events[3]["type"], "update")
+        self.assertEqual(str(write_requests[0].events[0]["fqid"]), "meeting/1")
+        self.assertEqual(str(write_requests[0].events[1]["fqid"]), "meeting/2")
+        self.assertEqual(str(write_requests[0].events[2]["fqid"]), "committee/1")
+        self.assertEqual(str(write_requests[0].events[3]["fqid"]), "committee/1")
+
+    def test_create_2_actions(self) -> None:
+        self.create_model("committee/1", {"name": "test_committee"})
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "meeting.create",
+                    "data": [
+                        {
+                            "name": "name1",
+                            "welcome_title": "title1",
+                            "committee_id": 1,
+                        }
+                    ],
+                },
+                {
+                    "action": "meeting.create",
+                    "data": [
+                        {
+                            "name": "name2",
+                            "welcome_title": "title2",
+                            "committee_id": 1,
+                        }
+                    ],
+                },
+            ],
+        )
+        self.assert_status_code(response, 200)
+        meeting1 = self.get_model("meeting/1")
+        assert meeting1.get("name") == "name1"
+        assert meeting1.get("committee_id") == 1
+        meeting2 = self.get_model("meeting/2")
+        assert meeting2.get("name") == "name2"
+        assert meeting2.get("committee_id") == 1
+
+    def test_create_1_2_events(self) -> None:
+        self.create_model("committee/1", {"name": "test_committee"})
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "meeting.create",
+                    "data": [
+                        {
+                            "name": "name1",
+                            "welcome_title": "title1",
+                            "committee_id": 1,
+                        },
+                        {
+                            "name": "name2",
+                            "welcome_title": "title2",
+                            "committee_id": 1,
+                        },
+                    ],
+                },
+            ],
+        )
+        self.assert_status_code(response, 200)
+        meeting1 = self.get_model("meeting/1")
+        assert meeting1.get("name") == "name1"
+        assert meeting1.get("committee_id") == 1
+        meeting2 = self.get_model("meeting/2")
+        assert meeting2.get("name") == "name2"
+        assert meeting2.get("committee_id") == 1
+
+    def test_update_2_actions(self) -> None:
+        self.create_model(
+            "meeting/1", {"name": "name1", "committee_id": 1, "welcome_title": "t"}
+        )
+        self.create_model(
+            "meeting/2", {"name": "name2", "committee_id": 1, "welcome_title": "t"}
+        )
+        self.create_model("committee/1", {"name": "test_committee"})
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "meeting.update",
+                    "data": [
+                        {
+                            "id": 1,
+                            "name": "name1_updated",
+                        }
+                    ],
+                },
+                {
+                    "action": "meeting.update",
+                    "data": [
+                        {
+                            "id": 2,
+                            "name": "name2_updated",
+                        }
+                    ],
+                },
+            ],
+        )
+        self.assert_status_code(response, 200)
+        meeting1 = self.get_model("meeting/1")
+        assert meeting1.get("name") == "name1_updated"
+        meeting2 = self.get_model("meeting/2")
+        assert meeting2.get("name") == "name2_updated"
+
+    def test_update_1_2_events(self) -> None:
+        self.create_model(
+            "meeting/1", {"name": "name1", "committee_id": 1, "welcome_title": "t"}
+        )
+        self.create_model(
+            "meeting/2", {"name": "name2", "committee_id": 1, "welcome_title": "t"}
+        )
+        self.create_model("committee/1", {"name": "test_committee"})
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "meeting.update",
+                    "data": [
+                        {
+                            "id": 1,
+                            "name": "name1_updated",
+                        },
+                        {
+                            "id": 2,
+                            "name": "name2_updated",
+                        },
+                    ],
+                },
+            ],
+        )
+        self.assert_status_code(response, 200)
+        meeting1 = self.get_model("meeting/1")
+        assert meeting1.get("name") == "name1_updated"
+        meeting2 = self.get_model("meeting/2")
+        assert meeting2.get("name") == "name2_updated"
+
+    def test_delete_2_actions(self) -> None:
+        self.create_model(
+            "meeting/1", {"name": "name1", "committee_id": 1, "welcome_title": "t"}
+        )
+        self.create_model(
+            "meeting/2", {"name": "name2", "committee_id": 1, "welcome_title": "t"}
+        )
+        self.create_model(
+            "committee/1", {"name": "test_committee", "meeting_ids": [1, 2]}
+        )
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "meeting.delete",
+                    "data": [
+                        {
+                            "id": 1,
+                        }
+                    ],
+                },
+                {
+                    "action": "meeting.delete",
+                    "data": [
+                        {
+                            "id": 2,
+                        }
+                    ],
+                },
+            ],
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_deleted("meeting/1")
+        self.assert_model_deleted("meeting/2")
+
+    def test_delete_1_2_events(self) -> None:
+        self.create_model(
+            "meeting/1", {"name": "name1", "committee_id": 1, "welcome_title": "t"}
+        )
+        self.create_model(
+            "meeting/2", {"name": "name2", "committee_id": 1, "welcome_title": "t"}
+        )
+        self.create_model(
+            "committee/1", {"name": "test_committee", "meeting_ids": [1, 2]}
+        )
+        response = self.client.post(
+            "/",
+            json=[
+                {
+                    "action": "meeting.delete",
+                    "data": [
+                        {
+                            "id": 1,
+                        },
+                        {
+                            "id": 2,
+                        },
+                    ],
+                },
+            ],
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_deleted("meeting/1")
+        self.assert_model_deleted("meeting/2")

--- a/tests/system/action/test_action_command_format.py
+++ b/tests/system/action/test_action_command_format.py
@@ -118,13 +118,11 @@ class GeneralActionCommandFormat(BaseActionTestCase):
                 },
             ],
         )
-        self.assert_status_code(response, 200)
-        meeting1 = self.get_model("meeting/1")
-        assert meeting1.get("name") == "name1"
-        assert meeting1.get("committee_id") == 1
-        meeting2 = self.get_model("meeting/2")
-        assert meeting2.get("name") == "name2"
-        assert meeting2.get("committee_id") == 1
+        self.assert_status_code(response, 400)
+        self.assertIn(b'{"success": false, "message": "Datastore service sends HTTP 400. {\'key\': \'committee/1\', \'type\': 6, \'type_verbose\': \'MODEL_LOCKED\'}"}', response.data)
+        self.assert_model_not_exists("meeting/1")
+        self.assert_model_not_exists("meeting/1")
+        self.assert_model_exists("committee/1", {"meeting_ids": None})
 
     def test_create_1_2_events(self) -> None:
         self.create_model("committee/1", {"name": "test_committee"})
@@ -256,9 +254,10 @@ class GeneralActionCommandFormat(BaseActionTestCase):
                 },
             ],
         )
-        self.assert_status_code(response, 200)
-        self.assert_model_deleted("meeting/1")
-        self.assert_model_deleted("meeting/2")
+        self.assert_status_code(response, 400)
+        self.assertIn(b'{"success": false, "message": "Datastore service sends HTTP 400. {\'key\': \'committee/1\', \'type\': 6, \'type_verbose\': \'MODEL_LOCKED\'}"}', response.data)
+        self.assert_model_exists("meeting/1")
+        self.assert_model_exists("meeting/2")
 
     def test_delete_1_2_events(self) -> None:
         self.create_model(

--- a/tests/system/action/test_action_command_format.py
+++ b/tests/system/action/test_action_command_format.py
@@ -119,7 +119,10 @@ class GeneralActionCommandFormat(BaseActionTestCase):
             ],
         )
         self.assert_status_code(response, 400)
-        self.assertIn(b'{"success": false, "message": "Datastore service sends HTTP 400. {\'key\': \'committee/1\', \'type\': 6, \'type_verbose\': \'MODEL_LOCKED\'}"}', response.data)
+        self.assertIn(
+            b"{\"success\": false, \"message\": \"Datastore service sends HTTP 400. {'key': 'committee/1', 'type': 6, 'type_verbose': 'MODEL_LOCKED'}\"}",
+            response.data,
+        )
         self.assert_model_not_exists("meeting/1")
         self.assert_model_not_exists("meeting/1")
         self.assert_model_exists("committee/1", {"meeting_ids": None})
@@ -255,7 +258,10 @@ class GeneralActionCommandFormat(BaseActionTestCase):
             ],
         )
         self.assert_status_code(response, 400)
-        self.assertIn(b'{"success": false, "message": "Datastore service sends HTTP 400. {\'key\': \'committee/1\', \'type\': 6, \'type_verbose\': \'MODEL_LOCKED\'}"}', response.data)
+        self.assertIn(
+            b"{\"success\": false, \"message\": \"Datastore service sends HTTP 400. {'key': 'committee/1', 'type': 6, 'type_verbose': 'MODEL_LOCKED'}\"}",
+            response.data,
+        )
         self.assert_model_exists("meeting/1")
         self.assert_model_exists("meeting/2")
 

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -80,6 +80,7 @@ class BaseSystemTestCase(TestCase):
             events=[Event(type=EventType.Create, fqid=get_fqid(fqid), fields=data)],
             information={},
             user_id=0,
+            locked_fields={},
         )
         if deleted:
             request.events.append(Event(type=EventType.Delete, fqid=get_fqid(fqid)))
@@ -91,6 +92,7 @@ class BaseSystemTestCase(TestCase):
             events=[Event(type=EventType.Update, fqid=get_fqid(fqid), fields=data)],
             information={},
             user_id=0,
+            locked_fields={},
         )
         self.datastore.write(request)
 

--- a/tests/unit/services/test_database_adapter.py
+++ b/tests/unit/services/test_database_adapter.py
@@ -219,16 +219,26 @@ class DatastoreAdapterTester(TestCase):
         self.engine.retrieve.assert_called_with("reserve_ids", command.data)
         assert new_id == 42
 
-    def test_write(self) -> None:
-        write_request = WriteRequest(
-            events=[],
-            information={},
-            user_id=42,
-        )
-        command = commands.Write(write_request=write_request, locked_fields={})
+    def test_write_new_style(self) -> None:
+        write_requests = [
+            WriteRequest(events=[], information={}, user_id=42, locked_fields={})
+        ]
+        command = commands.Write(write_requests=write_requests)
         self.engine.retrieve.return_value = "", 200
-        self.db.write(write_request=write_request)
+        self.db.write(write_requests=write_requests)
         assert (
             command.data
-            == '{"events": [], "information": {}, "user_id": 42, "locked_fields": {}}'
+            == '[{"events": [], "information": {}, "user_id": 42, "locked_fields": {}}]'
+        )
+
+    def test_write_old_style(self) -> None:
+        write_request = WriteRequest(
+            events=[], information={}, user_id=42, locked_fields={}
+        )
+        command = commands.Write(write_requests=[write_request])
+        self.engine.retrieve.return_value = "", 200
+        self.db.write(write_requests=write_request)
+        assert (
+            command.data
+            == '[{"events": [], "information": {}, "user_id": 42, "locked_fields": {}}]'
         )

--- a/tests/unit/test_action.py
+++ b/tests/unit/test_action.py
@@ -29,6 +29,7 @@ class ActionBaseTester(TestCase):
                 get_fqid("collection_Chebie1jie/42"): ["Information text laPu7iepei"]
             },
             user_id=1,
+            locked_fields={},
         )
         self.write_request_2 = WriteRequest(
             events=[
@@ -42,6 +43,7 @@ class ActionBaseTester(TestCase):
                 get_fqid("collection_Chebie1jie/42"): ["Information text eesh7thouY"]
             },
             user_id=1,
+            locked_fields={},
         )
 
     def test_merge_write_requests(self) -> None:
@@ -66,6 +68,7 @@ class ActionBaseTester(TestCase):
                 ]
             },
             user_id=1,
+            locked_fields={},
         )
         self.assertEqual(result, expected)
 


### PR DESCRIPTION
Fails with most of tests, because of changed interface to datastore.
This should be adjusted first, then I should test this one against datastore