### PR TITLE
assert_model_deleted with optional field checking

### DIFF
--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -183,9 +183,12 @@ class BaseSystemTestCase(TestCase):
         with self.assertRaises(DatastoreException):
             self.get_model(fqid)
 
-    def assert_model_deleted(self, fqid: str) -> None:
+    def assert_model_deleted(self, fqid: str, fields: Dict[str, Any] = None) -> None:
         model = self.get_model(fqid)
         self.assertTrue(model.get("meta_deleted"), f"Model '{fqid}' was not deleted.")
+        if fields is not None:
+            for field_name, value in fields.items():
+                self.assertEqual(model.get(field_name), value)
 
     def assert_defaults(self, model: Type[Model], instance: Dict[str, Any]) -> None:
         for field in model().get_fields():


### PR DESCRIPTION
Allows field checking analogue to assert_model_exist for deleted objects for help in testing relations