### PR TITLE
Implemented Collection field locking with filters

### DIFF
--- a/openslides_backend/services/datastore/commands.py
+++ b/openslides_backend/services/datastore/commands.py
@@ -5,6 +5,7 @@ from mypy_extensions import TypedDict
 
 from ...shared.filters import Filter as FilterInterface
 from ...shared.filters import FilterData
+from ...shared.interfaces.collection_field_lock import CollectionFieldLock
 from ...shared.interfaces.event import Event
 from ...shared.interfaces.write_request import WriteRequest
 from ...shared.patterns import Collection, FullQualifiedId
@@ -59,7 +60,7 @@ StringifiedWriteRequest = TypedDict(
         "events": List[Event],
         "information": Dict[str, List[str]],
         "user_id": int,
-        "locked_fields": Dict[str, int],
+        "locked_fields": Dict[str, CollectionFieldLock],
     },
 )
 
@@ -331,6 +332,8 @@ class Write(Command):
             def default(self, o):  # type: ignore
                 if isinstance(o, FullQualifiedId):
                     return str(o)
+                if isinstance(o, FilterInterface):
+                    return o.to_dict()
                 return super().default(o)
 
         return json.dumps(stringified_write_requests, cls=WriteRequestJSONEncoder)

--- a/openslides_backend/services/datastore/interface.py
+++ b/openslides_backend/services/datastore/interface.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 from typing_extensions import Protocol
 
 from ...shared.filters import Filter
+from ...shared.interfaces.collection_field_lock import CollectionFieldLock
 from ...shared.interfaces.write_request import WriteRequest
 from ...shared.patterns import Collection, FullQualifiedId
 from ...shared.typing import ModelMap
@@ -21,7 +22,7 @@ class DatastoreService(Protocol):
     """
 
     # The key of this dictionary is a stringified FullQualifiedId or FullQualifiedField
-    locked_fields: Dict[str, int]
+    locked_fields: Dict[str, CollectionFieldLock]
     additional_relation_models: ModelMap
 
     def get(

--- a/openslides_backend/shared/interfaces/collection_field_lock.py
+++ b/openslides_backend/shared/interfaces/collection_field_lock.py
@@ -1,0 +1,12 @@
+from typing import TypedDict, Union
+
+from ..filters import Filter
+
+CollectionFieldLockWithFilter = TypedDict(
+    "CollectionFieldLockWithFilter",
+    {
+        "position": int,
+        "filter": Filter,
+    },
+)
+CollectionFieldLock = Union[int, CollectionFieldLockWithFilter]

--- a/openslides_backend/shared/interfaces/write_request.py
+++ b/openslides_backend/shared/interfaces/write_request.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Dict, List
 
 from ..patterns import FullQualifiedId
+from .collection_field_lock import CollectionFieldLock
 from .event import Event
 
 Information = Dict[FullQualifiedId, List[str]]
@@ -16,4 +17,4 @@ class WriteRequest:
     events: List[Event]
     information: Information
     user_id: int
-    locked_fields: Dict[str, int]
+    locked_fields: Dict[str, CollectionFieldLock]


### PR DESCRIPTION
closes #384 

`filter` now automatically locks the collection fields with a filter. The rest of the aggregate methods still lock the whole collection field (as discussed in #384).

Also added back the mechanism that always the lower position gets saved in the `locked_fields` (was discussed [here](https://github.com/OpenSlides/openslides-backend/pull/335#discussion_r541184812), but then seemingly forgotten to take care of).