### PR TITLE
Fix action results

### DIFF
--- a/openslides_backend/action/actions/resource/upload.py
+++ b/openslides_backend/action/actions/resource/upload.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 from ....models.models import Resource
 from ....shared.exceptions import ActionException
 from ....shared.filters import And, FilterOperator
+from ...action import original_instances
 from ...generics.create import CreateAction
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
@@ -41,6 +42,7 @@ class MediafileUploadAction(CreateAction):
         self.media.upload_resource(file_, id_, mimetype_)
         return instance
 
+    @original_instances
     def get_updated_instances(self, action_data: ActionData) -> ActionData:
         tokens = [instance["token"] for instance in action_data]
         if len(tokens) != len(set(tokens)):

--- a/tests/system/action/base.py
+++ b/tests/system/action/base.py
@@ -15,7 +15,7 @@ class BaseActionTestCase(BaseSystemTestCase):
         return self.request_multi(action, [data])
 
     def request_multi(self, action: str, data: List[Dict[str, Any]]) -> Response:
-        return self.request_json(
+        response = self.request_json(
             [
                 {
                     "action": action,
@@ -23,6 +23,11 @@ class BaseActionTestCase(BaseSystemTestCase):
                 }
             ]
         )
+        if response.status_code == 200:
+            results = response.json.get("results", [])
+            assert len(results) == 1
+            assert len(results[0]) == len(data)
+        return response
 
     def request_json(self, payload: Payload) -> Response:
         return self.client.post("/", json=payload)


### PR DESCRIPTION
fixes #522

Some explanation: By default, one `ActionResult` element is created per instance in the action data (e.g. normal create action: 3 instances in action data -> 3 ids must be returned). For actions which change the action data (meaning they overwrite `get_updated_instance`, this no longer holds true - they have to manually set the results to return. For actions which override the method BUT do not change the list of instances, but only the instances itself, it can now just mark the `get_updated_instances` method with `original_instances` and everything should work (like `resource.upload`).