### PR TITLE
Implement equal_fields check for users

### DIFF
--- a/openslides_backend/action/actions/user/temporary_user_mixin.py
+++ b/openslides_backend/action/actions/user/temporary_user_mixin.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict
 
-from ....models.models import User
 from ....services.datastore.commands import GetManyRequest
 from ....shared.exceptions import ActionException
 from ...action import Action
@@ -19,9 +18,6 @@ class TemporaryUserMixin(Action):
             )
 
         if "group_ids" in instance:
-            self.check_equal_fields(
-                User.group__ids, instance, "group_ids", ["meeting_id"]
-            )
             group_ids = instance.pop("group_ids")
             instance["group_$_ids"] = {instance["meeting_id"]: group_ids}
 

--- a/openslides_backend/action/generics/create.py
+++ b/openslides_backend/action/generics/create.py
@@ -20,12 +20,18 @@ class CreateAction(Action):
         # Fetch new id to have it available in update_instance method
         new_id = self.datastore.reserve_id(collection=self.model.collection)
         instance["id"] = new_id
+
         self.datastore.additional_relation_models[
             FullQualifiedId(self.model.collection, instance["id"])
         ] = instance
 
         instance = self.update_instance(instance)
-        instance = self.validate_relation_fields(instance)
+
+        self.datastore.additional_relation_models[
+            FullQualifiedId(self.model.collection, instance["id"])
+        ] = instance
+
+        self.validate_relation_fields(instance)
 
         return instance
 

--- a/openslides_backend/action/generics/delete.py
+++ b/openslides_backend/action/generics/delete.py
@@ -9,7 +9,7 @@ from ...models.fields import (
 from ...shared.exceptions import ActionException, ProtectedModelsException
 from ...shared.interfaces.event import EventType
 from ...shared.interfaces.write_request import WriteRequest
-from ...shared.patterns import FullQualifiedId
+from ...shared.patterns import FullQualifiedId, transform_to_fqids
 from ...shared.typing import DeletedModel, ModelMap
 from ..action import Action
 from ..util.actions_map import actions_map
@@ -81,7 +81,9 @@ class DeleteAction(Action):
                     # field.on_delete == OnDelete.CASCADE
                     # Extract all foreign keys as fqids from the model
                     value = db_instance.get(field.own_field_name, [])
-                    foreign_fqids = self.get_field_value_as_fqid_list(field, value)
+                    foreign_fqids = transform_to_fqids(
+                        value, field.get_target_collection()
+                    )
 
                     # Execute the delete action for all fqids
                     for fqid in foreign_fqids:

--- a/openslides_backend/action/generics/update.py
+++ b/openslides_backend/action/generics/update.py
@@ -19,32 +19,9 @@ class UpdateAction(Action):
             FullQualifiedId(self.model.collection, instance["id"])
         ] = instance
 
-        instance = self.validate_relation_fields(instance)
+        self.validate_relation_fields(instance)
 
         return instance
-
-    def validate_relation_fields(self, instance: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Fetches missing fields from db for field equality check and removes them after.
-        """
-        missing_fields = [
-            equal_field_name
-            for field in self.model.get_relation_fields()
-            if field.equal_fields and field.own_field_name in instance
-            for equal_field_name in field.equal_fields
-            if equal_field_name not in instance
-        ]
-        if missing_fields:
-            db_instance = self.fetch_model(
-                FullQualifiedId(self.model.collection, instance["id"]), missing_fields
-            )
-        else:
-            db_instance = {}
-        updated_instance = super().validate_relation_fields({**instance, **db_instance})
-        for field_name in missing_fields:
-            if field_name in updated_instance:
-                del updated_instance[field_name]
-        return updated_instance
 
     def create_write_requests(self, instance: Dict[str, Any]) -> Iterable[WriteRequest]:
         """

--- a/openslides_backend/action/relations/single_relation_handler.py
+++ b/openslides_backend/action/relations/single_relation_handler.py
@@ -1,28 +1,16 @@
 from collections import defaultdict
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import Any, Dict, Iterable, List, Set, Tuple, Union, cast
 
 from ...models.base import model_registry
 from ...models.fields import (
     BaseGenericRelationField,
     BaseRelationField,
     BaseTemplateField,
+    BaseTemplateRelationField,
     GenericRelationField,
     GenericRelationListField,
     RelationField,
     RelationListField,
-    TemplateRelationField,
-    TemplateRelationListField,
 )
 from ...services.datastore.interface import (
     DatastoreService,
@@ -34,10 +22,10 @@ from ...shared.patterns import (
     Collection,
     FullQualifiedField,
     FullQualifiedId,
-    string_to_fqid,
+    transform_to_fqids,
 )
 from ...shared.typing import DeletedModel, ModelMap
-from .typing import FieldUpdateElement, IdentifierList, RelationFieldUpdates
+from .typing import FieldUpdateElement, RelationFieldUpdates
 
 
 class SingleRelationHandler:
@@ -120,14 +108,12 @@ class SingleRelationHandler:
         """
         # Prepare the new value of our field and the real field name of the reverse field.
         value = self.instance.get(self.field_name)
-        rel_ids = self.transform_to_fqids(value)
+        rel_ids = transform_to_fqids(value, self.field.get_target_collection())
         # We transform everything to lists of fqids to unify the handling. The values are
         # later transformed back
 
         # Just check if we have an invalid use case here.
-        if isinstance(self.field, TemplateRelationField) or isinstance(
-            self.field, TemplateRelationListField
-        ):
+        if isinstance(self.field, BaseTemplateRelationField):
             if self.field.is_template_field(self.field_name):
                 raise ValueError(
                     "You can not handle template fields here. Use them with populated replacements."
@@ -158,6 +144,8 @@ class SingleRelationHandler:
             related_name = self.get_related_name(collection)
             related_field = self.get_reverse_field(collection)
 
+            # TODO: check structured field replacement meeting id somewhere here
+
             # acquire all related models with the related fields
             rels = defaultdict(dict)
             for fqid in changed_fqids_per_collection[collection]:
@@ -166,7 +154,7 @@ class SingleRelationHandler:
                     [related_name],
                 )
                 # again, we transform everything to lists of fqids
-                rels[fqid][related_name] = self.transform_to_fqids(
+                rels[fqid][related_name] = transform_to_fqids(
                     related_model.get(related_name), self.model.collection
                 )
 
@@ -213,46 +201,6 @@ class SingleRelationHandler:
                 result_template_field = self.prepare_result_template_field(result)
                 final.update(result_template_field)
         return final
-
-    def transform_to_fqids(
-        self,
-        value: Optional[
-            Union[
-                int,
-                str,
-                FullQualifiedId,
-                Sequence[int],
-                Sequence[str],
-                Sequence[FullQualifiedId],
-            ]
-        ],
-        collection: Optional[Collection] = None,
-    ) -> List[FullQualifiedId]:
-        """
-        Get the given value of our field as a list. The list may be empty.
-        Transform all to fqids to handle everything in the same fashion.
-        """
-        id_list: IdentifierList
-        if value is None:
-            id_list = []  # type: ignore  # see https://github.com/python/mypy/issues/2164
-        elif not isinstance(value, list):
-            value_arr = cast(IdentifierList, [value])
-            id_list = value_arr
-        else:
-            id_list = value
-
-        fqid_list = []
-        for id in id_list:
-            if isinstance(id, str):
-                fqid_list.append(string_to_fqid(id))
-            elif isinstance(id, int):
-                if not collection:
-                    collection = self.field.get_target_collection()
-                fqid_list.append(FullQualifiedId(collection, id))
-            else:
-                assert isinstance(id, FullQualifiedId)
-                fqid_list.append(id)
-        return fqid_list
 
     def partition_by_collection(
         self, fqids: Iterable[FullQualifiedId]
@@ -342,7 +290,9 @@ class SingleRelationHandler:
 
             # Get current ids from relation field
             current_value = current_obj.get(self.field_name)
-            current_fqids = set(self.transform_to_fqids(current_value))
+            current_fqids = set(
+                transform_to_fqids(current_value, self.field.get_target_collection())
+            )
 
             # Calculate add set and remove set
             new_fqids = set(rel_fqids)

--- a/openslides_backend/action/relations/single_relation_handler.py
+++ b/openslides_backend/action/relations/single_relation_handler.py
@@ -144,8 +144,6 @@ class SingleRelationHandler:
             related_name = self.get_related_name(collection)
             related_field = self.get_reverse_field(collection)
 
-            # TODO: check structured field replacement meeting id somewhere here
-
             # acquire all related models with the related fields
             rels = defaultdict(dict)
             for fqid in changed_fqids_per_collection[collection]:

--- a/openslides_backend/action/relations/typing.py
+++ b/openslides_backend/action/relations/typing.py
@@ -1,9 +1,7 @@
-from typing import Dict, List, Optional, TypedDict, Union
+from typing import Dict, Optional, TypedDict, Union
 
-from ...shared.patterns import FullQualifiedField, FullQualifiedId
+from ...shared.patterns import FullQualifiedField, Identifier, IdentifierList
 
-Identifier = Union[int, str, FullQualifiedId]
-IdentifierList = Union[List[int], List[str], List[FullQualifiedId]]
 FieldUpdateElement = TypedDict(
     "FieldUpdateElement",
     {

--- a/openslides_backend/action/util/assert_belongs_to_meeting.py
+++ b/openslides_backend/action/util/assert_belongs_to_meeting.py
@@ -1,0 +1,39 @@
+from typing import List, Union
+
+from ...services.datastore.deleted_models_behaviour import InstanceAdditionalBehaviour
+from ...services.datastore.interface import DatastoreService
+from ...shared.exceptions import ActionException
+from ...shared.patterns import FullQualifiedId
+
+
+def assert_belongs_to_meeting(
+    datastore: DatastoreService,
+    fqids: Union[FullQualifiedId, List[FullQualifiedId]],
+    meeting_id: int,
+) -> None:
+    if not isinstance(fqids, list):
+        fqids = [fqids]
+
+    errors: List[FullQualifiedId] = []
+    for fqid in fqids:
+        mapped_fields = ["meeting_id"]
+        if fqid.collection.collection == "user":
+            mapped_fields += ["guest_meeting_ids", f"group_${meeting_id}_ids"]
+
+        instance = datastore.fetch_model(
+            fqid,
+            mapped_fields,
+            db_additional_relevance=InstanceAdditionalBehaviour.ADDITIONAL_BEFORE_DBINST,
+        )
+        if instance.get("meeting_id") != meeting_id:
+            if fqid.collection.collection == "user" and (
+                meeting_id in instance.get("guest_meeting_ids", [])
+                or instance.get(f"group_${meeting_id}_ids")
+            ):
+                continue
+            errors.append(fqid)
+
+    if errors:
+        raise ActionException(
+            f"The following models do not belong to meeting {meeting_id}: {errors}"
+        )

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -781,7 +781,9 @@ class Speaker(Model):
         equal_fields="meeting_id",
     )
     user_id = fields.RelationField(
-        to={Collection("user"): "speaker_$_ids"}, required=True
+        to={Collection("user"): "speaker_$_ids"},
+        required=True,
+        equal_fields="meeting_id",
     )
     meeting_id = fields.RelationField(
         to={Collection("meeting"): "speaker_ids"}, required=True

--- a/tests/system/action/agenda_item/test_create.py
+++ b/tests/system/action/agenda_item/test_create.py
@@ -96,7 +96,7 @@ class AgendaItemSystemTest(BaseActionTestCase):
         )
         self.assert_status_code(response, 400)
         self.assertIn(
-            "requires the following fields to be equal",
+            "The following models do not belong to meeting 1: [FullQualifiedId('agenda_item/1')]",
             response.json["message"],
         )
         self.assert_model_not_exists("agenda_item/2")

--- a/tests/system/action/mediafile/test_update.py
+++ b/tests/system/action/mediafile/test_update.py
@@ -5,8 +5,9 @@ class MediafileUpdateActionTest(BaseActionTestCase):
     def test_update_correct(self) -> None:
         self.set_models(
             {
-                "group/7": {"name": "group_LxAHErRs", "user_ids": []},
-                "mediafile/111": {"title": "title_srtgb123"},
+                "meeting/1": {},
+                "group/7": {"name": "group_LxAHErRs", "user_ids": [], "meeting_id": 1},
+                "mediafile/111": {"title": "title_srtgb123", "meeting_id": 1},
             }
         )
         response = self.request(
@@ -23,15 +24,21 @@ class MediafileUpdateActionTest(BaseActionTestCase):
     def test_update_children(self) -> None:
         self.set_models(
             {
-                "group/7": {"name": "group_LxAHErRs", "user_ids": []},
+                "meeting/1": {},
+                "group/7": {"name": "group_LxAHErRs", "user_ids": [], "meeting_id": 1},
                 "mediafile/110": {
                     "title": "title_ekxORNiV",
                     "child_ids": [111],
                     "is_public": False,
                     "inherited_access_group_ids": [7],
                     "access_group_ids": [7],
+                    "meeting_id": 1,
                 },
-                "mediafile/111": {"title": "title_srtgb123", "parent_id": 110},
+                "mediafile/111": {
+                    "title": "title_srtgb123",
+                    "parent_id": 110,
+                    "meeting_id": 1,
+                },
             }
         )
         response = self.request(
@@ -47,9 +54,18 @@ class MediafileUpdateActionTest(BaseActionTestCase):
     def test_update_parent(self) -> None:
         self.set_models(
             {
-                "group/7": {"name": "group_LxAHErRs", "user_ids": []},
-                "mediafile/110": {"title": "title_srtgb199", "child_ids": [111]},
-                "mediafile/111": {"title": "title_srtgb123", "parent_id": 110},
+                "meeting/1": {},
+                "group/7": {"name": "group_LxAHErRs", "user_ids": [], "meeting_id": 1},
+                "mediafile/110": {
+                    "title": "title_srtgb199",
+                    "child_ids": [111],
+                    "meeting_id": 1,
+                },
+                "mediafile/111": {
+                    "title": "title_srtgb123",
+                    "parent_id": 110,
+                    "meeting_id": 1,
+                },
             }
         )
         response = self.request(
@@ -66,15 +82,21 @@ class MediafileUpdateActionTest(BaseActionTestCase):
     def test_update_parent_inherited_list(self) -> None:
         self.set_models(
             {
-                "group/7": {"name": "group_LxAHErRs", "user_ids": []},
-                "group/8": {"name": "group_sdfafd", "user_ids": []},
+                "meeting/1": {},
+                "group/7": {"name": "group_LxAHErRs", "user_ids": [], "meeting_id": 1},
+                "group/8": {"name": "group_sdfafd", "user_ids": [], "meeting_id": 1},
                 "mediafile/110": {
                     "title": "title_srtgb199",
                     "child_ids": [111],
                     "inherited_access_group_ids": [8],
                     "is_public": False,
+                    "meeting_id": 1,
                 },
-                "mediafile/111": {"title": "title_srtgb123", "parent_id": 110},
+                "mediafile/111": {
+                    "title": "title_srtgb123",
+                    "parent_id": 110,
+                    "meeting_id": 1,
+                },
             }
         )
         response = self.request(
@@ -91,14 +113,20 @@ class MediafileUpdateActionTest(BaseActionTestCase):
     def test_update_parent_case1(self) -> None:
         self.set_models(
             {
+                "meeting/1": {},
                 "mediafile/110": {
                     "title": "title_srtgb199",
                     "child_ids": [111],
                     "access_group_ids": [],
                     "inherited_access_group_ids": [],
                     "is_public": True,
+                    "meeting_id": 1,
                 },
-                "mediafile/111": {"title": "title_srtgb123", "parent_id": 110},
+                "mediafile/111": {
+                    "title": "title_srtgb123",
+                    "parent_id": 110,
+                    "meeting_id": 1,
+                },
             }
         )
         response = self.request(
@@ -114,16 +142,22 @@ class MediafileUpdateActionTest(BaseActionTestCase):
     def test_update_parent_case2(self) -> None:
         self.set_models(
             {
-                "group/2": {"name": "group_LxAHErRs", "user_ids": []},
-                "group/4": {"name": "group_sdfafd", "user_ids": []},
+                "meeting/1": {},
+                "group/2": {"name": "group_LxAHErRs", "user_ids": [], "meeting_id": 1},
+                "group/4": {"name": "group_sdfafd", "user_ids": [], "meeting_id": 1},
                 "mediafile/110": {
                     "title": "title_srtgb199",
                     "child_ids": [111],
                     "inherited_access_group_ids": [2, 4],
                     "access_group_ids": [2, 4],
                     "is_public": False,
+                    "meeting_id": 1,
                 },
-                "mediafile/111": {"title": "title_srtgb123", "parent_id": 110},
+                "mediafile/111": {
+                    "title": "title_srtgb123",
+                    "parent_id": 110,
+                    "meeting_id": 1,
+                },
             }
         )
         response = self.request(
@@ -139,16 +173,22 @@ class MediafileUpdateActionTest(BaseActionTestCase):
     def test_update_parent_case3(self) -> None:
         self.set_models(
             {
-                "group/3": {"name": "group_LxAHErRs", "user_ids": []},
-                "group/6": {"name": "group_sdfafd", "user_ids": []},
+                "meeting/1": {},
+                "group/3": {"name": "group_LxAHErRs", "user_ids": [], "meeting_id": 1},
+                "group/6": {"name": "group_sdfafd", "user_ids": [], "meeting_id": 1},
                 "mediafile/110": {
                     "title": "title_srtgb199",
                     "child_ids": [111],
                     "inherited_access_group_ids": [],
                     "access_group_ids": [],
                     "is_public": True,
+                    "meeting_id": 1,
                 },
-                "mediafile/111": {"title": "title_srtgb123", "parent_id": 110},
+                "mediafile/111": {
+                    "title": "title_srtgb123",
+                    "parent_id": 110,
+                    "meeting_id": 1,
+                },
             }
         )
         response = self.request(
@@ -168,17 +208,23 @@ class MediafileUpdateActionTest(BaseActionTestCase):
     def test_update_parent_case4(self) -> None:
         self.set_models(
             {
-                "group/1": {"name": "group_LxAHErRs", "user_ids": []},
-                "group/2": {"name": "group_sdfafd", "user_ids": []},
-                "group/3": {"name": "group_ghjeei", "user_ids": []},
+                "meeting/1": {},
+                "group/1": {"name": "group_LxAHErRs", "user_ids": [], "meeting_id": 1},
+                "group/2": {"name": "group_sdfafd", "user_ids": [], "meeting_id": 1},
+                "group/3": {"name": "group_ghjeei", "user_ids": [], "meeting_id": 1},
                 "mediafile/110": {
                     "title": "title_srtgb199",
                     "child_ids": [111],
                     "inherited_access_group_ids": [1, 2],
                     "access_group_ids": [1, 2],
                     "is_public": False,
+                    "meeting_id": 1,
                 },
-                "mediafile/111": {"title": "title_srtgb123", "parent_id": 110},
+                "mediafile/111": {
+                    "title": "title_srtgb123",
+                    "parent_id": 110,
+                    "meeting_id": 1,
+                },
             }
         )
         response = self.request(
@@ -198,17 +244,23 @@ class MediafileUpdateActionTest(BaseActionTestCase):
     def test_update_parent_case5(self) -> None:
         self.set_models(
             {
-                "group/1": {"name": "group_LxAHErRs", "user_ids": []},
-                "group/2": {"name": "group_sdfafd", "user_ids": []},
-                "group/3": {"name": "group_ghjeei", "user_ids": []},
+                "meeting/1": {},
+                "group/1": {"name": "group_LxAHErRs", "user_ids": [], "meeting_id": 1},
+                "group/2": {"name": "group_sdfafd", "user_ids": [], "meeting_id": 1},
+                "group/3": {"name": "group_ghjeei", "user_ids": [], "meeting_id": 1},
                 "mediafile/110": {
                     "title": "title_srtgb199",
                     "child_ids": [111],
                     "inherited_access_group_ids": [1, 2],
                     "access_group_ids": [1, 2],
                     "is_public": False,
+                    "meeting_id": 1,
                 },
-                "mediafile/111": {"title": "title_srtgb123", "parent_id": 110},
+                "mediafile/111": {
+                    "title": "title_srtgb123",
+                    "parent_id": 110,
+                    "meeting_id": 1,
+                },
             }
         )
         response = self.request(
@@ -224,14 +276,20 @@ class MediafileUpdateActionTest(BaseActionTestCase):
     def test_update_parent_inherited_true(self) -> None:
         self.set_models(
             {
+                "meeting/1": {},
                 "mediafile/110": {
                     "title": "title_srtgb199",
                     "child_ids": [111],
                     "inherited_access_group_ids": [],
                     "access_group_ids": [],
                     "is_public": False,
+                    "meeting_id": 1,
                 },
-                "mediafile/111": {"title": "title_srtgb123", "parent_id": 110},
+                "mediafile/111": {
+                    "title": "title_srtgb123",
+                    "parent_id": 110,
+                    "meeting_id": 1,
+                },
             }
         )
         response = self.request(
@@ -259,17 +317,24 @@ class MediafileUpdateActionTest(BaseActionTestCase):
     def test_update_parent_and_children(self) -> None:
         self.set_models(
             {
-                "group/7": {"name": "group_LxAHErRs", "user_ids": []},
-                "mediafile/110": {"title": "title_srtgb199", "child_ids": [111]},
+                "meeting/1": {},
+                "group/7": {"name": "group_LxAHErRs", "user_ids": [], "meeting_id": 1},
+                "mediafile/110": {
+                    "title": "title_srtgb199",
+                    "child_ids": [111],
+                    "meeting_id": 1,
+                },
                 "mediafile/111": {
                     "title": "title_srtgb123",
                     "parent_id": 110,
                     "child_ids": [112],
+                    "meeting_id": 1,
                 },
                 "mediafile/112": {
                     "title": "title_srtgb123",
                     "parent_id": 111,
                     "access_group_ids": [7],
+                    "meeting_id": 1,
                 },
             }
         )
@@ -291,22 +356,30 @@ class MediafileUpdateActionTest(BaseActionTestCase):
     def test_update_parent_and_children_2(self) -> None:
         self.set_models(
             {
-                "group/7": {"name": "group_LxAHErRs", "user_ids": []},
-                "mediafile/110": {"title": "title_srtgb199", "child_ids": [111]},
+                "meeting/1": {},
+                "group/7": {"name": "group_LxAHErRs", "user_ids": [], "meeting_id": 1},
+                "mediafile/110": {
+                    "title": "title_srtgb199",
+                    "child_ids": [111],
+                    "meeting_id": 1,
+                },
                 "mediafile/111": {
                     "title": "title_srtgb123",
                     "parent_id": 110,
                     "child_ids": [112, 113],
+                    "meeting_id": 1,
                 },
                 "mediafile/112": {
                     "title": "title_srtgb123",
                     "parent_id": 111,
                     "access_group_ids": [7],
+                    "meeting_id": 1,
                 },
                 "mediafile/113": {
                     "title": "title_srtgb123",
                     "parent_id": 111,
                     "access_group_ids": [7],
+                    "meeting_id": 1,
                 },
             }
         )
@@ -332,23 +405,31 @@ class MediafileUpdateActionTest(BaseActionTestCase):
     def test_update_parent_and_children_3(self) -> None:
         self.set_models(
             {
-                "group/7": {"name": "group_LxAHErRs", "user_ids": []},
-                "mediafile/110": {"title": "title_srtgb199", "child_ids": [111]},
+                "meeting/1": {},
+                "group/7": {"name": "group_LxAHErRs", "user_ids": [], "meeting_id": 1},
+                "mediafile/110": {
+                    "title": "title_srtgb199",
+                    "child_ids": [111],
+                    "meeting_id": 1,
+                },
                 "mediafile/111": {
                     "title": "title_srtgb123",
                     "parent_id": 110,
                     "child_ids": [112],
+                    "meeting_id": 1,
                 },
                 "mediafile/112": {
                     "title": "title_srtgb123",
                     "parent_id": 111,
                     "access_group_ids": [7],
                     "child_ids": [113],
+                    "meeting_id": 1,
                 },
                 "mediafile/113": {
                     "title": "title_srtgb123",
                     "parent_id": 112,
                     "access_group_ids": [7],
+                    "meeting_id": 1,
                 },
             }
         )

--- a/tests/system/action/motion/test_update.py
+++ b/tests/system/action/motion/test_update.py
@@ -290,8 +290,9 @@ class MotionUpdateActionTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 400)
-        assert "requires the following fields to be equal" in response.json.get(
-            "message", ""
+        assert (
+            "The following models do not belong to meeting 1: [FullQualifiedId('motion/2')]"
+            in response.json.get("message", "")
         )
 
     def test_only_motion_allowed(self) -> None:

--- a/tests/system/action/speaker/test_create.py
+++ b/tests/system/action/speaker/test_create.py
@@ -6,7 +6,7 @@ class SpeakerCreateActionTest(BaseActionTestCase):
         self.set_models(
             {
                 "meeting/7844": {"name": "name_asdewqasd"},
-                "user/7": {"username": "test_username1"},
+                "user/7": {"username": "test_username1", "meeting_id": 7844},
                 "list_of_speakers/23": {"speaker_ids": [], "meeting_id": 7844},
             }
         )
@@ -44,7 +44,11 @@ class SpeakerCreateActionTest(BaseActionTestCase):
         self.set_models(
             {
                 "meeting/7844": {"name": "name_asdewqasd"},
-                "user/7": {"username": "test_username1", "speaker_$7844_ids": [42]},
+                "user/7": {
+                    "username": "test_username1",
+                    "speaker_$7844_ids": [42],
+                    "meeting_id": 7844,
+                },
                 "list_of_speakers/23": {"speaker_ids": [42], "meeting_id": 7844},
                 "speaker/42": {"user_id": 7, "list_of_speakers_id": 23},
             }
@@ -60,9 +64,9 @@ class SpeakerCreateActionTest(BaseActionTestCase):
         self.set_models(
             {
                 "meeting/7844": {"name": "name_asdewqasd"},
-                "user/7": {"username": "test_username6"},
-                "user/8": {"username": "test_username7"},
-                "user/9": {"username": "test_username8"},
+                "user/7": {"username": "test_username6", "meeting_id": 7844},
+                "user/8": {"username": "test_username7", "meeting_id": 7844},
+                "user/9": {"username": "test_username8", "meeting_id": 7844},
                 "speaker/1": {"user_id": 7, "list_of_speakers_id": 23, "weight": 10000},
                 "list_of_speakers/23": {"speaker_ids": [1], "meeting_id": 7844},
             }
@@ -81,15 +85,15 @@ class SpeakerCreateActionTest(BaseActionTestCase):
         )
 
     def test_create_add_2_speakers_in_2_actions(self) -> None:
-        self.create_model("meeting/7844", {"name": "name_asdewqasd"})
-        self.create_model("user/7", {"username": "test_username6"})
-        self.create_model("user/8", {"username": "test_username7"})
-        self.create_model("user/9", {"username": "test_username8"})
-        self.create_model(
-            "speaker/1", {"user_id": 7, "list_of_speakers_id": 23, "weight": 10000}
-        )
-        self.create_model(
-            "list_of_speakers/23", {"speaker_ids": [1], "meeting_id": 7844}
+        self.set_models(
+            {
+                "meeting/7844": {"name": "name_asdewqasd"},
+                "user/7": {"username": "test_username6", "meeting_id": 7844},
+                "user/8": {"username": "test_username7", "meeting_id": 7844},
+                "user/9": {"username": "test_username8", "meeting_id": 7844},
+                "speaker/1": {"user_id": 7, "list_of_speakers_id": 23, "weight": 10000},
+                "list_of_speakers/23": {"speaker_ids": [1], "meeting_id": 7844},
+            }
         )
         response = self.client.post(
             "/",
@@ -126,6 +130,7 @@ class SpeakerCreateActionTest(BaseActionTestCase):
                     "speaker_$7844_ids": [3],
                     "speaker_$_ids": ["7844"],
                     "is_present_in_meeting_ids": [7844],
+                    "meeting_id": 7844,
                 },
                 "list_of_speakers/23": {"speaker_ids": [], "meeting_id": 7844},
             }
@@ -151,6 +156,7 @@ class SpeakerCreateActionTest(BaseActionTestCase):
                     "username": "user9",
                     "speaker_$7844_ids": [3],
                     "speaker_$_ids": ["7844"],
+                    "meeting_id": 7844,
                 },
                 "list_of_speakers/23": {"speaker_ids": [], "meeting_id": 7844},
             }
@@ -171,7 +177,8 @@ class SpeakerCreateActionTest(BaseActionTestCase):
 
     def test_create_standard_speaker_in_only_talker_list(self) -> None:
         self.create_model("meeting/7844", {"name": "name_asdewqasd"})
-        self.create_model("user/7", {"username": "talking"})
+        self.update_model("user/1", {"meeting_id": 7844})
+        self.create_model("user/7", {"username": "talking", "meeting_id": 7844})
         self.create_model(
             "speaker/1",
             {
@@ -179,6 +186,7 @@ class SpeakerCreateActionTest(BaseActionTestCase):
                 "list_of_speakers_id": 23,
                 "begin_time": 100000,
                 "weight": 5,
+                "meeting_id": 7844,
             },
         )
         self.create_model(
@@ -202,14 +210,11 @@ class SpeakerCreateActionTest(BaseActionTestCase):
 
     def test_create_standard_speaker_at_the_end_of_filled_list(self) -> None:
         self.create_model("meeting/7844", {"name": "name_asdewqasd"})
-        self.create_model("user/7", {"username": "talking"})
-        self.create_model("user/8", {"username": "waiting"})
+        self.create_model("user/7", {"username": "talking", "meeting_id": 7844})
+        self.create_model("user/8", {"username": "waiting", "meeting_id": 7844})
         self.update_model(
             "user/1",
-            {
-                "speaker_$7844_ids": [3],
-                "speaker_$_ids": ["7844"],
-            },
+            {"speaker_$7844_ids": [3], "speaker_$_ids": ["7844"], "meeting_id": 7844},
         )
         self.create_model(
             "speaker/1",
@@ -218,10 +223,12 @@ class SpeakerCreateActionTest(BaseActionTestCase):
                 "list_of_speakers_id": 23,
                 "begin_time": 100000,
                 "weight": 5,
+                "meeting_id": 7844,
             },
         )
         self.create_model(
-            "speaker/2", {"user_id": 8, "list_of_speakers_id": 23, "weight": 1}
+            "speaker/2",
+            {"user_id": 8, "list_of_speakers_id": 23, "weight": 1, "meeting_id": 7844},
         )
         self.create_model(
             "speaker/3",
@@ -230,6 +237,7 @@ class SpeakerCreateActionTest(BaseActionTestCase):
                 "list_of_speakers_id": 23,
                 "point_of_order": True,
                 "weight": 2,
+                "meeting_id": 7844,
             },
         )
         self.create_model(
@@ -254,3 +262,34 @@ class SpeakerCreateActionTest(BaseActionTestCase):
             {"user_id": 1, "point_of_order": None, "weight": 3},
         )
         self.assert_model_exists("list_of_speakers/23", {"speaker_ids": [1, 2, 3, 4]})
+
+    def test_create_guest_in_meeting(self) -> None:
+        self.set_models(
+            {
+                "meeting/2": {},
+                "user/7": {"guest_meeting_ids": [2]},
+                "list_of_speakers/23": {"speaker_ids": [], "meeting_id": 2},
+            }
+        )
+        response = self.request(
+            "speaker.create", {"user_id": 7, "list_of_speakers_id": 23}
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "speaker/1",
+            {"user_id": 7, "meeting_id": 2},
+        )
+
+    def test_create_not_in_meeting(self) -> None:
+        self.set_models(
+            {
+                "meeting/1": {},
+                "meeting/2": {},
+                "user/7": {"meeting_id": 1},
+                "list_of_speakers/23": {"speaker_ids": [], "meeting_id": 2},
+            }
+        )
+        response = self.request(
+            "speaker.create", {"user_id": 7, "list_of_speakers_id": 23}
+        )
+        self.assert_status_code(response, 400)

--- a/tests/system/action/speaker/test_create_point_of_order.py
+++ b/tests/system/action/speaker/test_create_point_of_order.py
@@ -9,7 +9,8 @@ class SpeakerCreatePointOfOrderActionTest(BaseActionTestCase):
                     "name": "name_asdewqasd",
                     "list_of_speakers_enable_point_of_order_speakers": True,
                 },
-                "user/7": {"username": "talking"},
+                "user/1": {"meeting_id": 7844},
+                "user/7": {"username": "talking", "meeting_id": 7844},
                 "speaker/1": {
                     "user_id": 7,
                     "list_of_speakers_id": 23,
@@ -42,11 +43,12 @@ class SpeakerCreatePointOfOrderActionTest(BaseActionTestCase):
                     "list_of_speakers_enable_point_of_order_speakers": True,
                     "list_of_speakers_present_users_only": False,
                 },
-                "user/7": {"username": "talking with poo"},
-                "user/8": {"username": "waiting with poo"},
+                "user/7": {"username": "talking with poo", "meeting_id": 7844},
+                "user/8": {"username": "waiting with poo", "meeting_id": 7844},
                 "user/1": {
                     "speaker_$7844_ids": [3],
                     "speaker_$_ids": ["7844"],
+                    "meeting_id": 7844,
                 },
                 "speaker/1": {
                     "user_id": 7,
@@ -54,14 +56,21 @@ class SpeakerCreatePointOfOrderActionTest(BaseActionTestCase):
                     "point_of_order": True,
                     "begin_time": 100000,
                     "weight": 1,
+                    "meeting_id": 7844,
                 },
                 "speaker/2": {
                     "user_id": 8,
                     "list_of_speakers_id": 23,
                     "weight": 2,
                     "point_of_order": True,
+                    "meeting_id": 7844,
                 },
-                "speaker/3": {"user_id": 1, "list_of_speakers_id": 23, "weight": 3},
+                "speaker/3": {
+                    "user_id": 1,
+                    "list_of_speakers_id": 23,
+                    "weight": 3,
+                    "meeting_id": 7844,
+                },
                 "list_of_speakers/23": {"speaker_ids": [1, 2, 3], "meeting_id": 7844},
             }
         )
@@ -111,30 +120,39 @@ class SpeakerCreatePointOfOrderActionTest(BaseActionTestCase):
                     "list_of_speakers_enable_point_of_order_speakers": True,
                     "list_of_speakers_present_users_only": False,
                 },
-                "user/7": {"username": "waiting with poo1"},
-                "user/8": {"username": "waiting with poo2"},
+                "user/7": {"username": "waiting with poo1", "meeting_id": 7844},
+                "user/8": {"username": "waiting with poo2", "meeting_id": 7844},
                 "user/1": {
                     "speaker_$7844_ids": [3],
                     "speaker_$_ids": ["7844"],
+                    "meeting_id": 7844,
                 },
                 "speaker/1": {
                     "user_id": 7,
                     "list_of_speakers_id": 23,
                     "point_of_order": True,
                     "weight": 1,
+                    "meeting_id": 7844,
                 },
                 "speaker/2": {
                     "user_id": 8,
                     "list_of_speakers_id": 23,
                     "weight": 2,
                     "point_of_order": False,
+                    "meeting_id": 7844,
                 },
-                "speaker/3": {"user_id": 1, "list_of_speakers_id": 23, "weight": 3},
+                "speaker/3": {
+                    "user_id": 1,
+                    "list_of_speakers_id": 23,
+                    "weight": 3,
+                    "meeting_id": 7844,
+                },
                 "speaker/4": {
                     "user_id": 8,
                     "list_of_speakers_id": 23,
                     "weight": 4,
                     "point_of_order": True,
+                    "meeting_id": 7844,
                 },
                 "list_of_speakers/23": {
                     "speaker_ids": [1, 2, 3, 4],
@@ -204,16 +222,18 @@ class SpeakerCreatePointOfOrderActionTest(BaseActionTestCase):
                     "list_of_speakers_enable_point_of_order_speakers": True,
                     "list_of_speakers_present_users_only": False,
                 },
-                "user/7": {"username": "waiting with poo"},
+                "user/7": {"username": "waiting with poo", "meeting_id": 7844},
                 "user/1": {
                     "speaker_$7844_ids": [3],
                     "speaker_$_ids": ["7844"],
+                    "meeting_id": 7844,
                 },
                 "speaker/1": {
                     "user_id": 7,
                     "list_of_speakers_id": 23,
                     "point_of_order": True,
                     "weight": 1,
+                    "meeting_id": 7844,
                 },
                 "list_of_speakers/23": {"speaker_ids": [1], "meeting_id": 7844},
             }
@@ -244,12 +264,17 @@ class SpeakerCreatePointOfOrderActionTest(BaseActionTestCase):
                     "name": "name_asdewqasd",
                     "list_of_speakers_enable_point_of_order_speakers": True,
                 },
-                "user/1": {"username": "test_username1", "speaker_$7844_ids": [42]},
+                "user/1": {
+                    "username": "test_username1",
+                    "speaker_$7844_ids": [42],
+                    "meeting_id": 7844,
+                },
                 "list_of_speakers/23": {"speaker_ids": [42], "meeting_id": 7844},
                 "speaker/42": {
                     "user_id": 1,
                     "list_of_speakers_id": 23,
                     "point_of_order": True,
+                    "meeting_id": 7844,
                 },
             }
         )
@@ -298,14 +323,20 @@ class SpeakerCreatePointOfOrderActionTest(BaseActionTestCase):
                     "list_of_speakers_enable_point_of_order_speakers": True,
                     "list_of_speakers_present_users_only": False,
                 },
-                "user/7": {"username": "talking"},
-                "user/8": {"username": "waiting"},
+                "user/7": {"username": "talking", "meeting_id": 7844},
+                "user/8": {"username": "waiting", "meeting_id": 7844},
                 "speaker/1": {
                     "user_id": 7,
                     "list_of_speakers_id": 23,
                     "begin_time": 100000,
+                    "meeting_id": 7844,
                 },
-                "speaker/2": {"user_id": 8, "list_of_speakers_id": 23, "weight": 10000},
+                "speaker/2": {
+                    "user_id": 8,
+                    "list_of_speakers_id": 23,
+                    "weight": 10000,
+                    "meeting_id": 7844,
+                },
                 "list_of_speakers/23": {"speaker_ids": [1, 2], "meeting_id": 7844},
             }
         )

--- a/tests/system/action/test_equal_fields_check.py
+++ b/tests/system/action/test_equal_fields_check.py
@@ -14,10 +14,10 @@ class FakeModelEFA(Model):
     id = fields.IntegerField()
 
     b_id = fields.RelationField(
-        to={Collection("fake_model_ef_b"): "reference_field"},
+        to={Collection("fake_model_ef_b"): "meeting_id"},
     )
     c_id = fields.RelationField(
-        to={Collection("fake_model_ef_c"): "reference_field"},
+        to={Collection("fake_model_ef_c"): "meeting_id"},
     )
 
 
@@ -26,23 +26,23 @@ class FakeModelEFB(Model):
     verbose_name = "fake model for equal field check b"
     id = fields.IntegerField()
 
-    reference_field = fields.RelationField(to={Collection("fake_model_ef_a"): "b_id"})
+    meeting_id = fields.RelationField(to={Collection("fake_model_ef_a"): "b_id"})
 
     c_id = fields.RelationField(
         to={Collection("fake_model_ef_c"): "b_id"},
-        equal_fields="reference_field",
+        equal_fields="meeting_id",
     )
     c_ids = fields.RelationListField(
         to={Collection("fake_model_ef_c"): "b_ids"},
-        equal_fields="reference_field",
+        equal_fields="meeting_id",
     )
     c_generic_id = fields.GenericRelationField(
         to={Collection("fake_model_ef_c"): "b_generic_id"},
-        equal_fields="reference_field",
+        equal_fields="meeting_id",
     )
     c_generic_ids = fields.GenericRelationListField(
         to={Collection("fake_model_ef_c"): "b_generic_ids"},
-        equal_fields="reference_field",
+        equal_fields="meeting_id",
     )
 
 
@@ -51,7 +51,7 @@ class FakeModelEFC(Model):
     verbose_name = "fake model for equal field check c"
     id = fields.IntegerField()
 
-    reference_field = fields.RelationField(to={Collection("fake_model_ef_a"): "c_id"})
+    meeting_id = fields.RelationField(to={Collection("fake_model_ef_a"): "c_id"})
 
     b_id = fields.RelationField(
         to={Collection("fake_model_ef_b"): "c_id"},
@@ -84,12 +84,10 @@ class TestEqualFieldsCheck(BaseActionTestCase):
         self.set_models(
             {
                 "fake_model_ef_a/1": {"c_id": 1},
-                "fake_model_ef_c/1": {"reference_field": 1},
+                "fake_model_ef_c/1": {"meeting_id": 1},
             }
         )
-        response = self.request(
-            "fake_model_ef_b.create", {"reference_field": 1, "c_id": 1}
-        )
+        response = self.request("fake_model_ef_b.create", {"meeting_id": 1, "c_id": 1})
         self.assert_status_code(response, 200)
         self.assert_model_exists("fake_model_ef_b/1")
 
@@ -98,15 +96,13 @@ class TestEqualFieldsCheck(BaseActionTestCase):
             {
                 "fake_model_ef_a/1": {},
                 "fake_model_ef_a/2": {"c_id": 1},
-                "fake_model_ef_c/1": {"reference_field": 2},
+                "fake_model_ef_c/1": {"meeting_id": 2},
             }
         )
-        response = self.request(
-            "fake_model_ef_b.create", {"reference_field": 1, "c_id": 1}
-        )
+        response = self.request("fake_model_ef_b.create", {"meeting_id": 1, "c_id": 1})
         self.assert_status_code(response, 400)
         self.assertIn(
-            "requires the following fields to be equal",
+            "The following models do not belong to meeting 1: [FullQualifiedId('fake_model_ef_c/1')]",
             response.json["message"],
         )
         self.assert_model_not_exists("fake_model_ef_b/1")
@@ -115,9 +111,9 @@ class TestEqualFieldsCheck(BaseActionTestCase):
         self.set_models(
             {
                 "fake_model_ef_a/1": {"b_id": 1, "c_id": 1},
-                "fake_model_ef_b/1": {"reference_field": 1, "c_id": 1},
-                "fake_model_ef_c/1": {"reference_field": 1, "b_id": 1},
-                "fake_model_ef_c/2": {"reference_field": 1},
+                "fake_model_ef_b/1": {"meeting_id": 1, "c_id": 1},
+                "fake_model_ef_c/1": {"meeting_id": 1, "b_id": 1},
+                "fake_model_ef_c/2": {"meeting_id": 1},
             }
         )
         response = self.request("fake_model_ef_b.update", {"id": 1, "c_id": 2})
@@ -128,11 +124,11 @@ class TestEqualFieldsCheck(BaseActionTestCase):
         self.set_models(
             {
                 "fake_model_ef_a/1": {"c_id": 1},
-                "fake_model_ef_c/1": {"reference_field": 1},
+                "fake_model_ef_c/1": {"meeting_id": 1},
             }
         )
         response = self.request(
-            "fake_model_ef_b.create", {"reference_field": 1, "c_ids": [1]}
+            "fake_model_ef_b.create", {"meeting_id": 1, "c_ids": [1]}
         )
         self.assert_status_code(response, 200)
         self.assert_model_exists("fake_model_ef_b/1")
@@ -142,15 +138,15 @@ class TestEqualFieldsCheck(BaseActionTestCase):
             {
                 "fake_model_ef_a/1": {},
                 "fake_model_ef_a/2": {"c_id": 1},
-                "fake_model_ef_c/1": {"reference_field": 2},
+                "fake_model_ef_c/1": {"meeting_id": 2},
             }
         )
         response = self.request(
-            "fake_model_ef_b.create", {"reference_field": 1, "c_ids": [1]}
+            "fake_model_ef_b.create", {"meeting_id": 1, "c_ids": [1]}
         )
         self.assert_status_code(response, 400)
         self.assertIn(
-            "requires the following fields to be equal",
+            "The following models do not belong to meeting 1: [FullQualifiedId('fake_model_ef_c/1')]",
             response.json["message"],
         )
         self.assert_model_not_exists("fake_model_ef_b/1")
@@ -159,12 +155,12 @@ class TestEqualFieldsCheck(BaseActionTestCase):
         self.set_models(
             {
                 "fake_model_ef_a/1": {"c_id": 1},
-                "fake_model_ef_c/1": {"reference_field": 1},
+                "fake_model_ef_c/1": {"meeting_id": 1},
             }
         )
         response = self.request(
             "fake_model_ef_b.create",
-            {"reference_field": 1, "c_generic_id": "fake_model_ef_c/1"},
+            {"meeting_id": 1, "c_generic_id": "fake_model_ef_c/1"},
         )
         self.assert_status_code(response, 200)
         self.assert_model_exists("fake_model_ef_b/1")
@@ -174,16 +170,16 @@ class TestEqualFieldsCheck(BaseActionTestCase):
             {
                 "fake_model_ef_a/1": {},
                 "fake_model_ef_a/2": {"c_id": 1},
-                "fake_model_ef_c/1": {"reference_field": 2},
+                "fake_model_ef_c/1": {"meeting_id": 2},
             }
         )
         response = self.request(
             "fake_model_ef_b.create",
-            {"reference_field": 1, "c_generic_id": "fake_model_ef_c/1"},
+            {"meeting_id": 1, "c_generic_id": "fake_model_ef_c/1"},
         )
         self.assert_status_code(response, 400)
         self.assertIn(
-            "requires the following fields to be equal",
+            "The following models do not belong to meeting 1: [FullQualifiedId('fake_model_ef_c/1')]",
             response.json["message"],
         )
         self.assert_model_not_exists("fake_model_ef_b/1")
@@ -192,12 +188,12 @@ class TestEqualFieldsCheck(BaseActionTestCase):
         self.set_models(
             {
                 "fake_model_ef_a/1": {"c_id": 1},
-                "fake_model_ef_c/1": {"reference_field": 1},
+                "fake_model_ef_c/1": {"meeting_id": 1},
             }
         )
         response = self.request(
             "fake_model_ef_b.create",
-            {"reference_field": 1, "c_generic_ids": ["fake_model_ef_c/1"]},
+            {"meeting_id": 1, "c_generic_ids": ["fake_model_ef_c/1"]},
         )
         self.assert_status_code(response, 200)
         self.assert_model_exists("fake_model_ef_b/1")
@@ -207,16 +203,16 @@ class TestEqualFieldsCheck(BaseActionTestCase):
             {
                 "fake_model_ef_a/1": {},
                 "fake_model_ef_a/2": {"c_id": 1},
-                "fake_model_ef_c/1": {"reference_field": 2},
+                "fake_model_ef_c/1": {"meeting_id": 2},
             }
         )
         response = self.request(
             "fake_model_ef_b.create",
-            {"reference_field": 1, "c_generic_ids": ["fake_model_ef_c/1"]},
+            {"meeting_id": 1, "c_generic_ids": ["fake_model_ef_c/1"]},
         )
         self.assert_status_code(response, 400)
         self.assertIn(
-            "requires the following fields to be equal",
+            "The following models do not belong to meeting 1: [FullQualifiedId('fake_model_ef_c/1')]",
             response.json["message"],
         )
         self.assert_model_not_exists("fake_model_ef_b/1")

--- a/tests/system/action/user/test_create.py
+++ b/tests/system/action/user/test_create.py
@@ -47,7 +47,7 @@ class UserCreateActionTest(BaseActionTestCase):
             {
                 "meeting/1": {},
                 "meeting/2": {},
-                "user/222": {},
+                "user/222": {"meeting_id": 1},
                 "group/11": {"meeting_id": 1},
                 "group/22": {"meeting_id": 2},
             }
@@ -125,6 +125,23 @@ class UserCreateActionTest(BaseActionTestCase):
             "data.comment_$ must not contain {'str'} properties",
             response.json["message"],
         )
+
+    def test_create_invalid_group_id(self) -> None:
+        self.set_models(
+            {
+                "meeting/1": {},
+                "meeting/2": {},
+                "group/11": {"meeting_id": 1},
+            }
+        )
+        response = self.request(
+            "user.create",
+            {
+                "username": "test_Xcdfgee",
+                "group_$_ids": {2: [11]},
+            },
+        )
+        self.assert_status_code(response, 400)
 
     def test_create_empty_data(self) -> None:
         response = self.request("user.create", {})

--- a/tests/system/action/user/test_create_temporary.py
+++ b/tests/system/action/user/test_create_temporary.py
@@ -18,7 +18,7 @@ class UserCreateTemporaryActionTest(BaseActionTestCase):
             {
                 "meeting/222": {"name": "name_shjeuazu"},
                 "group/1": {"meeting_id": 222},
-                "user/7": {},
+                "user/7": {"meeting_id": 222},
             }
         )
         response = self.request(
@@ -108,7 +108,7 @@ class UserCreateTemporaryActionTest(BaseActionTestCase):
         )
         self.assert_status_code(response, 400)
         self.assertIn(
-            "requires the following fields to be equal",
+            "The following models do not belong to meeting 1: [FullQualifiedId('group/2')]",
             response.json["message"],
         )
         self.assert_model_not_exists("user/2")

--- a/tests/system/action/user/test_update.py
+++ b/tests/system/action/user/test_update.py
@@ -48,7 +48,7 @@ class UserUpdateActionTest(BaseActionTestCase):
             {
                 "meeting/1": {},
                 "meeting/2": {},
-                "user/222": {},
+                "user/222": {"meeting_id": 1},
                 "user/223": {},
                 "group/11": {"meeting_id": 1},
                 "group/22": {"meeting_id": 2},

--- a/tests/system/action/user/test_update_temporary.py
+++ b/tests/system/action/user/test_update_temporary.py
@@ -20,7 +20,7 @@ class UserUpdateTemporaryActionTest(BaseActionTestCase):
                 "meeting/222": {"name": "name_meeting222"},
                 "user/111": {"username": "username_srtgb123", "meeting_id": 222},
                 "group/7": {"name": "name_group7", "user_ids": [], "meeting_id": 222},
-                "user/7": {},
+                "user/7": {"meeting_id": 222},
             }
         )
         response = self.request(
@@ -176,7 +176,7 @@ class UserUpdateTemporaryActionTest(BaseActionTestCase):
         response = self.request("user.update_temporary", {"id": 111, "group_ids": [2]})
         self.assert_status_code(response, 400)
         self.assertIn(
-            "requires the following fields to be equal",
+            "The following models do not belong to meeting 1: [FullQualifiedId('group/2')]",
             response.json["message"],
         )
         model = self.get_model("user/111")

--- a/tests/system/relations/test_template_fields.py
+++ b/tests/system/relations/test_template_fields.py
@@ -4,7 +4,7 @@ from .setup import BaseRelationsTestCase, FakeModelA, FakeModelB, FakeModelC  # 
 class CreateActionWithTemplateFieldTester(BaseRelationsTestCase):
     def test_simple_create(self) -> None:
         self.create_model("meeting/42")
-        self.create_model("fake_model_b/123")
+        self.create_model("fake_model_b/123", {"meeting_id": 42})
         response = self.client.post(
             "/",
             json=[


### PR DESCRIPTION
fixes #512, #521 and #365 

The changes to the datastore adapter are pretty ugly, but this will need to be adjustet with #518 anyway, so it's only temporary.