### PR TITLE
Add admin_ids to meeting.create, add oml check to has_cml.

### DIFF
--- a/openslides_backend/action/actions/meeting/create.py
+++ b/openslides_backend/action/actions/meeting/create.py
@@ -134,6 +134,7 @@ class MeetingCreate(CreateActionWithDependencies, MeetingPermissionMixin):
         instance["admin_group_id"] = fqid_admin_group.id
 
         # Add user to admin group
+        admin_ids = []
         if instance.get("admin_ids"):
             admin_ids = instance.pop("admin_ids")
             committee = self.datastore.get(
@@ -170,6 +171,7 @@ class MeetingCreate(CreateActionWithDependencies, MeetingPermissionMixin):
                     "group_$_ids": {str(instance["id"]): [fqid_default_group.id]},
                 }
                 for user_id in user_ids
+                if user_id not in admin_ids
             ]
 
             self.execute_other_action(UserUpdate, action_data)

--- a/openslides_backend/action/actions/meeting/create.py
+++ b/openslides_backend/action/actions/meeting/create.py
@@ -31,7 +31,10 @@ class MeetingCreate(CreateActionWithDependencies, MeetingPermissionMixin):
             "url_name",
             "organization_tag_ids",
         ],
-        additional_optional_fields={"user_ids": id_list_schema},
+        additional_optional_fields={
+            "user_ids": id_list_schema,
+            "admin_ids": id_list_schema,
+        },
     )
     dependencies = [
         MotionWorkflowCreateSimpleWorkflowAction,
@@ -131,13 +134,25 @@ class MeetingCreate(CreateActionWithDependencies, MeetingPermissionMixin):
         instance["admin_group_id"] = fqid_admin_group.id
 
         # Add user to admin group
-        action_data = [
-            {
-                "id": self.user_id,
-                "group_$_ids": {str(instance["id"]): [fqid_admin_group.id]},
-            }
-        ]
-        self.execute_other_action(UserUpdate, action_data)
+        if instance.get("admin_ids"):
+            admin_ids = instance.pop("admin_ids")
+            committee = self.datastore.get(
+                FullQualifiedId(Collection("committee"), instance["committee_id"]),
+                ["user_ids"],
+            )
+            if not all(
+                user_id in committee.get("user_ids", []) for user_id in admin_ids
+            ):
+                raise ActionException("Only allowed to add admins from committee.")
+            action_data = [
+                {
+                    "id": user_id,
+                    "group_$_ids": {str(instance["id"]): [fqid_admin_group.id]},
+                }
+                for user_id in admin_ids
+            ]
+            self.execute_other_action(UserUpdate, action_data)
+
         # Add users to default group
         if instance.get("user_ids"):
             user_ids = instance.pop("user_ids")
@@ -149,14 +164,12 @@ class MeetingCreate(CreateActionWithDependencies, MeetingPermissionMixin):
                 user_id in committee.get("user_ids", []) for user_id in user_ids
             ):
                 raise ActionException("Only allowed to add users from committee.")
-            # filter out request user since he was already added
             action_data = [
                 {
                     "id": user_id,
                     "group_$_ids": {str(instance["id"]): [fqid_default_group.id]},
                 }
                 for user_id in user_ids
-                if user_id != self.user_id
             ]
 
             self.execute_other_action(UserUpdate, action_data)

--- a/openslides_backend/action/actions/meeting/update.py
+++ b/openslides_backend/action/actions/meeting/update.py
@@ -241,12 +241,7 @@ class MeetingUpdate(UpdateAction):
                 CommitteeManagementLevel.CAN_MANAGE,
                 meeting["committee_id"],
             )
-            can_manage_organization = has_organization_management_level(
-                self.datastore,
-                self.user_id,
-                OrganizationManagementLevel.CAN_MANAGE_ORGANIZATION,
-            )
-            if not is_manager and not can_manage_organization:
+            if not is_manager:
                 raise PermissionDenied(
                     "Missing permission: Not manager and not can_manage_organization"
                 )

--- a/openslides_backend/permissions/permission_helper.py
+++ b/openslides_backend/permissions/permission_helper.py
@@ -112,9 +112,9 @@ def has_committee_management_level(
             FullQualifiedId(Collection("user"), user_id),
             ["organization_management_level", cml_field],
         )
-        if (
-            user.get("organization_management_level")
-            == OrganizationManagementLevel.SUPERADMIN
+        if user.get("organization_management_level") in (
+            OrganizationManagementLevel.SUPERADMIN,
+            OrganizationManagementLevel.CAN_MANAGE_ORGANIZATION,
         ):
             return True
         return expected_level <= CommitteeManagementLevel(user.get(cml_field))

--- a/tests/system/action/meeting/test_create.py
+++ b/tests/system/action/meeting/test_create.py
@@ -253,7 +253,7 @@ class MeetingCreateActionTest(BaseActionTestCase):
         )
         self.basic_test({})
 
-    def test_create_with_admin_ids_and_permissions(self) -> None:
+    def test_create_with_admin_ids_and_permissions_cml(self) -> None:
         self.set_models(
             {
                 "user/1": {
@@ -269,27 +269,18 @@ class MeetingCreateActionTest(BaseActionTestCase):
             "user/2", {f"group_${meeting['id']}_ids": [admin_group_id]}
         )
 
-    def test_create_with_admin_ids_and_no_permissions(self) -> None:
+    def test_create_with_admin_ids_and_permissions_oml(self) -> None:
         self.set_models(
             {
                 "user/1": {
-                    "organization_management_level": OrganizationManagementLevel.CAN_MANAGE_USERS
-                },
-                "committee/1": {"name": "test_committee", "user_ids": [1, 2]},
-                "group/1": {},
-                "user/2": {},
+                    "organization_management_level": OrganizationManagementLevel.CAN_MANAGE_ORGANIZATION,
+                    "committee_$1_management_level": None,
+                }
             }
         )
-
-        response = self.request(
-            "meeting.create",
-            {
-                "name": "test_name",
-                "committee_id": 1,
-                "admin_ids": [2],
-            },
-        )
-        self.assert_status_code(response, 403)
-        assert (
-            "Missing CommitteeManagementLevel: can_manage" in response.json["message"]
+        meeting = self.basic_test({"admin_ids": [2]})
+        assert meeting.get("user_ids") == [2]
+        admin_group_id = meeting.get("admin_group_id")
+        self.assert_model_exists(
+            "user/2", {f"group_${meeting['id']}_ids": [admin_group_id]}
         )

--- a/tests/system/action/meeting/test_create.py
+++ b/tests/system/action/meeting/test_create.py
@@ -59,7 +59,7 @@ class MeetingCreateActionTest(BaseActionTestCase):
             },
         )
         self.assert_model_exists("group/2", {"name": "Default"})
-        self.assert_model_exists("group/3", {"name": "Admin", "user_ids": [1]})
+        self.assert_model_exists("group/3", {"name": "Admin"})
         self.assert_model_exists("group/4", {"name": "Delegates"})
         self.assert_model_exists("group/5", {"name": "Staff"})
         self.assert_model_exists("group/6", {"name": "Committees"})
@@ -111,13 +111,6 @@ class MeetingCreateActionTest(BaseActionTestCase):
             },
         )
         self.assert_model_exists(
-            "user/1",
-            {
-                "group_$1_ids": [3],  # meeting/1 and group 3
-                "group_$_ids": ["1"],  # only meeting/1 values
-            },
-        )
-        self.assert_model_exists(
             "projector_countdown/1",
             {
                 "title": "List of speakers countdown",
@@ -156,69 +149,36 @@ class MeetingCreateActionTest(BaseActionTestCase):
 
     def test_create_check_users(self) -> None:
         meeting = self.basic_test({"user_ids": [2]})
-        assert meeting.get("user_ids") == [1, 2]
+        assert meeting.get("user_ids") == [2]
         default_group_id = meeting.get("default_group_id")
         self.assert_model_exists(
             "user/2", {f"group_${meeting['id']}_ids": [default_group_id]}
         )
+
+    def test_create_check_admins(self) -> None:
+        meeting = self.basic_test({"admin_ids": [2]})
+        assert meeting.get("user_ids") == [2]
         admin_group_id = meeting.get("admin_group_id")
         self.assert_model_exists(
-            "user/1", {f"group_${meeting['id']}_ids": [admin_group_id]}
-        )
-
-    def test_create_with_request_user(self) -> None:
-        self.set_models(
-            {
-                "committee/3": {"user_ids": [1, 3]},
-                "user/3": {},
-            }
-        )
-        response = self.request(
-            "meeting.create",
-            {
-                "committee_id": 3,
-                "name": "Kuchenfest des Jahres",
-                "start_time": 1623362400,
-                "end_time": 1623362400,
-                "user_ids": [1, 3],
-            },
-        )
-        self.assert_status_code(response, 200)
-        # user/1 is only added to the admin group (2), not the default group
-        self.assert_model_exists(
-            "user/1",
-            {
-                "group_$1_ids": [2],
-                "group_$_ids": ["1"],
-                "meeting_ids": [1],
-            },
-        )
-        self.assert_model_exists(
-            "user/3",
-            {
-                "group_$1_ids": [1],
-                "group_$_ids": ["1"],
-                "meeting_ids": [1],
-            },
-        )
-        self.assert_model_exists(
-            "meeting/1",
-            {
-                "user_ids": [1, 3],
-            },
+            "user/2", {f"group_${meeting['id']}_ids": [admin_group_id]}
         )
 
     def test_create_multiple_users(self) -> None:
         self.set_models(
             {
-                "committee/1": {"user_ids": [2, 3]},
+                "committee/1": {"user_ids": [1, 2, 3]},
                 "user/2": {},
                 "user/3": {},
             }
         )
         response = self.request(
             "meeting.create",
-            {"name": "test_name", "committee_id": 1, "user_ids": [2, 3]},
+            {
+                "name": "test_name",
+                "committee_id": 1,
+                "user_ids": [2, 3],
+                "admin_ids": [1],
+            },
         )
         self.assert_status_code(response, 200)
         meeting = self.get_model("meeting/1")

--- a/tests/system/action/meeting/test_create.py
+++ b/tests/system/action/meeting/test_create.py
@@ -163,6 +163,14 @@ class MeetingCreateActionTest(BaseActionTestCase):
             "user/2", {f"group_${meeting['id']}_ids": [admin_group_id]}
         )
 
+    def test_create_with_same_user_in_users_and_admins(self) -> None:
+        meeting = self.basic_test({"user_ids": [2], "admin_ids": [2]})
+        assert meeting.get("user_ids") == [2]
+        admin_group_id = meeting.get("admin_group_id")
+        self.assert_model_exists(
+            "user/2", {f"group_${meeting['id']}_ids": [admin_group_id]}
+        )
+
     def test_create_multiple_users(self) -> None:
         self.set_models(
             {


### PR DESCRIPTION
Update tests.
Two things are done in this pr. The oml can_manage_organization is checked in the has_committee_management_level, too.
Add admins setting to meeting.create. 