### PR TITLE
Refine base_permission_test and update the permission tests.

### DIFF
--- a/tests/system/action/agenda_item/test_assign.py
+++ b/tests/system/action/agenda_item/test_assign.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -99,13 +100,23 @@ class AgendaItemAssignActionTest(BaseActionTestCase):
         agenda_item_8 = self.get_model("agenda_item/8")
         assert agenda_item_8.get("parent_id") is None
 
-    def test_permissions(self) -> None:
+    def test_assign_no_permissions(self) -> None:
         self.base_permission_test(
             {
-                "meeting/222": {},
-                "agenda_item/7": {"meeting_id": 222},
-                "agenda_item/8": {"meeting_id": 222},
+                "agenda_item/7": {"meeting_id": 1},
+                "agenda_item/8": {"meeting_id": 1},
             },
             "agenda_item.assign",
-            {"meeting_id": 222, "ids": [8], "parent_id": 7},
+            {"meeting_id": 1, "ids": [8], "parent_id": 7},
+        )
+
+    def test_assign_permissions(self) -> None:
+        self.base_permission_test(
+            {
+                "agenda_item/7": {"meeting_id": 1},
+                "agenda_item/8": {"meeting_id": 1},
+            },
+            "agenda_item.assign",
+            {"meeting_id": 1, "ids": [8], "parent_id": 7},
+            Permissions.AgendaItem.CAN_MANAGE,
         )

--- a/tests/system/action/agenda_item/test_create.py
+++ b/tests/system/action/agenda_item/test_create.py
@@ -1,4 +1,5 @@
 from openslides_backend.models.models import AgendaItem
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -244,9 +245,17 @@ class AgendaItemSystemTest(BaseActionTestCase):
         assert model.get("is_hidden") is True
         assert model.get("level") == 13
 
-    def test_permissions(self) -> None:
+    def test_create_no_permissions(self) -> None:
         self.base_permission_test(
-            {"meeting/2": {"name": "test"}, "topic/1": {"meeting_id": 2}},
+            {"topic/1": {"meeting_id": 1}},
             "agenda_item.create",
             {"content_object_id": "topic/1"},
+        )
+
+    def test_create_permissions(self) -> None:
+        self.base_permission_test(
+            {"topic/1": {"meeting_id": 1}},
+            "agenda_item.create",
+            {"content_object_id": "topic/1"},
+            Permissions.AgendaItem.CAN_MANAGE,
         )

--- a/tests/system/action/agenda_item/test_delete.py
+++ b/tests/system/action/agenda_item/test_delete.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -40,13 +41,23 @@ class AgendaItemActionTest(BaseActionTestCase):
         self.assert_model_deleted("agenda_item/111")
         self.get_model("motion/34")
 
-    def test_permissions(self) -> None:
+    def test_delete_no_permissions(self) -> None:
         self.base_permission_test(
             {
-                "meeting/1": {},
                 "motion/34": {"agenda_item_id": 111, "meeting_id": 1},
                 "agenda_item/111": {"content_object_id": "motion/34", "meeting_id": 1},
             },
             "agenda_item.delete",
             {"id": 111},
+        )
+
+    def test_delete_permissions(self) -> None:
+        self.base_permission_test(
+            {
+                "motion/34": {"agenda_item_id": 111, "meeting_id": 1},
+                "agenda_item/111": {"content_object_id": "motion/34", "meeting_id": 1},
+            },
+            "agenda_item.delete",
+            {"id": 111},
+            Permissions.AgendaItem.CAN_MANAGE,
         )

--- a/tests/system/action/agenda_item/test_numbering.py
+++ b/tests/system/action/agenda_item/test_numbering.py
@@ -1,4 +1,5 @@
 from openslides_backend.models.models import AgendaItem
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -155,7 +156,7 @@ class AgendaItemNumberingTester(BaseActionTestCase):
         agenda_item_2 = self.get_model("agenda_item/2")
         assert agenda_item_2.get("item_number") == ""
 
-    def test_permissions(self) -> None:
+    def test_numbering_no_permissions(self) -> None:
         self.base_permission_test(
             {
                 "meeting/1": {"agenda_item_ids": [1, 2]},
@@ -172,4 +173,24 @@ class AgendaItemNumberingTester(BaseActionTestCase):
             },
             "agenda_item.numbering",
             {"meeting_id": 1},
+        )
+
+    def test_numbering_permissions(self) -> None:
+        self.base_permission_test(
+            {
+                "meeting/1": {"agenda_item_ids": [1, 2]},
+                "agenda_item/1": {
+                    "meeting_id": 1,
+                    "weight": 10,
+                    "type": AgendaItem.AGENDA_ITEM,
+                },
+                "agenda_item/2": {
+                    "meeting_id": 1,
+                    "weight": 10,
+                    "type": AgendaItem.AGENDA_ITEM,
+                },
+            },
+            "agenda_item.numbering",
+            {"meeting_id": 1},
+            Permissions.AgendaItem.CAN_MANAGE,
         )

--- a/tests/system/action/agenda_item/test_sort.py
+++ b/tests/system/action/agenda_item/test_sort.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -162,12 +163,21 @@ class AgendaItemSortActionTest(BaseActionTestCase):
         assert model_12.get("child_ids") == []
         assert model_12.get("level") == 1
 
-    def test_permissions(self) -> None:
+    def test_sort_no_permissions(self) -> None:
         self.base_permission_test(
             {
-                "meeting/222": {"name": "name_SNLGsvIV"},
-                "agenda_item/22": {"meeting_id": 222, "comment": "test1"},
+                "agenda_item/22": {"meeting_id": 1, "comment": "test1"},
             },
             "agenda_item.sort",
-            {"meeting_id": 222, "tree": [{"id": 22}]},
+            {"meeting_id": 1, "tree": [{"id": 22}]},
+        )
+
+    def test_sort_permissions(self) -> None:
+        self.base_permission_test(
+            {
+                "agenda_item/22": {"meeting_id": 1, "comment": "test1"},
+            },
+            "agenda_item.sort",
+            {"meeting_id": 1, "tree": [{"id": 22}]},
+            Permissions.AgendaItem.CAN_MANAGE,
         )

--- a/tests/system/action/agenda_item/test_update.py
+++ b/tests/system/action/agenda_item/test_update.py
@@ -1,4 +1,5 @@
 from openslides_backend.models.models import AgendaItem
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -83,10 +84,9 @@ class AgendaItemActionTest(BaseActionTestCase):
         assert child_model.get("is_hidden") is True
         assert child_model.get("is_internal") is False
 
-    def test_permissions(self) -> None:
+    def test_update_no_permissions(self) -> None:
         self.base_permission_test(
             {
-                "meeting/1": {},
                 "topic/102": {"meeting_id": 1},
                 "agenda_item/111": {
                     "item_number": "101",
@@ -96,4 +96,19 @@ class AgendaItemActionTest(BaseActionTestCase):
             },
             "agenda_item.update",
             {"id": 111, "duration": 1200},
+        )
+
+    def test_update_permissions(self) -> None:
+        self.base_permission_test(
+            {
+                "topic/102": {"meeting_id": 1},
+                "agenda_item/111": {
+                    "item_number": "101",
+                    "duration": 600,
+                    "meeting_id": 1,
+                },
+            },
+            "agenda_item.update",
+            {"id": 111, "duration": 1200},
+            Permissions.AgendaItem.CAN_MANAGE,
         )

--- a/tests/system/action/assignment/test_create.py
+++ b/tests/system/action/assignment/test_create.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -141,12 +142,23 @@ class AssignmentCreateActionTest(BaseActionTestCase):
             response.json["message"],
         )
 
-    def test_permission(self) -> None:
+    def test_create_no_permission(self) -> None:
         self.base_permission_test(
-            {"meeting/110": {"name": "name_zvfbAjpZ"}},
+            {},
             "assignment.create",
             {
                 "title": "title_Xcdfgee",
-                "meeting_id": 110,
+                "meeting_id": 1,
             },
+        )
+
+    def test_create_permission(self) -> None:
+        self.base_permission_test(
+            {},
+            "assignment.create",
+            {
+                "title": "title_Xcdfgee",
+                "meeting_id": 1,
+            },
+            Permissions.Assignment.CAN_MANAGE,
         )

--- a/tests/system/action/assignment/test_delete.py
+++ b/tests/system/action/assignment/test_delete.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -52,12 +53,21 @@ class AssignmentDeleteActionTest(BaseActionTestCase):
         model = self.get_model("assignment/112")
         self.assertEqual(model.get("title"), "title_srtgb123")
 
-    def test_permission(self) -> None:
+    def test_delete_no_permission(self) -> None:
         self.base_permission_test(
             {
-                "meeting/110": {},
-                "assignment/111": {"meeting_id": 110, "title": "title_srtgb123"},
+                "assignment/111": {"meeting_id": 1, "title": "title_srtgb123"},
             },
             "assignment.delete",
             {"id": 111},
+        )
+
+    def test_delete_permission(self) -> None:
+        self.base_permission_test(
+            {
+                "assignment/111": {"meeting_id": 1, "title": "title_srtgb123"},
+            },
+            "assignment.delete",
+            {"id": 111},
+            Permissions.Assignment.CAN_MANAGE,
         )

--- a/tests/system/action/assignment/test_update.py
+++ b/tests/system/action/assignment/test_update.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -53,12 +54,21 @@ class AssignmentUpdateActionTest(BaseActionTestCase):
         model = self.get_model("assignment/111")
         assert model.get("title") == "title_srtgb123"
 
-    def test_permission(self) -> None:
+    def test_update_no_permission(self) -> None:
         self.base_permission_test(
             {
-                "meeting/110": {"name": "name_sdurqw12"},
-                "assignment/111": {"title": "title_srtgb123", "meeting_id": 110},
+                "assignment/111": {"title": "title_srtgb123", "meeting_id": 1},
             },
             "assignment.update",
             {"id": 111, "title": "title_Xcdfgee"},
+        )
+
+    def test_update_permission(self) -> None:
+        self.base_permission_test(
+            {
+                "assignment/111": {"title": "title_srtgb123", "meeting_id": 1},
+            },
+            "assignment.update",
+            {"id": 111, "title": "title_Xcdfgee"},
+            Permissions.Assignment.CAN_MANAGE,
         )

--- a/tests/system/action/group/test_create.py
+++ b/tests/system/action/group/test_create.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -56,7 +57,15 @@ class GroupCreateActionTest(BaseActionTestCase):
 
     def test_create_no_permissions(self) -> None:
         self.base_permission_test(
-            {"meeting/22": {"name": "name_vJxebUwo"}},
+            {},
             "group.create",
-            {"name": "test_Xcdfgee", "meeting_id": 22},
+            {"name": "test_Xcdfgee", "meeting_id": 1},
+        )
+
+    def test_create_check_permission(self) -> None:
+        self.base_permission_test(
+            {},
+            "group.create",
+            {"name": "test_Xcdfgee", "meeting_id": 1},
+            Permissions.User.CAN_MANAGE,
         )

--- a/tests/system/action/group/test_delete.py
+++ b/tests/system/action/group/test_delete.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -85,9 +86,18 @@ class GroupDeleteActionTest(BaseActionTestCase):
     def test_delete_no_permissions(self) -> None:
         self.base_permission_test(
             {
-                "meeting/22": {"name": "name_meeting_22", "group_ids": [111]},
-                "group/111": {"name": "name_srtgb123", "meeting_id": 22},
+                "group/111": {"name": "name_srtgb123", "meeting_id": 1},
             },
             "group.delete",
             {"id": 111},
+        )
+
+    def test_delete_permissions(self) -> None:
+        self.base_permission_test(
+            {
+                "group/111": {"name": "name_srtgb123", "meeting_id": 1},
+            },
+            "group.delete",
+            {"id": 111},
+            Permissions.User.CAN_MANAGE,
         )

--- a/tests/system/action/group/test_set_permission.py
+++ b/tests/system/action/group/test_set_permission.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -88,7 +89,6 @@ class GroupSetPermissionActionTest(BaseActionTestCase):
     def test_set_permissions_no_permissions(self) -> None:
         self.base_permission_test(
             {
-                "meeting/1": {},
                 "group/11": {
                     "name": "group_11",
                     "permissions": ["agenda_item.can_manage", "motion.can_create"],
@@ -97,4 +97,18 @@ class GroupSetPermissionActionTest(BaseActionTestCase):
             },
             "group.set_permission",
             {"id": 11, "permission": "projector.can_see", "set": True},
+        )
+
+    def test_set_permissions_permissions(self) -> None:
+        self.base_permission_test(
+            {
+                "group/11": {
+                    "name": "group_11",
+                    "permissions": ["agenda_item.can_manage", "motion.can_create"],
+                    "meeting_id": 1,
+                },
+            },
+            "group.set_permission",
+            {"id": 11, "permission": "projector.can_see", "set": True},
+            Permissions.User.CAN_MANAGE,
         )

--- a/tests/system/action/group/test_update.py
+++ b/tests/system/action/group/test_update.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -29,9 +30,18 @@ class GroupUpdateActionTest(BaseActionTestCase):
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
             {
-                "meeting/1": {},
                 "group/111": {"name": "name_srtgb123", "meeting_id": 1},
             },
             "group.update",
             {"id": 111, "name": "name_Xcdfgee"},
+        )
+
+    def test_update_permissions(self) -> None:
+        self.base_permission_test(
+            {
+                "group/111": {"name": "name_srtgb123", "meeting_id": 1},
+            },
+            "group.update",
+            {"id": 111, "name": "name_Xcdfgee"},
+            Permissions.User.CAN_MANAGE,
         )

--- a/tests/system/action/motion_block/test_create.py
+++ b/tests/system/action/motion_block/test_create.py
@@ -1,4 +1,5 @@
 from openslides_backend.models.models import AgendaItem
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -49,9 +50,17 @@ class MotionBlockActionTest(BaseActionTestCase):
             response.json["message"],
         )
 
-    def test_permissions(self) -> None:
+    def test_create_no_permissions(self) -> None:
         self.base_permission_test(
-            {"meeting/42": {"name": "test", "agenda_item_creation": "always"}},
+            {"meeting/1": {"name": "test", "agenda_item_creation": "always"}},
             "motion_block.create",
-            {"title": "test_Xcdfgee", "meeting_id": 42},
+            {"title": "test_Xcdfgee", "meeting_id": 1},
+        )
+
+    def test_create_permissions(self) -> None:
+        self.base_permission_test(
+            {"meeting/1": {"name": "test", "agenda_item_creation": "always"}},
+            "motion_block.create",
+            {"title": "test_Xcdfgee", "meeting_id": 1},
+            Permissions.Motion.CAN_MANAGE,
         )

--- a/tests/system/action/motion_block/test_delete.py
+++ b/tests/system/action/motion_block/test_delete.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -41,9 +42,17 @@ class MotionBlockActionTest(BaseActionTestCase):
         self.assert_model_deleted("agenda_item/333")
         self.assert_model_deleted("list_of_speakers/222")
 
-    def test_permissions(self) -> None:
+    def test_delete_no_permissions(self) -> None:
         self.base_permission_test(
-            {"meeting/11": {}, "motion_block/111": {"meeting_id": 11}},
+            {"motion_block/111": {"meeting_id": 1}},
             "motion_block.delete",
             {"id": 111},
+        )
+
+    def test_delete_permissions(self) -> None:
+        self.base_permission_test(
+            {"motion_block/111": {"meeting_id": 1}},
+            "motion_block.delete",
+            {"id": 111},
+            Permissions.Motion.CAN_MANAGE,
         )

--- a/tests/system/action/motion_block/test_update.py
+++ b/tests/system/action/motion_block/test_update.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -31,12 +32,21 @@ class MotionBlockActionTest(BaseActionTestCase):
         model = self.get_model("motion_block/111")
         assert model.get("title") == "title_srtgb123"
 
-    def test_permissions(self) -> None:
+    def test_update_no_permissions(self) -> None:
         self.base_permission_test(
             {
-                "meeting/11": {},
-                "motion_block/111": {"meeting_id": 11, "title": "title_srtgb123"},
+                "motion_block/111": {"meeting_id": 1, "title": "title_srtgb123"},
             },
             "motion_block.update",
             {"id": 111, "title": "title_Xcdfgee"},
+        )
+
+    def test_update_permissions(self) -> None:
+        self.base_permission_test(
+            {
+                "motion_block/111": {"meeting_id": 1, "title": "title_srtgb123"},
+            },
+            "motion_block.update",
+            {"id": 111, "title": "title_Xcdfgee"},
+            Permissions.Motion.CAN_MANAGE,
         )

--- a/tests/system/action/motion_workflow/test_create.py
+++ b/tests/system/action/motion_workflow/test_create.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -64,7 +65,15 @@ class MotionWorkflowSystemTest(BaseActionTestCase):
 
     def test_create_no_permissions(self) -> None:
         self.base_permission_test(
-            {"meeting/42": {"name": "test_name_fsdksjdfhdsfssdf"}},
+            {},
             "motion_workflow.create",
-            {"name": "test_Xcdfgee", "meeting_id": 42},
+            {"name": "test_Xcdfgee", "meeting_id": 1},
+        )
+
+    def test_create_permissions(self) -> None:
+        self.base_permission_test(
+            {},
+            "motion_workflow.create",
+            {"name": "test_Xcdfgee", "meeting_id": 1},
+            Permissions.Motion.CAN_MANAGE,
         )

--- a/tests/system/action/motion_workflow/test_delete.py
+++ b/tests/system/action/motion_workflow/test_delete.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -123,15 +124,32 @@ class MotionWorkflowSystemTest(BaseActionTestCase):
     def test_delete_no_permissions(self) -> None:
         self.base_permission_test(
             {
-                "meeting/90": {
+                "meeting/1": {
                     "name": "name_testtest",
                     "motions_default_workflow_id": 12,
                     "motions_default_statute_amendment_workflow_id": 13,
                     "motion_workflow_ids": [111, 2],
                 },
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 90},
-                "motion_workflow/2": {"meeting_id": 90},
+                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 1},
+                "motion_workflow/2": {"meeting_id": 1},
             },
             "motion_workflow.delete",
             {"id": 111},
+        )
+
+    def test_delete_permissions(self) -> None:
+        self.base_permission_test(
+            {
+                "meeting/1": {
+                    "name": "name_testtest",
+                    "motions_default_workflow_id": 12,
+                    "motions_default_statute_amendment_workflow_id": 13,
+                    "motion_workflow_ids": [111, 2],
+                },
+                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 1},
+                "motion_workflow/2": {"meeting_id": 1},
+            },
+            "motion_workflow.delete",
+            {"id": 111},
+            Permissions.Motion.CAN_MANAGE,
         )

--- a/tests/system/action/motion_workflow/test_update.py
+++ b/tests/system/action/motion_workflow/test_update.py
@@ -1,3 +1,4 @@
+from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -34,9 +35,18 @@ class MotionWorkflowSystemTest(BaseActionTestCase):
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
             {
-                "meeting/10": {},
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 10},
+                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 1},
             },
             "motion_workflow.update",
             {"id": 111, "name": "name_Xcdfgee"},
+        )
+
+    def test_update_permissions(self) -> None:
+        self.base_permission_test(
+            {
+                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 1},
+            },
+            "motion_workflow.update",
+            {"id": 111, "name": "name_Xcdfgee"},
+            Permissions.Motion.CAN_MANAGE,
         )


### PR DESCRIPTION
Add another way to call the base_permission_test.
Two tests should be done:
1. user with group (belong to meeting) but no permission and check 403 and Missing permission in msg.
2. user with group with permission and check 200.
