### PR TITLE
Rename payload to action_data

### DIFF
--- a/openslides_backend/action/actions/agenda_item/agenda_creation.py
+++ b/openslides_backend/action/actions/agenda_item/agenda_creation.py
@@ -70,10 +70,10 @@ class CreateActionWithAgendaItemMixin(Action):
             return result_default
         return agenda_create
 
-    def get_dependent_action_payload_agenda_item(
+    def get_dependent_action_data_agenda_item(
         self, instance: Dict[str, Any], CreateActionClass: Type[Action]
     ) -> List[Dict[str, Any]]:
-        agenda_item_payload_element = {
+        agenda_item_action_data = {
             "content_object_id": f"{str(self.model.collection)}{KEYSEPARATOR}{instance['id']}",
         }
         for extra_field in agenda_creation_properties.keys():
@@ -84,5 +84,5 @@ class CreateActionWithAgendaItemMixin(Action):
             extra_field_without_prefix = extra_field[prefix_len:]
             value = instance.pop(extra_field, None)
             if value is not None:
-                agenda_item_payload_element[extra_field_without_prefix] = value
-        return [agenda_item_payload_element]
+                agenda_item_action_data[extra_field_without_prefix] = value
+        return [agenda_item_action_data]

--- a/openslides_backend/action/actions/agenda_item/assign.py
+++ b/openslides_backend/action/actions/agenda_item/assign.py
@@ -31,10 +31,10 @@ class AgendaItemAssign(UpdateAction, SingularActionMixin):
         },
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        payload = super().get_updated_instances(payload)
-        # Payload is an iterable with exactly one item
-        instance = next(iter(payload))
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        action_data = super().get_updated_instances(action_data)
+        # Action data is an iterable with exactly one item
+        instance = next(iter(action_data))
         yield from self.prepare_assign_data(
             parent_id=instance["parent_id"],
             ids=instance["ids"],

--- a/openslides_backend/action/actions/agenda_item/create.py
+++ b/openslides_backend/action/actions/agenda_item/create.py
@@ -47,8 +47,8 @@ class AgendaItemCreate(CreateActionWithInferredMeeting):
         instance["weight"] = parent["weight"] + 1
         return instance
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        for instance in payload:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        for instance in action_data:
             if instance.get("parent_id") is None:
                 parent = {"is_hidden": False, "is_internal": False}
                 instance["level"] = 0
@@ -65,4 +65,4 @@ class AgendaItemCreate(CreateActionWithInferredMeeting):
                 "type"
             ) == AgendaItem.INTERNAL_ITEM or parent.get("is_internal", False)
 
-        return payload
+        return action_data

--- a/openslides_backend/action/actions/agenda_item/numbering.py
+++ b/openslides_backend/action/actions/agenda_item/numbering.py
@@ -18,11 +18,11 @@ class AgendaItemNumbering(SingularActionMixin, UpdateAction):
     model = AgendaItem()
     schema = DefaultSchema(AgendaItem()).get_default_schema(["meeting_id"])
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        payload = super().get_updated_instances(payload)
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        action_data = super().get_updated_instances(action_data)
         # Fetch all agenda items for this meeting from datastore.
-        # Payload is an iterable with exactly one item
-        instance = next(iter(payload))
+        # Action data is an iterable with exactly one item
+        instance = next(iter(action_data))
         meeting_id = instance["meeting_id"]
         agenda_items = self.datastore.filter(
             collection=self.model.collection,

--- a/openslides_backend/action/actions/agenda_item/sort.py
+++ b/openslides_backend/action/actions/agenda_item/sort.py
@@ -16,10 +16,10 @@ class AgendaItemSort(TreeSortMixin, SingularActionMixin, UpdateAction):
     model = AgendaItem()
     schema = DefaultSchema(AgendaItem()).get_tree_sort_schema()
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        payload = super().get_updated_instances(payload)
-        # Payload is an iterable with exactly one item
-        instance = next(iter(payload))
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        action_data = super().get_updated_instances(action_data)
+        # Action data is an iterable with exactly one item
+        instance = next(iter(action_data))
         yield from self.sort_tree(
             nodes=instance["tree"],
             meeting_id=instance["meeting_id"],

--- a/openslides_backend/action/actions/agenda_item/update.py
+++ b/openslides_backend/action/actions/agenda_item/update.py
@@ -78,15 +78,15 @@ class AgendaItemUpdate(UpdateAction):
                 )
         return instances
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
         new_instances = []
-        agenda_item_ids = [instance["id"] for instance in payload]
+        agenda_item_ids = [instance["id"] for instance in action_data]
         get_many_request = GetManyRequest(
             self.model.collection, agenda_item_ids, ["parent_id"]
         )
         gm_result = self.datastore.get_many([get_many_request])
         agenda_items = gm_result.get(self.model.collection, {})
-        for instance in payload:
+        for instance in action_data:
             if instance.get("type") is None:
                 new_instances.append(instance)
                 continue

--- a/openslides_backend/action/actions/assignment_candidate/sort.py
+++ b/openslides_backend/action/actions/assignment_candidate/sort.py
@@ -19,10 +19,10 @@ class AssignmentCandidateSort(LinearSortMixin, SingularActionMixin, UpdateAction
         "assignment_id",
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        payload = super().get_updated_instances(payload)
-        # Payload is an iterable with exactly one item
-        instance = next(iter(payload))
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        action_data = super().get_updated_instances(action_data)
+        # Action data is an iterable with exactly one item
+        instance = next(iter(action_data))
         yield from self.sort_linear(
             nodes=instance["candidate_ids"],
             filter_id=instance["assignment_id"],

--- a/openslides_backend/action/actions/group/set_permission.py
+++ b/openslides_backend/action/actions/group/set_permission.py
@@ -22,8 +22,8 @@ class GroupSetPermissionAction(UpdateAction):
         }
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        for instance in payload:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        for instance in action_data:
             new_instance = self.update_one_instance(instance)
             if new_instance.get("permissions") is None:
                 continue

--- a/openslides_backend/action/actions/list_of_speakers/delete_all_speakers.py
+++ b/openslides_backend/action/actions/list_of_speakers/delete_all_speakers.py
@@ -19,8 +19,8 @@ class ListOfSpeakersDeleteAllSpeakersAction(DeleteAction):
         description="Action to remove all speakers from the given list of speakers.",
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        for instance in payload:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        for instance in action_data:
             list_of_speakers = self.fetch_model(
                 FullQualifiedId(Collection("list_of_speakers"), instance["id"]),
                 mapped_fields=["speaker_ids"],

--- a/openslides_backend/action/actions/list_of_speakers/list_of_speakers_creation.py
+++ b/openslides_backend/action/actions/list_of_speakers/list_of_speakers_creation.py
@@ -13,7 +13,7 @@ class CreateActionWithListOfSpeakersMixin(BaseAction):
 
     model: Model
 
-    def get_dependent_action_payload_list_of_speakers(
+    def get_dependent_action_data_list_of_speakers(
         self, instance: Dict[str, Any], CreateActionClass: Type[Action]
     ) -> List[Dict[str, Any]]:
         return [

--- a/openslides_backend/action/actions/mediafile/delete.py
+++ b/openslides_backend/action/actions/mediafile/delete.py
@@ -17,8 +17,8 @@ class MediafileDelete(DeleteAction):
     model = Mediafile()
     schema = DefaultSchema(Mediafile()).get_delete_schema()
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        for instance in payload:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        for instance in action_data:
             yield from ({"id": id_} for id_ in self.get_tree_ids(instance["id"]))
 
     def get_tree_ids(self, id_: int) -> List[int]:

--- a/openslides_backend/action/actions/mediafile/move.py
+++ b/openslides_backend/action/actions/mediafile/move.py
@@ -41,10 +41,10 @@ class MediafileMoveAction(
         if not item.get("is_directory"):
             raise ActionException("New parent is not a directory.")
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        payload = super().get_updated_instances(payload)
-        # Payload is an iterable with exactly one item
-        instance = next(iter(payload))
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        action_data = super().get_updated_instances(action_data)
+        # Action data is an iterable with exactly one item
+        instance = next(iter(action_data))
         yield from self.prepare_move_data(
             parent_id=instance["parent_id"],
             ids=instance["ids"],

--- a/openslides_backend/action/actions/meeting/create_update_delete.py
+++ b/openslides_backend/action/actions/meeting/create_update_delete.py
@@ -125,7 +125,7 @@ class MeetingCreate(CreateActionWithDependencies):
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
         instance = super().update_instance(instance)
 
-        payload = [
+        action_data = [
             {
                 "name": "Default",
                 "meeting_id": instance["id"],
@@ -200,7 +200,9 @@ class MeetingCreate(CreateActionWithDependencies):
                 ],
             },
         ]
-        write_requests, action_results = self.execute_other_action(GroupCreate, payload)
+        write_requests, action_results = self.execute_other_action(
+            GroupCreate, action_data
+        )
 
         used_groups_dict = {
             event["fields"]["name"]: event["fqid"].id  # type: ignore
@@ -217,16 +219,16 @@ class MeetingCreate(CreateActionWithDependencies):
         instance["admin_group_id"] = used_groups_dict["Admin"]
 
         # Add user to admin group
-        payload = [
+        action_data = [
             {
                 "id": self.user_id,
                 "group_$_ids": {str(instance["id"]): [used_groups_dict["Admin"]]},
             }
         ]
-        self.execute_other_action(UserUpdate, payload)
+        self.execute_other_action(UserUpdate, action_data)
         return instance
 
-    def get_dependent_action_payload(
+    def get_dependent_action_data(
         self, instance: Dict[str, Any], CreateActionClass: Type[Action]
     ) -> List[Dict[str, Any]]:
         if CreateActionClass == MotionWorkflowCreateSimpleWorkflowAction:

--- a/openslides_backend/action/actions/meeting/delete_all_speakers_of_all_lists.py
+++ b/openslides_backend/action/actions/meeting/delete_all_speakers_of_all_lists.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict, Iterable
-
 from ....models.models import Meeting, Speaker
 from ....services.datastore.commands import GetManyRequest
 from ....shared.patterns import Collection
@@ -22,9 +20,9 @@ class DeleteAllSpeakersOfAllListsAction(DeleteAction):
         description="An array of meeting objects which speakers to be deleted",
     )
 
-    def get_updated_instances(self, payload: ActionData) -> Iterable[Dict[str, Any]]:
-        new_payload = []
-        meeting_ids = [instance["id"] for instance in payload]
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        new_action_data = []
+        meeting_ids = [instance["id"] for instance in action_data]
         get_many_request = GetManyRequest(
             Collection("meeting"), meeting_ids, ["list_of_speakers_ids"]
         )
@@ -41,5 +39,5 @@ class DeleteAllSpeakersOfAllListsAction(DeleteAction):
         lists_of_speakers = gm_result.get(Collection("list_of_speakers"), {})
         for los in lists_of_speakers.values():
             for speaker in los.get("speaker_ids", []):
-                new_payload.append({"id": speaker})
-        return new_payload
+                new_action_data.append({"id": speaker})
+        return new_action_data

--- a/openslides_backend/action/actions/motion/create.py
+++ b/openslides_backend/action/actions/motion/create.py
@@ -159,11 +159,11 @@ class MotionCreate(
         additional_relation_models = {
             FullQualifiedId(self.model.collection, instance["id"]): instance
         }
-        payload = []
+        action_data = []
         for user_id in submitter_ids:
-            payload.append({"motion_id": instance["id"], "user_id": user_id})
+            action_data.append({"motion_id": instance["id"], "user_id": user_id})
         self.execute_other_action(
-            MotionSubmitterCreateAction, payload, additional_relation_models
+            MotionSubmitterCreateAction, action_data, additional_relation_models
         )
 
         instance["sequential_number"] = self.get_sequential_number(

--- a/openslides_backend/action/actions/motion/follow_recommendation.py
+++ b/openslides_backend/action/actions/motion/follow_recommendation.py
@@ -16,8 +16,8 @@ class MotionFollowRecommendationAction(MotionSetStateAction):
     model = Motion()
     schema = DefaultSchema(Motion()).get_update_schema()
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        ids = [instance["id"] for instance in payload]
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        ids = [instance["id"] for instance in action_data]
         get_many_request = GetManyRequest(
             self.model.collection,
             ids,

--- a/openslides_backend/action/actions/motion/set_support_self.py
+++ b/openslides_backend/action/actions/motion/set_support_self.py
@@ -25,10 +25,10 @@ class MotionSetSupportSelfAction(UpdateAction):
         },
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
         motion_get_many_request = GetManyRequest(
             self.model.collection,
-            [instance["motion_id"] for instance in payload],
+            [instance["motion_id"] for instance in action_data],
             ["meeting_id", "state_id", "supporter_ids"],
         )
         gm_motion_result = self.datastore.get_many([motion_get_many_request])
@@ -48,7 +48,7 @@ class MotionSetSupportSelfAction(UpdateAction):
             Collection("motion_state"), state_ids, ["allow_support"]
         )
         gm_result = self.datastore.get_many([gm_request_meeting, gm_request_state])
-        for instance in payload:
+        for instance in action_data:
             motion = motions.get(instance["motion_id"], {})
             meeting_id = motion.get("meeting_id")
             if meeting_id is None:

--- a/openslides_backend/action/actions/motion/sort.py
+++ b/openslides_backend/action/actions/motion/sort.py
@@ -16,10 +16,10 @@ class MotionSort(TreeSortMixin, SingularActionMixin, UpdateAction):
     model = Motion()
     schema = DefaultSchema(Motion()).get_tree_sort_schema()
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        payload = super().get_updated_instances(payload)
-        # Payload is an iterable with exactly one item
-        instance = next(iter(payload))
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        action_data = super().get_updated_instances(action_data)
+        # Action data is an iterable with exactly one item
+        instance = next(iter(action_data))
         yield from self.sort_tree(
             nodes=instance["tree"],
             meeting_id=instance["meeting_id"],

--- a/openslides_backend/action/actions/motion_category/number_motions.py
+++ b/openslides_backend/action/actions/motion_category/number_motions.py
@@ -25,8 +25,8 @@ class MotionCategoryNumberMotions(UpdateAction):
         required_properties=["id"],
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        for instance in payload:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        for instance in action_data:
             self.init_memory(instance["id"])
 
             affected_categories = self.get_affected_categories(instance["id"])

--- a/openslides_backend/action/actions/motion_category/sort.py
+++ b/openslides_backend/action/actions/motion_category/sort.py
@@ -16,10 +16,10 @@ class MotionCategorySort(TreeSortMixin, SingularActionMixin, UpdateAction):
     model = MotionCategory()
     schema = DefaultSchema(MotionCategory()).get_tree_sort_schema()
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        payload = super().get_updated_instances(payload)
-        # Payload is an iterable with exactly one item
-        instance = next(iter(payload))
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        action_data = super().get_updated_instances(action_data)
+        # Action data is an iterable with exactly one item
+        instance = next(iter(action_data))
         yield from self.sort_tree(
             nodes=instance["tree"],
             meeting_id=instance["meeting_id"],

--- a/openslides_backend/action/actions/motion_category/sort_motions_in_category.py
+++ b/openslides_backend/action/actions/motion_category/sort_motions_in_category.py
@@ -18,10 +18,10 @@ class MotionCategorySortMotionInCategorySort(
     model = Motion()
     schema = DefaultSchema(Motion()).get_linear_sort_schema("motion_ids", "id")
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        payload = super().get_updated_instances(payload)
-        # Payload is an iterable with exactly one item
-        instance = next(iter(payload))
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        action_data = super().get_updated_instances(action_data)
+        # Action data is an iterable with exactly one item
+        instance = next(iter(action_data))
         yield from self.sort_linear(
             nodes=instance["motion_ids"],
             filter_id=instance["id"],

--- a/openslides_backend/action/actions/motion_comment_section/sort.py
+++ b/openslides_backend/action/actions/motion_comment_section/sort.py
@@ -19,10 +19,10 @@ class MotionCommentSectionSort(LinearSortMixin, SingularActionMixin, UpdateActio
         "meeting_id",
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        payload = super().get_updated_instances(payload)
-        # Payload is an iterable with exactly one item
-        instance = next(iter(payload))
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        action_data = super().get_updated_instances(action_data)
+        # Action data is an iterable with exactly one item
+        instance = next(iter(action_data))
         yield from self.sort_linear(
             nodes=instance["motion_comment_section_ids"],
             filter_id=instance["meeting_id"],

--- a/openslides_backend/action/actions/motion_statute_paragraph/sort.py
+++ b/openslides_backend/action/actions/motion_statute_paragraph/sort.py
@@ -19,10 +19,10 @@ class MotionStatueParagraphSort(LinearSortMixin, SingularActionMixin, UpdateActi
         "meeting_id",
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        payload = super().get_updated_instances(payload)
-        # Payload is an iterable with exactly one item
-        instance = next(iter(payload))
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        action_data = super().get_updated_instances(action_data)
+        # Action data is an iterable with exactly one item
+        instance = next(iter(action_data))
         yield from self.sort_linear(
             nodes=instance["statute_paragraph_ids"],
             filter_id=instance["meeting_id"],

--- a/openslides_backend/action/actions/motion_submitter/sort.py
+++ b/openslides_backend/action/actions/motion_submitter/sort.py
@@ -18,10 +18,10 @@ class MotionSubmitterSort(LinearSortMixin, SingularActionMixin, UpdateAction):
         "motion_submitter_ids", "motion_id"
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        payload = super().get_updated_instances(payload)
-        # Payload is an iterable with exactly one item
-        instance = next(iter(payload))
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        action_data = super().get_updated_instances(action_data)
+        # Action data is an iterable with exactly one item
+        instance = next(iter(action_data))
         yield from self.sort_linear(
             nodes=instance["motion_submitter_ids"],
             filter_id=instance["motion_id"],

--- a/openslides_backend/action/actions/motion_workflow/create.py
+++ b/openslides_backend/action/actions/motion_workflow/create.py
@@ -53,14 +53,10 @@ class MotionWorkflowCreateSimpleWorkflowAction(CreateAction):
     )
 
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Updates one instance of the payload. This can be overridden by custom
-        action classes. Meant to be called inside base_update_instance.
-        """
         additional_relation_models: Dict[FullQualifiedId, Any] = {
             FullQualifiedId(self.model.collection, instance["id"]): instance
         }
-        payload = [
+        action_data = [
             {
                 "name": "submitted",
                 "allow_create_poll": True,
@@ -93,7 +89,7 @@ class MotionWorkflowCreateSimpleWorkflowAction(CreateAction):
 
         write_requests, action_results = self.execute_other_action(
             MotionStateActionSet.get_action("create"),
-            payload,
+            action_data,
             additional_relation_models,
         )
         additional_relation_models.update(
@@ -105,10 +101,10 @@ class MotionWorkflowCreateSimpleWorkflowAction(CreateAction):
         )
         first_state_id = action_results[0]["id"]  # type: ignore
         next_state_ids = [ar["id"] for ar in action_results[-3:]]  # type: ignore
-        payload = [{"id": first_state_id, "next_state_ids": next_state_ids}]
+        action_data = [{"id": first_state_id, "next_state_ids": next_state_ids}]
         self.execute_other_action(
             MotionStateActionSet.get_action("update"),
-            payload,
+            action_data,
             additional_relation_models,
         )
         return instance

--- a/openslides_backend/action/actions/motion_workflow/create.py
+++ b/openslides_backend/action/actions/motion_workflow/create.py
@@ -23,7 +23,7 @@ class MotionWorkflowCreateAction(CreateActionWithDependencies):
     schema = DefaultSchema(MotionWorkflow()).get_create_schema(["name", "meeting_id"])
     dependencies = [MotionStateActionSet.get_action("create")]
 
-    def get_dependent_action_payload(
+    def get_dependent_action_data(
         self, instance: Dict[str, Any], CreateActionClass: Type[Action]
     ) -> List[Dict[str, Any]]:
         return [

--- a/openslides_backend/action/actions/option/create.py
+++ b/openslides_backend/action/actions/option/create.py
@@ -40,24 +40,26 @@ class OptionCreateAction(CreateAction):
         if not instance.get("text") and not instance.get("content_object_id"):
             raise ActionException("Need text xor content_object_id.")
 
-        payload = []
-        yes_data = self.get_vote_payload_data(instance, "Y", "yes")
+        action_data = []
+        yes_data = self.get_vote_action_data(instance, "Y", "yes")
         if yes_data is not None:
-            payload.append(yes_data)
-        no_data = self.get_vote_payload_data(instance, "N", "no")
+            action_data.append(yes_data)
+        no_data = self.get_vote_action_data(instance, "N", "no")
         if no_data is not None:
-            payload.append(no_data)
-        abstain_data = self.get_vote_payload_data(instance, "A", "abstain")
+            action_data.append(no_data)
+        abstain_data = self.get_vote_action_data(instance, "A", "abstain")
         if abstain_data is not None:
-            payload.append(abstain_data)
-        if payload:
+            action_data.append(abstain_data)
+        if action_data:
             additional_relation_models = {
                 FullQualifiedId(self.model.collection, instance["id"]): instance
             }
-            self.execute_other_action(VoteCreate, payload, additional_relation_models)
+            self.execute_other_action(
+                VoteCreate, action_data, additional_relation_models
+            )
         return instance
 
-    def get_vote_payload_data(
+    def get_vote_action_data(
         self, instance: Dict[str, Any], value: str, prop: str
     ) -> Optional[Dict[str, Any]]:
         if instance.get(prop):

--- a/openslides_backend/action/actions/option/update.py
+++ b/openslides_backend/action/actions/option/update.py
@@ -38,13 +38,13 @@ class OptionUpdateAction(UpdateAction):
 
         id_to_vote = self._fetch_votes(option.get("vote_ids", []))
 
-        payload_create = []
-        payload_update = []
+        action_data_create = []
+        action_data_update = []
         for field_name, vote_name in (("yes", "Y"), ("no", "N"), ("abstain", "A")):
             if field_name in instance:
                 vote_id = self._get_vote_id(vote_name, id_to_vote)
                 if vote_id is None:
-                    payload_create.append(
+                    action_data_create.append(
                         {
                             "option_id": instance["id"],
                             "value": vote_name,
@@ -53,13 +53,13 @@ class OptionUpdateAction(UpdateAction):
                         }
                     )
                 else:
-                    payload_update.append(
+                    action_data_update.append(
                         {"id": vote_id, "weight": instance[field_name]}
                     )
-        if payload_create:
-            self.execute_other_action(VoteCreate, payload_create)
-        if payload_update:
-            self.execute_other_action(VoteUpdate, payload_update)
+        if action_data_create:
+            self.execute_other_action(VoteCreate, action_data_create)
+        if action_data_update:
+            self.execute_other_action(VoteUpdate, action_data_update)
 
         return instance
 

--- a/openslides_backend/action/actions/poll/anonymize.py
+++ b/openslides_backend/action/actions/poll/anonymize.py
@@ -20,8 +20,8 @@ class PollAnonymize(UpdateAction):
     model = Poll()
     schema = DefaultSchema(Poll()).get_update_schema()
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        for instance in payload:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        for instance in action_data:
 
             self.check_allowed(instance["id"])
             option_ids = self._get_option_ids(instance["id"])
@@ -62,7 +62,7 @@ class PollAnonymize(UpdateAction):
         return options
 
     def _remove_user_id_from(self, vote_ids: List[int]) -> None:
-        payload = []
+        action_data = []
         for id_ in vote_ids:
-            payload.append({"id": id_})
-        self.execute_other_action(VoteAnonymize, payload)
+            action_data.append({"id": id_})
+        self.execute_other_action(VoteAnonymize, action_data)

--- a/openslides_backend/action/actions/poll/create.py
+++ b/openslides_backend/action/actions/poll/create.py
@@ -64,7 +64,7 @@ class PollCreateAction(CreateAction):
     )
 
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
-        payload = []
+        action_data = []
 
         # check enabled_electronic_voting
         if instance["type"] in (Poll.TYPE_NAMED, Poll.TYPE_PSEUDOANONYMOUS):
@@ -99,7 +99,7 @@ class PollCreateAction(CreateAction):
                         if instance["pollmethod"] == "YNA":
                             data["abstain"] = self.parse_vote_value(option, "A")
 
-            payload.append(data)
+            action_data.append(data)
 
         # handle global option
         global_data = {
@@ -132,14 +132,14 @@ class PollCreateAction(CreateAction):
                 global_data["abstain"] = self.parse_vote_value(
                     instance, "amount_global_abstain"
                 )
-        payload.append(global_data)
+        action_data.append(global_data)
 
         # Execute the create option actions
         additional_relation_models = {
             FullQualifiedId(self.model.collection, instance["id"]): instance
         }
         self.execute_other_action(
-            OptionCreateAction, payload, additional_relation_models
+            OptionCreateAction, action_data, additional_relation_models
         )
 
         # set state

--- a/openslides_backend/action/actions/poll/reset.py
+++ b/openslides_backend/action/actions/poll/reset.py
@@ -53,13 +53,13 @@ class PollResetAction(UpdateAction):
         return options
 
     def _delete_votes(self, vote_ids: List[int]) -> None:
-        payload = []
+        action_data = []
         for id_ in vote_ids:
-            payload.append({"id": id_})
-        self.execute_other_action(VoteDelete, payload)
+            action_data.append({"id": id_})
+        self.execute_other_action(VoteDelete, action_data)
 
     def _clear_option_auto_fields(self, option_id: int) -> None:
-        payload = [
+        action_data = [
             {
                 "id": option_id,
                 "yes": "0.000000",
@@ -67,4 +67,4 @@ class PollResetAction(UpdateAction):
                 "abstain": "0.000000",
             }
         ]
-        self.execute_other_action(OptionSetAutoFields, payload)
+        self.execute_other_action(OptionSetAutoFields, action_data)

--- a/openslides_backend/action/actions/projector/next.py
+++ b/openslides_backend/action/actions/projector/next.py
@@ -20,8 +20,8 @@ class ProjectorNext(UpdateAction):
     model = Projector()
     schema = DefaultSchema(Projector()).get_update_schema()
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        for instance in payload:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        for instance in action_data:
             projector = self.datastore.get(
                 FullQualifiedId(self.model.collection, instance["id"]),
                 [
@@ -93,13 +93,13 @@ class ProjectorNext(UpdateAction):
     ) -> None:
         max_weight = self.get_max_projection_weight(meeting_id, projector_id)
         increment = 1
-        payload_set_weight = []
+        action_data_set_weight = []
         for projection_id in projection_ids:
-            payload_set_weight.append(
+            action_data_set_weight.append(
                 {"id": projection_id, "weight": max_weight + increment}
             )
             increment += 1
-        self.execute_other_action(ProjectionSetWeight, payload_set_weight)
+        self.execute_other_action(ProjectionSetWeight, action_data_set_weight)
 
     def get_min_preview_projection(self, projector: Dict[str, Any]) -> int:
         gmr2 = GetManyRequest(

--- a/openslides_backend/action/actions/resource/upload.py
+++ b/openslides_backend/action/actions/resource/upload.py
@@ -41,14 +41,14 @@ class MediafileUploadAction(CreateAction):
         self.media.upload_resource(file_, id_, mimetype_)
         return instance
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        tokens = [instance["token"] for instance in payload]
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        tokens = [instance["token"] for instance in action_data]
         if len(tokens) != len(set(tokens)):
             raise ActionException(
                 "It is not permitted to use the same token twice in a request."
             )
 
-        for instance in payload:
+        for instance in action_data:
             results = self.datastore.filter(
                 self.model.collection,
                 And(
@@ -66,4 +66,4 @@ class MediafileUploadAction(CreateAction):
                 self.logger.error(text)
                 raise ActionException(text)
 
-        return payload
+        return action_data

--- a/openslides_backend/action/actions/speaker/create_update_delete.py
+++ b/openslides_backend/action/actions/speaker/create_update_delete.py
@@ -24,18 +24,18 @@ class SpeakerCreateAction(CreateActionWithInferredMeeting):
         optional_properties=["marked", "point_of_order"],
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
         """
         Reason for this Exception: It's hard and specific doing the weight calculation
         of creating speakers with point of orders, because of the used max- and min-datastore methods.
         These should handle the still not generated speakers with specific filters.
         But we don't need this functionality
         """
-        if len(payload) > 1:  # type: ignore
+        if len(action_data) > 1:  # type: ignore
             raise ActionException(
                 "It is not permitted to create more than one speaker per request!"
             )
-        yield from super().get_updated_instances(payload)
+        yield from super().get_updated_instances(action_data)
 
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
         instance = super().update_instance(instance)
@@ -61,13 +61,13 @@ class SpeakerCreateAction(CreateActionWithInferredMeeting):
         additional_relation_models = {
             FullQualifiedId(self.model.collection, instance["id"]): instance
         }
-        payload = [
+        action_data = [
             {
                 "list_of_speakers_id": list_of_speakers_id,
                 "speaker_ids": speaker_ids,
             }
         ]
-        self.execute_other_action(SpeakerSort, payload, additional_relation_models)
+        self.execute_other_action(SpeakerSort, action_data, additional_relation_models)
         return instance
 
     def _insert_before_weight(

--- a/openslides_backend/action/actions/speaker/end_speech.py
+++ b/openslides_backend/action/actions/speaker/end_speech.py
@@ -22,8 +22,8 @@ class SpeakerEndSpeach(UpdateAction):
         description="Schema to stop a speaker's speach.",
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        for instance in payload:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        for instance in action_data:
             speaker = self.fetch_model(
                 FullQualifiedId(self.model.collection, instance["id"]),
                 mapped_fields=["begin_time", "end_time"],

--- a/openslides_backend/action/actions/speaker/sort.py
+++ b/openslides_backend/action/actions/speaker/sort.py
@@ -22,11 +22,11 @@ class SpeakerSort(LinearSortMixin, SingularActionMixin, UpdateAction):
         "list_of_speakers_id",
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
         filter: Optional[Filter] = None
-        payload = super().get_updated_instances(payload)
-        # Payload is an iterable with exactly one item
-        instance = next(iter(payload))
+        action_data = super().get_updated_instances(action_data)
+        # Action data is an iterable with exactly one item
+        instance = next(iter(action_data))
         if not filter:
             filter = And(
                 FilterOperator(

--- a/openslides_backend/action/actions/speaker/speak.py
+++ b/openslides_backend/action/actions/speaker/speak.py
@@ -23,8 +23,8 @@ class SpeakerSpeak(UpdateAction):
         description="Schema to let a speaker's speach begin.",
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        for instance in payload:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        for instance in action_data:
             this_speaker = self.fetch_model(
                 FullQualifiedId(self.model.collection, instance["id"]),
                 mapped_fields=["list_of_speakers_id"],

--- a/openslides_backend/action/actions/topic/create.py
+++ b/openslides_backend/action/actions/topic/create.py
@@ -39,6 +39,6 @@ class TopicCreate(
     ) -> bool:
         """
         We always create an agenda item for each topic regardless of
-        payload or metting settings.
+        the given action data or metting settings.
         """
         return True

--- a/openslides_backend/action/actions/user/set_present.py
+++ b/openslides_backend/action/actions/user/set_present.py
@@ -22,13 +22,13 @@ class UserSetPresentAction(UpdateAction):
         }
     )
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
         """
         update is_present_in_meeting_ids:
         add meeting_id if present is True.
         remove meeting_id if present is False.
         """
-        for instance in payload:
+        for instance in action_data:
             if self.user_id == instance["id"]:
                 meeting = self.datastore.get(
                     FullQualifiedId(Collection("meeting"), instance["meeting_id"]),

--- a/openslides_backend/action/actions/user/temporary_user_mixin.py
+++ b/openslides_backend/action/actions/user/temporary_user_mixin.py
@@ -33,8 +33,8 @@ class TemporaryUserMixin(Action):
             gm_result = self.datastore.get_many([get_many_request])
             users = gm_result.get(self.model.collection, {})
 
-            set_payload = set(vote_delegations_from_ids)
-            diff = set_payload.difference(users.keys())
+            set_action_data = set(vote_delegations_from_ids)
+            diff = set_action_data.difference(users.keys())
             if len(diff):
                 raise ActionException(f"The following users were not found: {diff}")
 

--- a/openslides_backend/action/generics/delete.py
+++ b/openslides_backend/action/generics/delete.py
@@ -46,7 +46,7 @@ class DeleteAction(Action):
         # Collect relation fields and also update instance and set
         # all relation fields to None.
         relation_fields: List[Tuple[str, BaseRelationField]] = []
-        # Gather all delete actions with payload and also all models to be deleted
+        # Gather all delete actions with action data and also all models to be deleted
         delete_actions: List[Tuple[Type[Action], ActionData]] = []
         additional_relation_models: ModelMap = {this_fqid: DeletedModel()}
         for field in self.model.get_relation_fields():
@@ -98,9 +98,9 @@ class DeleteAction(Action):
                                 f"Can't cascade the delete action to {str(fqid.collection)} "
                                 "since no delete action was found."
                             )
-                        # Assume that the delete action uses the standard payload
-                        payload = [{"id": fqid.id}]
-                        delete_actions.append((delete_action_class, payload))
+                        # Assume that the delete action uses the standard action data
+                        action_data = [{"id": fqid.id}]
+                        delete_actions.append((delete_action_class, action_data))
                         additional_relation_models[fqid] = DeletedModel()
             else:
                 # field.on_delete == OnDelete.SET_NULL
@@ -124,10 +124,10 @@ class DeleteAction(Action):
         # Add additional relation models and execute all previously gathered delete actions
         # catch all protected models exception to gather all protected fqids
         all_protected_fqids: List[FullQualifiedId] = []
-        for delete_action_class, action_payload in delete_actions:
+        for delete_action_class, delete_action_data in delete_actions:
             try:
                 self.execute_other_action(
-                    delete_action_class, action_payload, additional_relation_models
+                    delete_action_class, delete_action_data, additional_relation_models
                 )
             except ProtectedModelsException as e:
                 all_protected_fqids.extend(e.fqids)

--- a/openslides_backend/action/mixins/create_action_with_dependencies.py
+++ b/openslides_backend/action/mixins/create_action_with_dependencies.py
@@ -31,14 +31,16 @@ class CreateActionWithDependencies(CreateAction):
             )
             if not check_method(instance, ActionClass):
                 continue
-            special_payload_method_name = "get_dependent_action_payload_" + str(
+            special_action_data_method_name = "get_dependent_action_data_" + str(
                 ActionClass.model.collection
             )
-            payload_method = getattr(
-                self, special_payload_method_name, self.get_dependent_action_payload
+            action_data_method = getattr(
+                self, special_action_data_method_name, self.get_dependent_action_data
             )
-            payload = payload_method(instance, ActionClass)
-            self.execute_other_action(ActionClass, payload, additional_relation_models)
+            action_data = action_data_method(instance, ActionClass)
+            self.execute_other_action(
+                ActionClass, action_data, additional_relation_models
+            )
         return instance
 
     def check_dependant_action_execution(
@@ -50,13 +52,13 @@ class CreateActionWithDependencies(CreateAction):
         """
         return True
 
-    def get_dependent_action_payload(
+    def get_dependent_action_data(
         self, instance: Dict[str, Any], CreateActionClass: Type[Action]
     ) -> List[Dict[str, Any]]:
         """
-        Override in subclass to provide the correct payload for the dependencies.
+        Override in subclass to provide the correct action data for the dependencies.
         """
         raise NotImplementedError(
-            "You have to implement get_dependent_action_payload for a "
+            "You have to implement get_dependent_action_data for a "
             "CreateActionWithDependencies."
         )

--- a/openslides_backend/action/mixins/create_action_with_inferred_meeting.py
+++ b/openslides_backend/action/mixins/create_action_with_inferred_meeting.py
@@ -8,7 +8,7 @@ from ..generics.create import CreateAction
 
 class CreateActionWithInferredMeetingMixin(CreateAction):
     """
-    Mixin to autmatically set the meeting_id on create if it's not given in the payload.
+    Mixin to autmatically set the meeting_id on create if it's not given in the action data.
     The given relation_field_for_meeting must be a relation field.
     """
 

--- a/openslides_backend/action/mixins/singular_action_mixin.py
+++ b/openslides_backend/action/mixins/singular_action_mixin.py
@@ -20,17 +20,17 @@ singular_schema = fastjsonschema.compile(
 
 class SingularActionMixin(Action):
     """
-    Mixin to ensure that the action payload contains only on object.
+    Mixin to ensure that the action data contains only on object.
     """
 
     is_singular = True
 
-    def get_updated_instances(self, payload: ActionData) -> ActionData:
-        self.assert_singular_payload(payload)
-        return super().get_updated_instances(payload)
+    def get_updated_instances(self, action_data: ActionData) -> ActionData:
+        self.assert_singular_action_data(action_data)
+        return super().get_updated_instances(action_data)
 
-    def assert_singular_payload(self, payload: ActionData) -> None:
+    def assert_singular_action_data(self, action_data: ActionData) -> None:
         try:
-            singular_schema(payload)
+            singular_schema(action_data)
         except fastjsonschema.JsonSchemaException as exception:
             raise ActionException(exception.message)

--- a/openslides_backend/action/util/default_schema.py
+++ b/openslides_backend/action/util/default_schema.py
@@ -48,7 +48,7 @@ class DefaultSchema:
         """
         Returns a default schema with properties and required properties as given.
         The additional_fields can be used to add additional field definitions to a
-        payload which are not present in the model.
+        schema which are not present in the model.
         """
         schema = {
             "$schema": schema_version,

--- a/openslides_backend/action/util/typing.py
+++ b/openslides_backend/action/util/typing.py
@@ -1,9 +1,12 @@
 from typing import Any, Dict, Iterable, List, Literal, Optional, TypedDict, Union
 
+# the list of action data that is processed in a single action call
 ActionData = Iterable[Dict[str, Any]]
 
+# a single payload element which contains the action data for this action
 PayloadElement = TypedDict("PayloadElement", {"action": str, "data": ActionData})
 
+# the whole payload that is received from the client
 Payload = List[PayloadElement]
 
 ActionResultElement = Dict[str, Any]

--- a/tests/system/action/agenda_item/test_assign.py
+++ b/tests/system/action/agenda_item/test_assign.py
@@ -78,7 +78,7 @@ class AgendaItemAssignActionTest(BaseActionTestCase):
         assert agenda_item_9.get("child_ids") == []
         assert agenda_item_9.get("parent_id") == 7
 
-    def test_assign_multiple_payload_items(self) -> None:
+    def test_assign_multiple_action_data_items(self) -> None:
         self.set_models(
             {
                 "meeting/222": {},

--- a/tests/system/action/mediafile/test_move.py
+++ b/tests/system/action/mediafile/test_move.py
@@ -127,7 +127,7 @@ class MediafileMoveActionTest(BaseActionTestCase):
         self.assert_status_code(response, 400)
         self.assertIn("New parent is not a directory.", response.json["message"])
 
-    def test_move_multiple_payload_items(self) -> None:
+    def test_move_multiple_action_data_items(self) -> None:
         self.set_models(
             {
                 "meeting/222": {},

--- a/tests/system/action/meeting/test_create.py
+++ b/tests/system/action/meeting/test_create.py
@@ -107,7 +107,8 @@ class MeetingCreateActionTest(BaseActionTestCase):
             },
         )
 
-    def test_check_payload_fields(self) -> None:
+    def test_check_action_data_fields(self) -> None:
+        self.create_model("user/2")
         meeting = self.basic_test(
             {
                 "welcome_text": "htXiSgbj",

--- a/tests/system/action/meeting/test_create.py
+++ b/tests/system/action/meeting/test_create.py
@@ -108,7 +108,6 @@ class MeetingCreateActionTest(BaseActionTestCase):
         )
 
     def test_check_action_data_fields(self) -> None:
-        self.create_model("user/2")
         meeting = self.basic_test(
             {
                 "welcome_text": "htXiSgbj",

--- a/tests/system/action/test_create_relation.py
+++ b/tests/system/action/test_create_relation.py
@@ -79,7 +79,7 @@ class FakeModelCRBCreateAction(CreateActionWithDependencies):
 
     dependencies = [FakeModelCRCCreateAction]
 
-    def get_dependent_action_payload(
+    def get_dependent_action_data(
         self, instance: Dict[str, Any], CreateActionClass: Type[Action]
     ) -> List[Dict[str, Any]]:
         return [


### PR DESCRIPTION
closes #454 

Forgot to add the renaming to #461, so adding that with this PR.

@all: Please consequently use the new wording:
- Payload: Everything that is sent from the client.
- PayloadElement: A single Element of this list which contains the name of the action and the ActionData.
- ActionData: The list of data that is supplied for a single action.
- Instance (Action data element, ...): May have different names, depending on the context. Most of the time it reflects an instance of a model (e.g. for CUD actions)