### PR TITLE
Add permissions for personal notes

### DIFF
--- a/openslides_backend/action/actions/personal_note/delete.py
+++ b/openslides_backend/action/actions/personal_note/delete.py
@@ -6,10 +6,11 @@ from ....shared.patterns import FullQualifiedId
 from ...generics.delete import DeleteAction
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
+from .mixins import PermissionMixin
 
 
 @register_action("personal_note.delete")
-class PersonalNoteDeleteAction(DeleteAction):
+class PersonalNoteDeleteAction(DeleteAction, PermissionMixin):
     """
     Action to delete a personal note.
     """
@@ -28,3 +29,7 @@ class PersonalNoteDeleteAction(DeleteAction):
         if self.user_id != personal_note.get("user_id"):
             raise ActionException("Cannot delete not owned personal note.")
         return instance
+
+    def check_permissions(self, instance: Dict[str, Any]) -> None:
+        meeting_id = self.get_meeting_id(instance)
+        self.check_anonymous_and_user_in_meeting(meeting_id)

--- a/openslides_backend/action/actions/personal_note/delete.py
+++ b/openslides_backend/action/actions/personal_note/delete.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from ....models.models import PersonalNote
-from ....shared.exceptions import ActionException
+from ....shared.exceptions import PermissionDenied
 from ....shared.patterns import FullQualifiedId
 from ...generics.delete import DeleteAction
 from ...util.default_schema import DefaultSchema
@@ -18,18 +18,12 @@ class PersonalNoteDeleteAction(DeleteAction, PermissionMixin):
     model = PersonalNote()
     schema = DefaultSchema(PersonalNote()).get_delete_schema()
 
-    def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Compare item user_id to self.user_id
-        """
+    def check_permissions(self, instance: Dict[str, Any]) -> None:
+        meeting_id = self.get_meeting_id(instance)
+        self.check_anonymous_and_user_in_meeting(meeting_id)
         personal_note = self.datastore.get(
             FullQualifiedId(self.model.collection, instance["id"]),
             ["user_id"],
         )
         if self.user_id != personal_note.get("user_id"):
-            raise ActionException("Cannot delete not owned personal note.")
-        return instance
-
-    def check_permissions(self, instance: Dict[str, Any]) -> None:
-        meeting_id = self.get_meeting_id(instance)
-        self.check_anonymous_and_user_in_meeting(meeting_id)
+            raise PermissionDenied("Cannot delete not owned personal note.")

--- a/openslides_backend/action/actions/personal_note/mixins.py
+++ b/openslides_backend/action/actions/personal_note/mixins.py
@@ -1,0 +1,15 @@
+from ....shared.exceptions import PermissionDenied
+from ....shared.patterns import Collection, FullQualifiedId
+from ...action import Action
+
+
+class PermissionMixin(Action):
+    def check_anonymous_and_user_in_meeting(self, meeting_id: int) -> None:
+        if self.auth.is_anonymous(self.user_id):
+            raise PermissionDenied("Can't create personal note for anonymous")
+
+        user = self.datastore.get(
+            FullQualifiedId(Collection("user"), self.user_id), ["meeting_ids"]
+        )
+        if meeting_id not in user.get("meeting_ids", []):
+            raise PermissionDenied("User not associated with meeting.")

--- a/openslides_backend/action/actions/personal_note/mixins.py
+++ b/openslides_backend/action/actions/personal_note/mixins.py
@@ -6,7 +6,7 @@ from ...action import Action
 class PermissionMixin(Action):
     def check_anonymous_and_user_in_meeting(self, meeting_id: int) -> None:
         if self.auth.is_anonymous(self.user_id):
-            raise PermissionDenied("Can't create personal note for anonymous")
+            raise PermissionDenied(f"Anonymous user cannot do {self.name}.")
 
         user = self.datastore.get(
             FullQualifiedId(Collection("user"), self.user_id), ["meeting_ids"]

--- a/openslides_backend/action/actions/personal_note/update.py
+++ b/openslides_backend/action/actions/personal_note/update.py
@@ -6,10 +6,11 @@ from ....shared.patterns import FullQualifiedId
 from ...generics.update import UpdateAction
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
+from .mixins import PermissionMixin
 
 
 @register_action("personal_note.update")
-class PersonalNoteUpdateAction(UpdateAction):
+class PersonalNoteUpdateAction(UpdateAction, PermissionMixin):
     """
     Action to update a personal note.
     """
@@ -30,3 +31,7 @@ class PersonalNoteUpdateAction(UpdateAction):
         if self.user_id != personal_note.get("user_id"):
             raise ActionException("Cannot change not owned personal note.")
         return instance
+
+    def check_permissions(self, instance: Dict[str, Any]) -> None:
+        meeting_id = self.get_meeting_id(instance)
+        self.check_anonymous_and_user_in_meeting(meeting_id)

--- a/openslides_backend/action/actions/personal_note/update.py
+++ b/openslides_backend/action/actions/personal_note/update.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 
 from ....models.models import PersonalNote
-from ....shared.exceptions import ActionException
+from ....shared.exceptions import PermissionDenied
 from ....shared.patterns import FullQualifiedId
 from ...generics.update import UpdateAction
 from ...util.default_schema import DefaultSchema
@@ -20,18 +20,12 @@ class PersonalNoteUpdateAction(UpdateAction, PermissionMixin):
         optional_properties=["star", "note"]
     )
 
-    def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Compare item user_id to self.user_id
-        """
+    def check_permissions(self, instance: Dict[str, Any]) -> None:
+        meeting_id = self.get_meeting_id(instance)
+        self.check_anonymous_and_user_in_meeting(meeting_id)
         personal_note = self.datastore.get(
             FullQualifiedId(self.model.collection, instance["id"]),
             ["user_id"],
         )
         if self.user_id != personal_note.get("user_id"):
-            raise ActionException("Cannot change not owned personal note.")
-        return instance
-
-    def check_permissions(self, instance: Dict[str, Any]) -> None:
-        meeting_id = self.get_meeting_id(instance)
-        self.check_anonymous_and_user_in_meeting(meeting_id)
+            raise PermissionDenied("Cannot change not owned personal note.")

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -156,6 +156,7 @@ class User(Model):
         replacement="meeting_id",
         to={Collection("user"): "vote_delegated_$_to_id"},
     )
+    meeting_ids = fields.NumberArrayField(read_only=True)
 
 
 class Resource(Model):

--- a/tests/system/action/personal_note/test_create.py
+++ b/tests/system/action/personal_note/test_create.py
@@ -3,6 +3,7 @@ from tests.system.action.base import BaseActionTestCase
 
 class PersonalNoteCreateActionTest(BaseActionTestCase):
     def test_create(self) -> None:
+        # checks permissions too.
         self.set_models(
             {
                 "meeting/110": {"name": "name_meeting_110"},
@@ -69,4 +70,37 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
         self.assertIn(
             "(user_id, content_object_id) must be unique.",
             response.json["message"],
+        )
+
+    def test_create_no_permission_user_not_in_meeting(self) -> None:
+        self.set_models(
+            {
+                "meeting/110": {"name": "name_meeting_110"},
+                "motion/23": {"meeting_id": 110},
+                "user/1": {"meeting_ids": []},
+            }
+        )
+        response = self.request(
+            "personal_note.create", {"content_object_id": "motion/23", "star": True}
+        )
+        self.assert_status_code(response, 403)
+        assert "User not associated with meeting." in response.json["message"]
+
+    def test_create_no_permission_anon_user(self) -> None:
+        self.set_models(
+            {
+                "meeting/110": {"name": "name_meeting_110"},
+                "motion/23": {"meeting_id": 110},
+                "user/1": {"meeting_ids": [110]},
+            }
+        )
+        self.set_anonymous(meeting_id=110)
+        response = self.request(
+            "personal_note.create",
+            {"content_object_id": "motion/23", "star": True},
+            anonymous=True,
+        )
+        self.assert_status_code(response, 403)
+        assert (
+            "Anonymous user cannot do personal_note.create." in response.json["message"]
         )

--- a/tests/system/action/personal_note/test_create.py
+++ b/tests/system/action/personal_note/test_create.py
@@ -43,9 +43,9 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
         )
 
     def test_create_not_unique(self) -> None:
-        self.set_models(self.test_models)
         self.set_models(
             {
+                **self.test_models,
                 "personal_note/1": {
                     "star": True,
                     "note": "blablabla",
@@ -68,12 +68,8 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
         )
 
     def test_create_no_permission_user_not_in_meeting(self) -> None:
+        self.test_models["user/1"]["meeting_ids"] = []
         self.set_models(self.test_models)
-        self.set_models(
-            {
-                "user/1": {"meeting_ids": []},
-            }
-        )
         response = self.request(
             "personal_note.create", {"content_object_id": "motion/23", "star": True}
         )

--- a/tests/system/action/personal_note/test_create.py
+++ b/tests/system/action/personal_note/test_create.py
@@ -6,15 +6,14 @@ from tests.system.action.base import BaseActionTestCase
 class PersonalNoteCreateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.test_model: Dict[str, Dict[str, Any]] = {
+        self.test_models: Dict[str, Dict[str, Any]] = {
             "meeting/110": {"name": "name_meeting_110"},
             "motion/23": {"meeting_id": 110},
             "user/1": {"meeting_ids": [110]},
         }
 
     def test_create(self) -> None:
-        # checks permissions too.
-        self.set_models(self.test_model)
+        self.set_models(self.test_models)
         response = self.request(
             "personal_note.create", {"content_object_id": "motion/23", "star": True}
         )
@@ -33,7 +32,7 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
         )
 
     def test_create_no_star_and_no_html(self) -> None:
-        self.set_models(self.test_model)
+        self.set_models(self.test_models)
         response = self.request(
             "personal_note.create", {"content_object_id": "motion/23"}
         )
@@ -44,13 +43,17 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
         )
 
     def test_create_not_unique(self) -> None:
-        self.test_model["personal_note/1"] = {
-            "star": True,
-            "note": "blablabla",
-            "user_id": 1,
-            "content_object_id": "motion/23",
-        }
-        self.set_models(self.test_model)
+        self.set_models(self.test_models)
+        self.set_models(
+            {
+                "personal_note/1": {
+                    "star": True,
+                    "note": "blablabla",
+                    "user_id": 1,
+                    "content_object_id": "motion/23",
+                },
+            }
+        )
         response = self.request(
             "personal_note.create",
             {
@@ -65,8 +68,12 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
         )
 
     def test_create_no_permission_user_not_in_meeting(self) -> None:
-        self.test_model["user/1"]["meeting_ids"] = []
-        self.set_models(self.test_model)
+        self.set_models(self.test_models)
+        self.set_models(
+            {
+                "user/1": {"meeting_ids": []},
+            }
+        )
         response = self.request(
             "personal_note.create", {"content_object_id": "motion/23", "star": True}
         )
@@ -74,7 +81,7 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
         assert "User not associated with meeting." in response.json["message"]
 
     def test_create_no_permission_anon_user(self) -> None:
-        self.set_models(self.test_model)
+        self.set_models(self.test_models)
         self.set_anonymous(meeting_id=110)
         response = self.request(
             "personal_note.create",

--- a/tests/system/action/personal_note/test_create.py
+++ b/tests/system/action/personal_note/test_create.py
@@ -7,6 +7,7 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
             {
                 "meeting/110": {"name": "name_meeting_110"},
                 "motion/23": {"meeting_id": 110},
+                "user/1": {"meeting_ids": [110]},
             }
         )
         response = self.request(
@@ -31,6 +32,7 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
             {
                 "meeting/110": {"name": "name_meeting_110"},
                 "motion/23": {"meeting_id": 110},
+                "user/1": {"meeting_ids": [110]},
             }
         )
         response = self.request(
@@ -53,6 +55,7 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
                     "user_id": 1,
                     "content_object_id": "motion/23",
                 },
+                "user/1": {"meeting_ids": [110]},
             }
         )
         response = self.request(

--- a/tests/system/action/personal_note/test_create.py
+++ b/tests/system/action/personal_note/test_create.py
@@ -1,16 +1,20 @@
+from typing import Any, Dict
+
 from tests.system.action.base import BaseActionTestCase
 
 
 class PersonalNoteCreateActionTest(BaseActionTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_model: Dict[str, Dict[str, Any]] = {
+            "meeting/110": {"name": "name_meeting_110"},
+            "motion/23": {"meeting_id": 110},
+            "user/1": {"meeting_ids": [110]},
+        }
+
     def test_create(self) -> None:
         # checks permissions too.
-        self.set_models(
-            {
-                "meeting/110": {"name": "name_meeting_110"},
-                "motion/23": {"meeting_id": 110},
-                "user/1": {"meeting_ids": [110]},
-            }
-        )
+        self.set_models(self.test_model)
         response = self.request(
             "personal_note.create", {"content_object_id": "motion/23", "star": True}
         )
@@ -29,13 +33,7 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
         )
 
     def test_create_no_star_and_no_html(self) -> None:
-        self.set_models(
-            {
-                "meeting/110": {"name": "name_meeting_110"},
-                "motion/23": {"meeting_id": 110},
-                "user/1": {"meeting_ids": [110]},
-            }
-        )
+        self.set_models(self.test_model)
         response = self.request(
             "personal_note.create", {"content_object_id": "motion/23"}
         )
@@ -46,19 +44,13 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
         )
 
     def test_create_not_unique(self) -> None:
-        self.set_models(
-            {
-                "meeting/110": {"name": "name_meeting_110"},
-                "motion/23": {"meeting_id": 110},
-                "personal_note/1": {
-                    "star": True,
-                    "note": "blablabla",
-                    "user_id": 1,
-                    "content_object_id": "motion/23",
-                },
-                "user/1": {"meeting_ids": [110]},
-            }
-        )
+        self.test_model["personal_note/1"] = {
+            "star": True,
+            "note": "blablabla",
+            "user_id": 1,
+            "content_object_id": "motion/23",
+        }
+        self.set_models(self.test_model)
         response = self.request(
             "personal_note.create",
             {
@@ -73,13 +65,8 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
         )
 
     def test_create_no_permission_user_not_in_meeting(self) -> None:
-        self.set_models(
-            {
-                "meeting/110": {"name": "name_meeting_110"},
-                "motion/23": {"meeting_id": 110},
-                "user/1": {"meeting_ids": []},
-            }
-        )
+        self.test_model["user/1"]["meeting_ids"] = []
+        self.set_models(self.test_model)
         response = self.request(
             "personal_note.create", {"content_object_id": "motion/23", "star": True}
         )
@@ -87,13 +74,7 @@ class PersonalNoteCreateActionTest(BaseActionTestCase):
         assert "User not associated with meeting." in response.json["message"]
 
     def test_create_no_permission_anon_user(self) -> None:
-        self.set_models(
-            {
-                "meeting/110": {"name": "name_meeting_110"},
-                "motion/23": {"meeting_id": 110},
-                "user/1": {"meeting_ids": [110]},
-            }
-        )
+        self.set_models(self.test_model)
         self.set_anonymous(meeting_id=110)
         response = self.request(
             "personal_note.create",

--- a/tests/system/action/personal_note/test_delete.py
+++ b/tests/system/action/personal_note/test_delete.py
@@ -49,7 +49,7 @@ class PersonalNoteDeleteActionTest(BaseActionTestCase):
             }
         )
         response = self.request("personal_note.delete", {"id": 1})
-        self.assert_status_code(response, 400)
+        self.assert_status_code(response, 403)
         self.assertIn(
             "Cannot delete not owned personal note.", response.json["message"]
         )

--- a/tests/system/action/personal_note/test_delete.py
+++ b/tests/system/action/personal_note/test_delete.py
@@ -9,6 +9,7 @@ class PersonalNoteDeleteActionTest(BaseActionTestCase):
                 "user/1": {
                     "personal_note_$111_ids": [1],
                     "personal_note_$_ids": ["111"],
+                    "meeting_ids": [111],
                 },
                 "personal_note/1": {
                     "star": True,
@@ -39,6 +40,7 @@ class PersonalNoteDeleteActionTest(BaseActionTestCase):
                     "user_id": 2,
                     "meeting_id": 111,
                 },
+                "user/1": {"meeting_ids": [111]},
             }
         )
         response = self.request("personal_note.delete", {"id": 1})

--- a/tests/system/action/personal_note/test_delete.py
+++ b/tests/system/action/personal_note/test_delete.py
@@ -56,8 +56,8 @@ class PersonalNoteDeleteActionTest(BaseActionTestCase):
         self.assert_model_exists("personal_note/1")
 
     def test_delete_no_permission_user_not_in_meeting(self) -> None:
+        self.test_models["user/1"]["meeting_ids"] = []
         self.set_models(self.test_models)
-        self.set_models({"user/1": {"meeting_ids": []}})
         response = self.request("personal_note.delete", {"id": 1})
         self.assert_status_code(response, 403)
         assert "User not associated with meeting." in response.json["message"]

--- a/tests/system/action/personal_note/test_delete.py
+++ b/tests/system/action/personal_note/test_delete.py
@@ -1,25 +1,29 @@
+from typing import Any, Dict
+
 from tests.system.action.base import BaseActionTestCase
 
 
 class PersonalNoteDeleteActionTest(BaseActionTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_model: Dict[str, Dict[str, Any]] = {
+            "meeting/111": {"personal_note_ids": [1]},
+            "user/1": {
+                "personal_note_$111_ids": [1],
+                "personal_note_$_ids": ["111"],
+                "meeting_ids": [111],
+            },
+            "personal_note/1": {
+                "star": True,
+                "note": "blablabla",
+                "user_id": 1,
+                "meeting_id": 111,
+            },
+        }
+
     def test_delete_correct(self) -> None:
         # checks permissions too.
-        self.set_models(
-            {
-                "meeting/111": {"personal_note_ids": [1]},
-                "user/1": {
-                    "personal_note_$111_ids": [1],
-                    "personal_note_$_ids": ["111"],
-                    "meeting_ids": [111],
-                },
-                "personal_note/1": {
-                    "star": True,
-                    "note": "blablabla",
-                    "user_id": 1,
-                    "meeting_id": 111,
-                },
-            }
-        )
+        self.set_models(self.test_model)
         response = self.request("personal_note.delete", {"id": 1})
         self.assert_status_code(response, 200)
         self.assert_model_deleted("personal_note/1")
@@ -52,43 +56,14 @@ class PersonalNoteDeleteActionTest(BaseActionTestCase):
         self.assert_model_exists("personal_note/1")
 
     def test_delete_no_permission_user_not_in_meeting(self) -> None:
-        self.set_models(
-            {
-                "meeting/111": {"personal_note_ids": [1]},
-                "user/1": {
-                    "personal_note_$111_ids": [1],
-                    "personal_note_$_ids": ["111"],
-                    "meeting_ids": [],
-                },
-                "personal_note/1": {
-                    "star": True,
-                    "note": "blablabla",
-                    "user_id": 1,
-                    "meeting_id": 111,
-                },
-            }
-        )
+        self.test_model["user/1"]["meeting_ids"] = []
+        self.set_models(self.test_model)
         response = self.request("personal_note.delete", {"id": 1})
         self.assert_status_code(response, 403)
         assert "User not associated with meeting." in response.json["message"]
 
     def test_delete_no_permission_anon_user(self) -> None:
-        self.set_models(
-            {
-                "meeting/111": {"personal_note_ids": [1]},
-                "user/1": {
-                    "personal_note_$111_ids": [1],
-                    "personal_note_$_ids": ["111"],
-                    "meeting_ids": [1],
-                },
-                "personal_note/1": {
-                    "star": True,
-                    "note": "blablabla",
-                    "user_id": 1,
-                    "meeting_id": 111,
-                },
-            }
-        )
+        self.set_models(self.test_model)
         self.set_anonymous(meeting_id=111)
         response = self.request(
             "personal_note.delete",

--- a/tests/system/action/personal_note/test_delete.py
+++ b/tests/system/action/personal_note/test_delete.py
@@ -6,7 +6,7 @@ from tests.system.action.base import BaseActionTestCase
 class PersonalNoteDeleteActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.test_model: Dict[str, Dict[str, Any]] = {
+        self.test_models: Dict[str, Dict[str, Any]] = {
             "meeting/111": {"personal_note_ids": [1]},
             "user/1": {
                 "personal_note_$111_ids": [1],
@@ -23,7 +23,7 @@ class PersonalNoteDeleteActionTest(BaseActionTestCase):
 
     def test_delete_correct(self) -> None:
         # checks permissions too.
-        self.set_models(self.test_model)
+        self.set_models(self.test_models)
         response = self.request("personal_note.delete", {"id": 1})
         self.assert_status_code(response, 200)
         self.assert_model_deleted("personal_note/1")
@@ -56,14 +56,14 @@ class PersonalNoteDeleteActionTest(BaseActionTestCase):
         self.assert_model_exists("personal_note/1")
 
     def test_delete_no_permission_user_not_in_meeting(self) -> None:
-        self.test_model["user/1"]["meeting_ids"] = []
-        self.set_models(self.test_model)
+        self.set_models(self.test_models)
+        self.set_models({"user/1": {"meeting_ids": []}})
         response = self.request("personal_note.delete", {"id": 1})
         self.assert_status_code(response, 403)
         assert "User not associated with meeting." in response.json["message"]
 
     def test_delete_no_permission_anon_user(self) -> None:
-        self.set_models(self.test_model)
+        self.set_models(self.test_models)
         self.set_anonymous(meeting_id=111)
         response = self.request(
             "personal_note.delete",

--- a/tests/system/action/personal_note/test_update.py
+++ b/tests/system/action/personal_note/test_update.py
@@ -3,8 +3,17 @@ from tests.system.action.base import BaseActionTestCase
 
 class PersonalNoteUpdateActionTest(BaseActionTestCase):
     def test_update_correct(self) -> None:
-        self.create_model(
-            "personal_note/1", {"star": True, "note": "blablabla", "user_id": 1}
+        self.set_models(
+            {
+                "meeting/1": {},
+                "personal_note/1": {
+                    "star": True,
+                    "note": "blablabla",
+                    "user_id": 1,
+                    "meeting_id": 1,
+                },
+                "user/1": {"meeting_ids": [1]},
+            }
         )
         response = self.request(
             "personal_note.update", {"id": 1, "star": False, "note": "blopblop"}
@@ -15,8 +24,12 @@ class PersonalNoteUpdateActionTest(BaseActionTestCase):
         assert model.get("note") == "blopblop"
 
     def test_update_wrong_user(self) -> None:
-        self.create_model(
-            "personal_note/1", {"star": True, "note": "blablabla", "user_id": 2}
+        self.set_models(
+            {
+                "meeting/1": {},
+                "personal_note/1": {"star": True, "note": "blablabla", "user_id": 2},
+                "user/1": {"meeting_ids": [1]},
+            }
         )
         response = self.request(
             "personal_note.update", {"id": 1, "star": False, "note": "blopblop"}

--- a/tests/system/action/personal_note/test_update.py
+++ b/tests/system/action/personal_note/test_update.py
@@ -40,8 +40,8 @@ class PersonalNoteUpdateActionTest(BaseActionTestCase):
         )
 
     def test_update_no_permission_user_not_in_meeting(self) -> None:
+        self.test_models["user/1"]["meeting_ids"] = []
         self.set_models(self.test_models)
-        self.set_models({"user/1": {"meeting_ids": []}})
         response = self.request(
             "personal_note.update", {"id": 1, "star": False, "note": "blopblop"}
         )

--- a/tests/system/action/personal_note/test_update.py
+++ b/tests/system/action/personal_note/test_update.py
@@ -6,7 +6,7 @@ from tests.system.action.base import BaseActionTestCase
 class PersonalNoteUpdateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.test_model: Dict[str, Dict[str, Any]] = {
+        self.test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {},
             "personal_note/1": {
                 "star": True,
@@ -19,7 +19,7 @@ class PersonalNoteUpdateActionTest(BaseActionTestCase):
 
     def test_update_correct(self) -> None:
         # checks permissions too.
-        self.set_models(self.test_model)
+        self.set_models(self.test_models)
         response = self.request(
             "personal_note.update", {"id": 1, "star": False, "note": "blopblop"}
         )
@@ -29,8 +29,8 @@ class PersonalNoteUpdateActionTest(BaseActionTestCase):
         assert model.get("note") == "blopblop"
 
     def test_update_wrong_user(self) -> None:
-        self.test_model["personal_note/1"]["user_id"] = 2
-        self.set_models(self.test_model)
+        self.set_models(self.test_models)
+        self.set_models({"personal_note/1": {"user_id": 2}})
         response = self.request(
             "personal_note.update", {"id": 1, "star": False, "note": "blopblop"}
         )
@@ -40,8 +40,8 @@ class PersonalNoteUpdateActionTest(BaseActionTestCase):
         )
 
     def test_update_no_permission_user_not_in_meeting(self) -> None:
-        self.test_model["user/1"]["meeting_ids"] = []
-        self.set_models(self.test_model)
+        self.set_models(self.test_models)
+        self.set_models({"user/1": {"meeting_ids": []}})
         response = self.request(
             "personal_note.update", {"id": 1, "star": False, "note": "blopblop"}
         )
@@ -49,7 +49,7 @@ class PersonalNoteUpdateActionTest(BaseActionTestCase):
         assert "User not associated with meeting." in response.json["message"]
 
     def test_create_no_permission_anon_user(self) -> None:
-        self.set_models(self.test_model)
+        self.set_models(self.test_models)
         self.set_anonymous()
         response = self.request(
             "personal_note.update",

--- a/tests/system/action/personal_note/test_update.py
+++ b/tests/system/action/personal_note/test_update.py
@@ -34,7 +34,7 @@ class PersonalNoteUpdateActionTest(BaseActionTestCase):
         response = self.request(
             "personal_note.update", {"id": 1, "star": False, "note": "blopblop"}
         )
-        self.assert_status_code(response, 400)
+        self.assert_status_code(response, 403)
         self.assertIn(
             "Cannot change not owned personal note.", response.json["message"]
         )

--- a/tests/system/action/personal_note/test_update.py
+++ b/tests/system/action/personal_note/test_update.py
@@ -3,6 +3,7 @@ from tests.system.action.base import BaseActionTestCase
 
 class PersonalNoteUpdateActionTest(BaseActionTestCase):
     def test_update_correct(self) -> None:
+        # checks permissions too.
         self.set_models(
             {
                 "meeting/1": {},
@@ -27,7 +28,12 @@ class PersonalNoteUpdateActionTest(BaseActionTestCase):
         self.set_models(
             {
                 "meeting/1": {},
-                "personal_note/1": {"star": True, "note": "blablabla", "user_id": 2},
+                "personal_note/1": {
+                    "star": True,
+                    "note": "blablabla",
+                    "user_id": 2,
+                    "meeting_id": 1,
+                },
                 "user/1": {"meeting_ids": [1]},
             }
         )
@@ -37,4 +43,47 @@ class PersonalNoteUpdateActionTest(BaseActionTestCase):
         self.assert_status_code(response, 400)
         self.assertIn(
             "Cannot change not owned personal note.", response.json["message"]
+        )
+
+    def test_update_no_permission_user_not_in_meeting(self) -> None:
+        self.set_models(
+            {
+                "meeting/1": {},
+                "personal_note/1": {
+                    "star": True,
+                    "note": "blablabla",
+                    "user_id": 1,
+                    "meeting_id": 1,
+                },
+                "user/1": {"meeting_ids": []},
+            }
+        )
+        response = self.request(
+            "personal_note.update", {"id": 1, "star": False, "note": "blopblop"}
+        )
+        self.assert_status_code(response, 403)
+        assert "User not associated with meeting." in response.json["message"]
+
+    def test_create_no_permission_anon_user(self) -> None:
+        self.set_models(
+            {
+                "meeting/1": {},
+                "personal_note/1": {
+                    "star": True,
+                    "note": "blablabla",
+                    "user_id": 1,
+                    "meeting_id": 1,
+                },
+                "user/1": {"meeting_ids": [1]},
+            }
+        )
+        self.set_anonymous()
+        response = self.request(
+            "personal_note.update",
+            {"id": 1, "star": False, "note": "blopblop"},
+            anonymous=True,
+        )
+        self.assert_status_code(response, 403)
+        assert (
+            "Anonymous user cannot do personal_note.update." in response.json["message"]
         )


### PR DESCRIPTION
Add meeting_ids to models. Generate models is not working at the moment, so just pick only the needed field.
Add some tests for no permissions, the permission allowed test is the default create/update/delete test.