### PR TITLE
Add calc fields for motion.create_forwarded.

### DIFF
--- a/openslides_backend/action/actions/motion/__init__.py
+++ b/openslides_backend/action/actions/motion/__init__.py
@@ -10,4 +10,5 @@ from . import (  # noqa
     set_support_self,
     sort,
     update,
+    update_all_derived_motion_ids,
 )

--- a/openslides_backend/action/actions/motion/create_forwarded.py
+++ b/openslides_backend/action/actions/motion/create_forwarded.py
@@ -8,6 +8,7 @@ from ....shared.patterns import Collection, FullQualifiedId
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
 from .create_base import MotionCreateBase
+from .update_all_derived_motion_ids import MotionUpdateAllDerivedMotionIds
 
 
 @register_action("motion.create_forwarded")
@@ -35,6 +36,7 @@ class MotionCreateForwarded(MotionCreateBase):
         self.create_submitters(instance)
         self.set_sequential_number(instance)
         self.set_created_last_modified_and_number(instance)
+        self.calculate_all_origin_ids_and_all_derived_motion_ids(instance)
         return instance
 
     def check_for_origin_id(self, instance: Dict[str, Any]) -> None:
@@ -82,3 +84,34 @@ class MotionCreateForwarded(MotionCreateBase):
             msg = f"You are not allowed to perform action {self.name}."
             msg += f" Missing permission: {perm_origin}"
             raise PermissionDenied(msg)
+
+    def calculate_all_origin_ids_and_all_derived_motion_ids(
+        self, instance: Dict[str, Any]
+    ) -> None:
+        instance["all_derived_motion_ids"] = []
+        if instance.get("origin_id"):
+            origin = self.datastore.get(
+                FullQualifiedId(Collection("motion"), instance["origin_id"]),
+                ["all_origin_ids"],
+            )
+            instance["all_origin_ids"] = origin.get("all_origin_ids", [])
+            instance["all_origin_ids"].append(instance["origin_id"])
+        else:
+            instance["all_origin_ids"] = []
+
+        # Update the all_derived_motion_ids of the origins
+        action_data = []
+        for origin_id in instance["all_origin_ids"]:
+            origin = self.datastore.get(
+                FullQualifiedId(Collection("motion"), instance["origin_id"]),
+                ["all_derived_motion_ids"],
+            )
+            action_data.append(
+                {
+                    "id": origin_id,
+                    "all_derived_motion_ids": origin.get("all_derived_motion_ids", [])
+                    + [instance["id"]],
+                }
+            )
+        if action_data:
+            self.execute_other_action(MotionUpdateAllDerivedMotionIds, action_data)

--- a/openslides_backend/action/actions/motion/create_forwarded.py
+++ b/openslides_backend/action/actions/motion/create_forwarded.py
@@ -103,7 +103,7 @@ class MotionCreateForwarded(MotionCreateBase):
         action_data = []
         for origin_id in instance["all_origin_ids"]:
             origin = self.datastore.get(
-                FullQualifiedId(Collection("motion"), instance["origin_id"]),
+                FullQualifiedId(Collection("motion"), origin_id),
                 ["all_derived_motion_ids"],
             )
             action_data.append(

--- a/openslides_backend/action/actions/motion/update_all_derived_motion_ids.py
+++ b/openslides_backend/action/actions/motion/update_all_derived_motion_ids.py
@@ -1,0 +1,16 @@
+from ....models.models import Motion
+from ...generics.update import UpdateAction
+from ...util.default_schema import DefaultSchema
+from ...util.register import register_action
+
+
+@register_action("motion.update_all_derived_motion_ids", internal=True)
+class MotionUpdateAllDerivedMotionIds(UpdateAction):
+    """
+    Action to update the all_derived_motion_ids of a motion.
+    """
+
+    model = Motion()
+    schema = DefaultSchema(Motion()).get_update_schema(
+        required_properties=["all_derived_motion_ids"]
+    )

--- a/tests/system/action/motion/test_create_forwarded.py
+++ b/tests/system/action/motion/test_create_forwarded.py
@@ -45,10 +45,14 @@ class MotionCreateForwarded(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 200)
-        model = self.get_model("motion/13")
-        assert model.get("title") == "test_Xcdfgee"
-        assert model.get("meeting_id") == 2
-        assert model.get("origin_id") == 12
+        self.assert_model_exists("motion/13", 
+            {"title":  "test_Xcdfgee",
+             "meeting_id": 2,
+             "origin_id": 12,
+             "all_derived_motion_ids": [],
+             "all_origin_ids": [12]})
+        self.assert_model_exists("motion/12", {"derived_motion_ids": [13],
+            "all_derived_motion_ids": [13]})
 
     def test_correct_origin_id_wrong_1(self) -> None:
         self.test_model["committee/53"]["forward_to_committee_ids"] = []

--- a/tests/system/action/motion/test_create_forwarded.py
+++ b/tests/system/action/motion/test_create_forwarded.py
@@ -88,6 +88,99 @@ class MotionCreateForwarded(BaseActionTestCase):
         self.assert_status_code(response, 400)
         assert "Model 'motion/12' does not exist." in response.json["message"]
 
+    def test_all_origin_ids_complex(self) -> None:
+        self.set_models(
+            {
+                "meeting/1": {"name": "name_XDAddEAW", "committee_id": 53},
+                "meeting/2": {
+                    "name": "name_SNLGsvIV",
+                    "motions_default_workflow_id": 12,
+                    "committee_id": 52,
+                },
+                "user/1": {"meeting_ids": [1, 2]},
+                "motion_workflow/12": {
+                    "name": "name_workflow1",
+                    "first_state_id": 34,
+                    "state_ids": [34],
+                },
+                "motion_state/34": {"name": "name_state34", "meeting_id": 2},
+                "motion/6": {
+                    "title": "title_FcnPUXJB layer 1",
+                    "meeting_id": 1,
+                    "state_id": 34,
+                    "derived_motion_ids": [11, 12],
+                    "all_origin_ids": [],
+                    "all_derived_motion_ids": [11, 12, 13],
+                },
+                "motion/11": {
+                    "title": "test11 layer 2",
+                    "meeting_id": 1,
+                    "state_id": 34,
+                    "origin_id": 6,
+                    "derived_motion_ids": [13],
+                    "all_origin_ids": [6],
+                    "all_derived_motion_ids": [13],
+                },
+                "motion/12": {
+                    "title": "test12 layer 2",
+                    "meeting_id": 1,
+                    "state_id": 34,
+                    "origin_id": 6,
+                    "derived_motion_ids": [],
+                    "all_origin_ids": [6],
+                    "all_derived_motion_ids": [],
+                },
+                "motion/13": {
+                    "title": "test13 layer 3",
+                    "meeting_id": 1,
+                    "state_id": 34,
+                    "origin_id": 11,
+                    "derived_motion_ids": [],
+                    "all_origin_ids": [6, 11],
+                    "all_derived_motion_ids": [],
+                },
+                "committee/52": {"name": "name_EeKbwxpa"},
+                "committee/53": {
+                    "name": "name_auSwgfJC",
+                    "forward_to_committee_ids": [52],
+                },
+            }
+        )
+        response = self.request(
+            "motion.create_forwarded",
+            {
+                "title": "test_XXX_leyer 3",
+                "meeting_id": 2,
+                "origin_id": 11,
+                "text": "test",
+            },
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "motion/14",
+            {"origin_id": 11, "all_origin_ids": [6, 11], "all_derived_motion_ids": []},
+        )
+        self.assert_model_exists(
+            "motion/13",
+            {"origin_id": 11, "all_origin_ids": [6, 11], "all_derived_motion_ids": []},
+        )
+        self.assert_model_exists(
+            "motion/12",
+            {"origin_id": 6, "all_origin_ids": [6], "all_derived_motion_ids": []},
+        )
+        self.assert_model_exists(
+            "motion/11",
+            {"origin_id": 6, "all_origin_ids": [6], "all_derived_motion_ids": [13, 14]},
+        )
+        self.assert_model_exists(
+            "motion/6",
+            {
+                "origin_id": None,
+                "all_origin_ids": [],
+                "all_derived_motion_ids": [11, 12, 13, 14],
+            },
+        )
+
     def test_no_permissions(self) -> None:
         self.create_meeting()
         self.user_id = self.create_user("user")

--- a/tests/system/action/motion/test_create_forwarded.py
+++ b/tests/system/action/motion/test_create_forwarded.py
@@ -45,14 +45,19 @@ class MotionCreateForwarded(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 200)
-        self.assert_model_exists("motion/13", 
-            {"title":  "test_Xcdfgee",
-             "meeting_id": 2,
-             "origin_id": 12,
-             "all_derived_motion_ids": [],
-             "all_origin_ids": [12]})
-        self.assert_model_exists("motion/12", {"derived_motion_ids": [13],
-            "all_derived_motion_ids": [13]})
+        self.assert_model_exists(
+            "motion/13",
+            {
+                "title": "test_Xcdfgee",
+                "meeting_id": 2,
+                "origin_id": 12,
+                "all_derived_motion_ids": [],
+                "all_origin_ids": [12],
+            },
+        )
+        self.assert_model_exists(
+            "motion/12", {"derived_motion_ids": [13], "all_derived_motion_ids": [13]}
+        )
 
     def test_correct_origin_id_wrong_1(self) -> None:
         self.test_model["committee/53"]["forward_to_committee_ids"] = []


### PR DESCRIPTION
Calc all_derived_motion_ids and all_origin_ids.
Update the tests.

**Note:** This is only the create case. The delete case must be discussed.
Based on the gen_models branch.