### PR TITLE
isssue441: Add final slash to mediafile-upload url

### DIFF
--- a/openslides_backend/services/media/adapter.py
+++ b/openslides_backend/services/media/adapter.py
@@ -15,7 +15,7 @@ class MediaServiceAdapter(MediaService):
         self.media_url = media_url + "/"
 
     def _upload(self, file: str, id: int, mimetype: str, subpath: str) -> None:
-        url = self.media_url + subpath
+        url = self.media_url + subpath + "/"
         payload = {"file": file, "id": id, "mimetype": mimetype}
         self.logger.debug("Starting upload of file")
         try:


### PR DESCRIPTION
Without  final slash in url the mediaservice can't upload the file, but also didn't return a correct error to caller