### PR TITLE
Update projector.toggle. Add test.

### DIFF
--- a/openslides_backend/action/actions/projector/toggle.py
+++ b/openslides_backend/action/actions/projector/toggle.py
@@ -53,8 +53,6 @@ class ProjectorToggle(UpdateAction):
             )
 
             for projector_id in instance["ids"]:
-                # Set scroll to 0 is needed, if unstable and no results
-                scroll_to_0 = False
                 stable = instance.get("stable", False)
                 filter_ = And(
                     FilterOperator("current_projector_id", "=", projector_id),
@@ -91,10 +89,8 @@ class ProjectorToggle(UpdateAction):
                         self.move_all_unstable_projections_to_history(
                             projector_id, meeting_id
                         )
-                        scroll_to_0 = True
+                        yield {"id": projector_id, "scroll": 0}
                     self.execute_other_action(ProjectionCreate, [data])
-                if scroll_to_0:
-                    yield {"id": projector_id, "scroll": 0}
 
     def move_projections_to_history(
         self, projector_id: int, projection_ids: List[int]

--- a/tests/system/action/projector/test_toggle.py
+++ b/tests/system/action/projector/test_toggle.py
@@ -105,8 +105,10 @@ class ProjectorToggle(BaseActionTestCase):
         )
         self.assert_status_code(response, 200)
         projector = self.get_model("projector/23")
+        assert projector.get("current_projection_ids") == [34]
         assert projector.get("history_projection_ids") == [33]
         assert projector.get("scroll") == 0
+        self.assert_model_exists("projection/34")
 
     def test_toggle_no_permissions(self) -> None:
         self.base_permission_test(

--- a/tests/system/action/projector/test_toggle.py
+++ b/tests/system/action/projector/test_toggle.py
@@ -86,6 +86,27 @@ class ProjectorToggle(BaseActionTestCase):
         projector = self.get_model("projector/23")
         assert projector.get("current_projection_ids") == [1]
 
+    def test_toggle_unstable_move_into_history(self) -> None:
+        self.setup_models(False)
+        self.set_models(
+            {
+                "poll/888": {"meeting_id": 1},
+            }
+        )
+        response = self.request(
+            "projector.toggle",
+            {
+                "ids": [23],
+                "content_object_id": "poll/888",
+                "meeting_id": 1,
+                "stable": False,
+            },
+        )
+        self.assert_status_code(response, 200)
+        projector = self.get_model("projector/23")
+        assert projector.get("history_projection_ids") == [33]
+        assert projector.get("scroll") == 0
+
     def test_toggle_no_permissions(self) -> None:
         self.base_permission_test(
             self.permission_test_model,

--- a/tests/system/action/projector/test_toggle.py
+++ b/tests/system/action/projector/test_toggle.py
@@ -91,6 +91,7 @@ class ProjectorToggle(BaseActionTestCase):
         self.set_models(
             {
                 "poll/888": {"meeting_id": 1},
+                "projector/23": {"scroll": 100},
             }
         )
         response = self.request(


### PR DESCRIPTION
If unstable and not result, set scroll to 0 and move all current
unstable projections into history, too.