### PR TITLE
Add DeletedModelsBehaviour to all aggregate methods

### DIFF
--- a/openslides_backend/action/actions/motion/sequential_numbers_mixin.py
+++ b/openslides_backend/action/actions/motion/sequential_numbers_mixin.py
@@ -1,3 +1,4 @@
+from ....services.datastore.deleted_models_behaviour import DeletedModelsBehaviour
 from ....shared.filters import FilterOperator
 from ...generics.create import CreateAction
 
@@ -6,7 +7,6 @@ class SequentialNumbersMixin(CreateAction):
     def get_sequential_number(self, meeting_id: int) -> int:
         """
         Creates a sequential number, unique per meeting and returns it
-        "datastore.max" evaluates the expressin per default with records marked as deleted
         """
         filter = FilterOperator("meeting_id", "=", meeting_id)
 
@@ -14,7 +14,7 @@ class SequentialNumbersMixin(CreateAction):
             collection=self.model.collection,
             filter=filter,
             field="sequential_number",
-            type="int",
+            get_deleted_models=DeletedModelsBehaviour.ALL_MODELS,
             lock_result=True,
         )
         number = 1 if number is None else number + 1

--- a/openslides_backend/action/actions/motion/set_number_mixin.py
+++ b/openslides_backend/action/actions/motion/set_number_mixin.py
@@ -112,7 +112,6 @@ class SetNumberMixin(BaseAction):
                 FilterOperator("meeting_id", "=", meeting_id),
                 FilterOperator("lead_motion_id", "=", None),
             )
-        filter = And(filter, FilterOperator("meta_deleted", "=", False))
         max_result = self.datastore.max(Collection("motion"), filter, "number_value")
         max_result = 1 if max_result is None else max_result + 1
         return max_result
@@ -121,7 +120,6 @@ class SetNumberMixin(BaseAction):
         filter = And(
             FilterOperator("meeting_id", "=", meeting_id),
             FilterOperator("number", "=", number),
-            FilterOperator("meta_deleted", "=", False),
         )
         exists = self.datastore.exists(collection=Collection("motion"), filter=filter)
         return not exists

--- a/openslides_backend/action/actions/motion_submitter/create.py
+++ b/openslides_backend/action/actions/motion_submitter/create.py
@@ -40,7 +40,7 @@ class MotionSubmitterCreateAction(CreateActionWithInferredMeetingMixin, CreateAc
                 "Cannot create motion_submitter, meeting id of motion and (temporary) user don't match."
             )
 
-        # check, if (user_id, motion_id) already in the databse.
+        # check, if (user_id, motion_id) already in the datastore.
         filter = And(
             FilterOperator("user_id", "=", instance["user_id"]),
             FilterOperator("motion_id", "=", instance["motion_id"]),

--- a/openslides_backend/action/actions/speaker/create_update_delete.py
+++ b/openslides_backend/action/actions/speaker/create_update_delete.py
@@ -80,7 +80,6 @@ class SpeakerCreateAction(CreateActionWithInferredMeeting):
         filter = And(
             FilterOperator("list_of_speakers_id", "=", list_of_speakers_id),
             FilterOperator("begin_time", "=", None),
-            FilterOperator("meta_deleted", "=", False),
         )
         speakers = self.datastore.filter(
             self.model.collection,
@@ -102,10 +101,8 @@ class SpeakerCreateAction(CreateActionWithInferredMeeting):
             filter=And(
                 FilterOperator("list_of_speakers_id", "=", list_of_speakers_id),
                 FilterOperator("begin_time", "=", None),
-                FilterOperator("meta_deleted", "=", False),
             ),
             field="weight",
-            type="int",
             lock_result=True,
         )
 
@@ -119,10 +116,8 @@ class SpeakerCreateAction(CreateActionWithInferredMeeting):
                     FilterOperator("point_of_order", "=", None),
                 ),
                 FilterOperator("begin_time", "=", None),
-                FilterOperator("meta_deleted", "=", False),
             ),
             field="weight",
-            type="int",
             lock_result=True,
         )
 

--- a/openslides_backend/services/datastore/adapter.py
+++ b/openslides_backend/services/datastore/adapter.py
@@ -199,14 +199,9 @@ class DatastoreAdapter(DatastoreService):
         get_deleted_models: DeletedModelsBehaviour = None,
         lock_result: bool = False,
     ) -> Dict[int, PartialModel]:
-        # by default, only filter for existing models
-        if get_deleted_models != DeletedModelsBehaviour.ALL_MODELS:
-            deleted_models_filter = FilterOperator(
-                "meta_deleted",
-                "=",
-                get_deleted_models == DeletedModelsBehaviour.ONLY_DELETED,
-            )
-            full_filter = And(filter, deleted_models_filter)
+        full_filter = self.apply_deleted_models_behaviour_to_filter(
+            filter, get_deleted_models
+        )
         command = commands.Filter(
             collection=collection, filter=full_filter, mapped_fields=set(mapped_fields)
         )
@@ -230,9 +225,13 @@ class DatastoreAdapter(DatastoreService):
         self,
         collection: Collection,
         filter: Filter,
+        get_deleted_models: DeletedModelsBehaviour = None,
         lock_result: bool = False,
     ) -> bool:
-        command = commands.Exists(collection=collection, filter=filter)
+        full_filter = self.apply_deleted_models_behaviour_to_filter(
+            filter, get_deleted_models
+        )
+        command = commands.Exists(collection=collection, filter=full_filter)
         self.logger.debug(
             f"Start EXISTS request to datastore with the following data: {command.data}"
         )
@@ -248,9 +247,13 @@ class DatastoreAdapter(DatastoreService):
         self,
         collection: Collection,
         filter: Filter,
+        get_deleted_models: DeletedModelsBehaviour = None,
         lock_result: bool = False,
     ) -> int:
-        command = commands.Count(collection=collection, filter=filter)
+        full_filter = self.apply_deleted_models_behaviour_to_filter(
+            filter, get_deleted_models
+        )
+        command = commands.Count(collection=collection, filter=full_filter)
         self.logger.debug(
             f"Start COUNT request to datastore with the following data: {command.data}"
         )
@@ -264,12 +267,16 @@ class DatastoreAdapter(DatastoreService):
         collection: Collection,
         filter: Filter,
         field: str,
-        type: str = None,
+        type: str = "int",
+        get_deleted_models: DeletedModelsBehaviour = None,
         lock_result: bool = False,
     ) -> Optional[int]:
         # TODO: This method does not reflect the position of the fetched objects.
+        full_filter = self.apply_deleted_models_behaviour_to_filter(
+            filter, get_deleted_models
+        )
         command = commands.Min(
-            collection=collection, filter=filter, field=field, type=type
+            collection=collection, filter=full_filter, field=field, type=type
         )
         self.logger.debug(
             f"Start MIN request to datastore with the following data: {command.data}"
@@ -286,15 +293,16 @@ class DatastoreAdapter(DatastoreService):
         collection: Collection,
         filter: Filter,
         field: str,
-        type: str = None,
+        type: str = "int",
+        get_deleted_models: DeletedModelsBehaviour = None,
         lock_result: bool = False,
     ) -> Optional[int]:
-        """
-        Per default records, marked as deleted, are counted
-        """
         # TODO: This method does not reflect the position of the fetched objects.
+        full_filter = self.apply_deleted_models_behaviour_to_filter(
+            filter, get_deleted_models
+        )
         command = commands.Max(
-            collection=collection, filter=filter, field=field, type=type
+            collection=collection, filter=full_filter, field=field, type=type
         )
         self.logger.debug(
             f"Start MAX request to datastore with the following data: {command.data}"
@@ -305,6 +313,21 @@ class DatastoreAdapter(DatastoreService):
                 CollectionField(collection, field), response.get("position")
             )
         return response.get("max")
+
+    def apply_deleted_models_behaviour_to_filter(
+        self, filter: Filter, get_deleted_models: Optional[DeletedModelsBehaviour]
+    ) -> Filter:
+        if get_deleted_models == DeletedModelsBehaviour.ALL_MODELS:
+            return filter
+
+        # if get_deleted_models is None (default case), it is handled as if NO_DELETED
+        # was used
+        deleted_models_filter = FilterOperator(
+            "meta_deleted",
+            "=",
+            get_deleted_models == DeletedModelsBehaviour.ONLY_DELETED,
+        )
+        return And(filter, deleted_models_filter)
 
     def update_locked_fields(
         self,

--- a/openslides_backend/services/datastore/adapter.py
+++ b/openslides_backend/services/datastore/adapter.py
@@ -86,7 +86,7 @@ class DatastoreAdapter(DatastoreService):
         fqid: FullQualifiedId,
         mapped_fields: List[str] = None,
         position: int = None,
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> PartialModel:
         mapped_fields_set = set()
@@ -118,7 +118,7 @@ class DatastoreAdapter(DatastoreService):
         get_many_requests: List[commands.GetManyRequest],
         mapped_fields: List[str] = None,
         position: int = None,
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> Dict[Collection, Dict[int, PartialModel]]:
         if mapped_fields is not None:
@@ -162,7 +162,7 @@ class DatastoreAdapter(DatastoreService):
         self,
         collection: Collection,
         mapped_fields: List[str] = None,
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> Dict[int, PartialModel]:
         mapped_fields_set = set()
@@ -196,7 +196,7 @@ class DatastoreAdapter(DatastoreService):
         collection: Collection,
         filter: Filter,
         mapped_fields: List[str] = [],
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> Dict[int, PartialModel]:
         full_filter = self.apply_deleted_models_behaviour_to_filter(
@@ -225,7 +225,7 @@ class DatastoreAdapter(DatastoreService):
         self,
         collection: Collection,
         filter: Filter,
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> bool:
         full_filter = self.apply_deleted_models_behaviour_to_filter(
@@ -247,7 +247,7 @@ class DatastoreAdapter(DatastoreService):
         self,
         collection: Collection,
         filter: Filter,
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> int:
         full_filter = self.apply_deleted_models_behaviour_to_filter(
@@ -268,7 +268,7 @@ class DatastoreAdapter(DatastoreService):
         filter: Filter,
         field: str,
         type: str = "int",
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> Optional[int]:
         # TODO: This method does not reflect the position of the fetched objects.
@@ -294,7 +294,7 @@ class DatastoreAdapter(DatastoreService):
         filter: Filter,
         field: str,
         type: str = "int",
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> Optional[int]:
         # TODO: This method does not reflect the position of the fetched objects.
@@ -315,13 +315,11 @@ class DatastoreAdapter(DatastoreService):
         return response.get("max")
 
     def apply_deleted_models_behaviour_to_filter(
-        self, filter: Filter, get_deleted_models: Optional[DeletedModelsBehaviour]
+        self, filter: Filter, get_deleted_models: DeletedModelsBehaviour
     ) -> Filter:
         if get_deleted_models == DeletedModelsBehaviour.ALL_MODELS:
             return filter
 
-        # if get_deleted_models is None (default case), it is handled as if NO_DELETED
-        # was used
         deleted_models_filter = FilterOperator(
             "meta_deleted",
             "=",

--- a/openslides_backend/services/datastore/commands.py
+++ b/openslides_backend/services/datastore/commands.py
@@ -104,7 +104,7 @@ class Get(Command):
         fqid: FullQualifiedId,
         mapped_fields: Set[str] = None,
         position: int = None,
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
     ) -> None:
         self.fqid = fqid
         self.mapped_fields = mapped_fields
@@ -133,7 +133,7 @@ class GetMany(Command):
         get_many_requests: List[GetManyRequest],
         mapped_fields: Set[str] = None,
         position: int = None,
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
     ) -> None:
         self.get_many_requests = get_many_requests
         self.mapped_fields = mapped_fields
@@ -167,7 +167,7 @@ class GetAll(Command):
         self,
         collection: Collection,
         mapped_fields: Set[str] = None,
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
     ) -> None:
         self.collection = collection
         self.mapped_fields = mapped_fields

--- a/openslides_backend/services/datastore/interface.py
+++ b/openslides_backend/services/datastore/interface.py
@@ -59,12 +59,20 @@ class DatastoreService(Protocol):
         ...
 
     def exists(
-        self, collection: Collection, filter: Filter, lock_result: bool = False
+        self,
+        collection: Collection,
+        filter: Filter,
+        get_deleted_models: DeletedModelsBehaviour = None,
+        lock_result: bool = False,
     ) -> bool:
         ...
 
     def count(
-        self, collection: Collection, filter: Filter, lock_result: bool = False
+        self,
+        collection: Collection,
+        filter: Filter,
+        get_deleted_models: DeletedModelsBehaviour = None,
+        lock_result: bool = False,
     ) -> int:
         ...
 
@@ -73,7 +81,8 @@ class DatastoreService(Protocol):
         collection: Collection,
         filter: Filter,
         field: str,
-        type: str = None,
+        type: str = "int",
+        get_deleted_models: DeletedModelsBehaviour = None,
         lock_result: bool = False,
     ) -> Optional[int]:
         ...
@@ -83,7 +92,8 @@ class DatastoreService(Protocol):
         collection: Collection,
         filter: Filter,
         field: str,
-        type: str = None,
+        type: str = "int",
+        get_deleted_models: DeletedModelsBehaviour = None,
         lock_result: bool = False,
     ) -> Optional[int]:
         ...

--- a/openslides_backend/services/datastore/interface.py
+++ b/openslides_backend/services/datastore/interface.py
@@ -24,7 +24,7 @@ class DatastoreService(Protocol):
         fqid: FullQualifiedId,
         mapped_fields: List[str] = None,
         position: int = None,
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> PartialModel:
         ...
@@ -34,7 +34,7 @@ class DatastoreService(Protocol):
         get_many_requests: List[GetManyRequest],
         mapped_fields: List[str] = None,
         position: int = None,
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> Dict[Collection, Dict[int, PartialModel]]:
         ...
@@ -43,7 +43,7 @@ class DatastoreService(Protocol):
         self,
         collection: Collection,
         mapped_fields: List[str] = None,
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> Dict[int, PartialModel]:
         ...
@@ -53,7 +53,7 @@ class DatastoreService(Protocol):
         collection: Collection,
         filter: Filter,
         mapped_fields: List[str] = [],
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> Dict[int, PartialModel]:
         ...
@@ -62,7 +62,7 @@ class DatastoreService(Protocol):
         self,
         collection: Collection,
         filter: Filter,
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> bool:
         ...
@@ -71,7 +71,7 @@ class DatastoreService(Protocol):
         self,
         collection: Collection,
         filter: Filter,
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> int:
         ...
@@ -82,7 +82,7 @@ class DatastoreService(Protocol):
         filter: Filter,
         field: str,
         type: str = "int",
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> Optional[int]:
         ...
@@ -93,7 +93,7 @@ class DatastoreService(Protocol):
         filter: Filter,
         field: str,
         type: str = "int",
-        get_deleted_models: DeletedModelsBehaviour = None,
+        get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = False,
     ) -> Optional[int]:
         ...

--- a/tests/unit/services/test_database_adapter.py
+++ b/tests/unit/services/test_database_adapter.py
@@ -54,6 +54,7 @@ class DatastoreAdapterTester(TestCase):
         assert result is not None
         assert command.get_raw_data() == {
             "requests": [gmr.to_dict()],
+            "get_deleted_models": 1,
         }
         self.engine.retrieve.assert_called_with("get_many", command.data)
 


### PR DESCRIPTION
Unified the usage with the `filter` method.
Fixes https://github.com/OpenSlides/openslides-backend/issues/447