### PR TITLE
Add _missing_ method to ManagementLevels and remove no_right from code

### DIFF
--- a/openslides_backend/action/actions/user/create_update_permissions_mixin.py
+++ b/openslides_backend/action/actions/user/create_update_permissions_mixin.py
@@ -59,15 +59,13 @@ class CreateUpdatePermissionsMixin(Action):
             FullQualifiedId(Collection("user"), self.user_id),
             ["organisation_management_level", "committee_as_manager_ids"],
         )
-        user_oml = OrganisationManagementLevel(
-            user.get("organisation_management_level", "no_right")
-        )  # type: ignore
+        user_oml = OrganisationManagementLevel(user.get("organisation_management_level"))
         if user_oml == OrganisationManagementLevel.SUPERADMIN:
             return
 
         if "organisation_management_level" in instance:
             if (
-                OrganisationManagementLevel(instance["organisation_management_level"])  # type: ignore
+                OrganisationManagementLevel(instance["organisation_management_level"])
                 > user_oml
             ):
                 raise PermissionDenied(

--- a/openslides_backend/action/actions/user/create_update_permissions_mixin.py
+++ b/openslides_backend/action/actions/user/create_update_permissions_mixin.py
@@ -59,7 +59,9 @@ class CreateUpdatePermissionsMixin(Action):
             FullQualifiedId(Collection("user"), self.user_id),
             ["organisation_management_level", "committee_as_manager_ids"],
         )
-        user_oml = OrganisationManagementLevel(user.get("organisation_management_level"))
+        user_oml = OrganisationManagementLevel(
+            user.get("organisation_management_level")
+        )
         if user_oml == OrganisationManagementLevel.SUPERADMIN:
             return
 

--- a/openslides_backend/permissions/management_levels.py
+++ b/openslides_backend/permissions/management_levels.py
@@ -1,14 +1,24 @@
 from enum import Enum
+from typing import Optional
 
 from .base_classes import VerbosePermission
 
 
 class CompareRightLevel(str, VerbosePermission, Enum):
-    def __new__(cls, value: str, weight: int):  # type: ignore
+    def __new__(
+        cls, value: Optional[str], weight: Optional[int] = None
+    ) -> "CompareRightLevel":
         obj = str.__new__(cls, value)  # type: ignore
         obj._value_ = value
         obj.weight = weight
         return obj
+
+    @classmethod
+    def _missing_(cls, value: object) -> "CompareRightLevel":
+        """
+        Always return the first enum item if no matching one was found. -> NO_RIGHT must always be listed first.
+        """
+        return next(iter(cls))
 
     def check_instance(self, other: str) -> None:
         if not isinstance(other, self.__class__):
@@ -34,18 +44,18 @@ class CompareRightLevel(str, VerbosePermission, Enum):
 
 
 class OrganisationManagementLevel(CompareRightLevel):
-    SUPERADMIN = ("superadmin", 3)
+    NO_RIGHT = ("no_right", 0)
     CAN_MANAGE_USERS = ("can_manage_users", 1)
     CAN_MANAGE_ORGANISATION = ("can_manage_organisation", 2)
-    NO_RIGHT = ("no_right", 0)
+    SUPERADMIN = ("superadmin", 3)
 
     def get_base_model(self) -> str:
         return "organisation"
 
 
 class CommitteeManagementLevel(CompareRightLevel):
-    CAN_MANAGE = ("can_manage", 1)
     NO_RIGHT = ("no_right", 0)
+    CAN_MANAGE = ("can_manage", 1)
 
     def get_base_model(self) -> str:
         return "committee"

--- a/openslides_backend/permissions/permission_helper.py
+++ b/openslides_backend/permissions/permission_helper.py
@@ -94,8 +94,8 @@ def has_organisation_management_level(
             FullQualifiedId(Collection("user"), user_id),
             ["organisation_management_level"],
         )
-        return expected_level <= OrganisationManagementLevel(  # type: ignore
-            user.get("organisation_management_level", "no_right")
+        return expected_level <= OrganisationManagementLevel(
+            user.get("organisation_management_level")
         )
     return False
 
@@ -118,9 +118,7 @@ def has_committee_management_level(
             == OrganisationManagementLevel.SUPERADMIN
         ):
             return True
-        return expected_level <= CommitteeManagementLevel(  # type: ignore
-            user.get(cml_field, "no_right")
-        )
+        return expected_level <= CommitteeManagementLevel(user.get(cml_field))
     return False
 
 

--- a/tests/unit/test_management_levels.py
+++ b/tests/unit/test_management_levels.py
@@ -61,3 +61,11 @@ def test_committee_level_CML_string() -> None:
         "The comparison expect an <enum 'CommitteeManagementLevel'>-type and no string!"
         in str(exc.value)
     )
+
+
+def test_implicit_no_right_1() -> None:
+    assert OrganisationManagementLevel(None) == OrganisationManagementLevel.NO_RIGHT
+
+
+def test_implicit_no_right_2() -> None:
+    assert OrganisationManagementLevel("") == OrganisationManagementLevel.NO_RIGHT


### PR DESCRIPTION
I discovered that enums in python offer a `_missing_` method and I added it to the `CompareRightLevel` class for a little cleaner access and creation.