### PR TITLE
Add permissions to meeting.create and meeting.delete. Add tests.

### DIFF
--- a/openslides_backend/action/actions/committee/update.py
+++ b/openslides_backend/action/actions/committee/update.py
@@ -5,9 +5,11 @@ from ....permissions.management_levels import (
     CommitteeManagementLevel,
     OrganisationManagementLevel,
 )
-from ....permissions.permission_helper import has_organisation_management_level
+from ....permissions.permission_helper import (
+    has_committee_management_level,
+    has_organisation_management_level,
+)
 from ....shared.exceptions import MissingPermission, PermissionDenied
-from ....shared.patterns import Collection, FullQualifiedId
 from ...generics.update import UpdateAction
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
@@ -34,18 +36,12 @@ class CommitteeUpdateAction(UpdateAction):
     )
 
     def check_permissions(self, instance: Dict[str, Any]) -> None:
-        if has_organisation_management_level(
-            self.datastore, self.user_id, OrganisationManagementLevel.SUPERADMIN
-        ):
-            return
 
-        cml_field = f"committee_${instance['id']}_management_level"
-        user = self.datastore.get(
-            FullQualifiedId(Collection("user"), self.user_id), [cml_field]
-        )
-        is_manager = (
-            CommitteeManagementLevel.get_level(user.get(cml_field, "no_right"))
-            >= CommitteeManagementLevel.CAN_MANAGE
+        is_manager = has_committee_management_level(
+            self.datastore,
+            self.user_id,
+            instance["id"],
+            CommitteeManagementLevel.CAN_MANAGE,
         )
         can_manage_organisation = has_organisation_management_level(
             self.datastore,

--- a/openslides_backend/action/actions/meeting/create.py
+++ b/openslides_backend/action/actions/meeting/create.py
@@ -11,11 +11,12 @@ from ..motion_workflow.create import MotionWorkflowCreateSimpleWorkflowAction
 from ..projector.create import ProjectorCreateAction
 from ..projector_countdown.create import ProjectorCountdownCreate
 from ..user.update import UserUpdate
+from .mixins import MeetingPermissionMixin
 from .shared_meeting import meeting_projector_default_replacements
 
 
 @register_action("meeting.create")
-class MeetingCreate(CreateActionWithDependencies):
+class MeetingCreate(CreateActionWithDependencies, MeetingPermissionMixin):
     model = Meeting()
     schema = DefaultSchema(Meeting()).get_create_schema(
         required_properties=["committee_id", "name", "welcome_title"],

--- a/openslides_backend/action/actions/meeting/delete.py
+++ b/openslides_backend/action/actions/meeting/delete.py
@@ -1,14 +1,24 @@
+from typing import Any, Dict
+
 from ....models.models import Meeting
+from ....shared.patterns import FullQualifiedId
 from ...generics.delete import DeleteAction
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
+from .mixins import MeetingPermissionMixin
 
 
 @register_action("meeting.delete")
-class MeetingDelete(DeleteAction):
+class MeetingDelete(DeleteAction, MeetingPermissionMixin):
     """
     Action to delete meetings.
     """
 
     model = Meeting()
     schema = DefaultSchema(Meeting()).get_delete_schema()
+
+    def get_committee_id(self, instance: Dict[str, Any]) -> int:
+        meeting = self.datastore.get(
+            FullQualifiedId(self.model.collection, instance["id"]), ["committee_id"]
+        )
+        return meeting["committee_id"]

--- a/openslides_backend/action/actions/meeting/mixins.py
+++ b/openslides_backend/action/actions/meeting/mixins.py
@@ -1,27 +1,21 @@
 from typing import Any, Dict
 
-from ....permissions.management_levels import OrganisationManagementLevel
-from ....permissions.permission_helper import has_organisation_management_level
-from ....shared.exceptions import PermissionDenied
-from ....shared.patterns import Collection, FullQualifiedId
+from ....permissions.management_levels import CommitteeManagementLevel
+from ....permissions.permission_helper import has_committee_management_level
+from ....shared.exceptions import MissingPermission
 from ...action import Action
 
 
 class MeetingPermissionMixin(Action):
     def check_permissions(self, instance: Dict[str, Any]) -> None:
-        if has_organisation_management_level(
-            self.datastore, self.user_id, OrganisationManagementLevel.SUPERADMIN
-        ):
-            return
-
-        committee_id = self.get_committee_id(instance)
-        cml_field = f"committee_${committee_id}_management_level"
-        user = self.datastore.get(
-            FullQualifiedId(Collection("user"), self.user_id), [cml_field]
+        is_manager = has_committee_management_level(
+            self.datastore,
+            self.user_id,
+            self.get_committee_id(instance),
+            CommitteeManagementLevel.CAN_MANAGE,
         )
-        is_manager = user.get(cml_field) == "can_manage"
         if not is_manager:
-            raise PermissionDenied("Not committee manager.")
+            raise MissingPermission(CommitteeManagementLevel.CAN_MANAGE)
 
     def get_committee_id(self, instance: Dict[str, Any]) -> int:
         return instance["committee_id"]

--- a/openslides_backend/action/actions/meeting/mixins.py
+++ b/openslides_backend/action/actions/meeting/mixins.py
@@ -1,0 +1,27 @@
+from typing import Any, Dict
+
+from ....permissions.management_levels import OrganisationManagementLevel
+from ....permissions.permission_helper import has_organisation_management_level
+from ....shared.exceptions import PermissionDenied
+from ....shared.patterns import Collection, FullQualifiedId
+from ...action import Action
+
+
+class MeetingPermissionMixin(Action):
+    def check_permissions(self, instance: Dict[str, Any]) -> None:
+        if has_organisation_management_level(
+            self.datastore, self.user_id, OrganisationManagementLevel.SUPERADMIN
+        ):
+            return
+
+        committee_id = self.get_committee_id(instance)
+        cml_field = f"committee_${committee_id}_management_level"
+        user = self.datastore.get(
+            FullQualifiedId(Collection("user"), self.user_id), [cml_field]
+        )
+        is_manager = user.get(cml_field) == "can_manage"
+        if not is_manager:
+            raise PermissionDenied("Not committee manager.")
+
+    def get_committee_id(self, instance: Dict[str, Any]) -> int:
+        return instance["committee_id"]

--- a/tests/system/action/meeting/test_create.py
+++ b/tests/system/action/meeting/test_create.py
@@ -172,7 +172,9 @@ class MeetingCreateActionTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 403)
-        assert "Not committee manager." in response.json["message"]
+        assert (
+            "Missing Committee Management Level: can_manage" in response.json["message"]
+        )
 
     def test_create_permissions(self) -> None:
         self.set_models(

--- a/tests/system/action/meeting/test_create.py
+++ b/tests/system/action/meeting/test_create.py
@@ -152,3 +152,35 @@ class MeetingCreateActionTest(BaseActionTestCase):
         assert meeting.get("end_time") == 1608121653
         assert meeting.get("url_name") == "JWdYZqDX"
         assert meeting.get("enable_anonymous") is False
+
+    def test_create_no_permissions(self) -> None:
+        self.set_models(
+            {
+                "user/1": {"organisation_management_level": "can_manage_users"},
+                "committee/1": {"name": "test_committee", "user_ids": [1, 2]},
+                "group/1": {},
+                "user/2": {},
+            }
+        )
+
+        response = self.request(
+            "meeting.create",
+            {
+                "name": "test_name",
+                "committee_id": 1,
+                "welcome_title": "test_wel_title",
+            },
+        )
+        self.assert_status_code(response, 403)
+        assert "Not committee manager." in response.json["message"]
+
+    def test_create_permissions(self) -> None:
+        self.set_models(
+            {
+                "user/1": {
+                    "organisation_management_level": "can_manage_users",
+                    "committee_$1_management_level": "can_manage",
+                }
+            }
+        )
+        self.basic_test({})

--- a/tests/system/action/meeting/test_delete.py
+++ b/tests/system/action/meeting/test_delete.py
@@ -1,0 +1,26 @@
+from tests.system.action.base import BaseActionTestCase
+
+
+class MeetingDeleteActionTest(BaseActionTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.set_models(
+            {
+                "user/1": {"organisation_management_level": "can_manage_users"},
+                "committee/1": {"name": "test_committee", "user_ids": [1, 2]},
+                "group/1": {},
+                "user/2": {},
+                "meeting/1": {"name": "test", "committee_id": 1},
+            }
+        )
+
+    def test_delete_no_permissions(self) -> None:
+        response = self.request("meeting.delete", {"id": 1})
+        self.assert_status_code(response, 403)
+        assert "Not committee manager." in response.json["message"]
+
+    def test_delete_permissions(self) -> None:
+        self.set_models({"user/1": {"committee_$1_management_level": "can_manage"}})
+        response = self.request("meeting.delete", {"id": 1})
+        self.assert_status_code(response, 200)
+        self.assert_model_deleted("meeting/1")

--- a/tests/system/action/meeting/test_delete.py
+++ b/tests/system/action/meeting/test_delete.py
@@ -17,7 +17,9 @@ class MeetingDeleteActionTest(BaseActionTestCase):
     def test_delete_no_permissions(self) -> None:
         response = self.request("meeting.delete", {"id": 1})
         self.assert_status_code(response, 403)
-        assert "Not committee manager." in response.json["message"]
+        assert (
+            "Missing Committee Management Level: can_manage" in response.json["message"]
+        )
 
     def test_delete_permissions(self) -> None:
         self.set_models({"user/1": {"committee_$1_management_level": "can_manage"}})


### PR DESCRIPTION
The permissions of create_forwarded is missing, because the action is not there. It can be easy added, by using the mixin.