### PR TITLE
Fix user extraction in meeting.create

### DIFF
--- a/openslides_backend/action/actions/meeting/create.py
+++ b/openslides_backend/action/actions/meeting/create.py
@@ -154,9 +154,7 @@ class MeetingCreate(CreateActionWithDependencies, MeetingPermissionMixin):
         instance["admin_group_id"] = fqid_admin_group.id
 
         # Add user to admin group
-        admin_ids = []
-        if instance.get("admin_ids"):
-            admin_ids = instance.pop("admin_ids")
+        if admin_ids := instance.pop("admin_ids", []):
             if not all(
                 user_id in committee.get("user_ids", []) for user_id in admin_ids
             ):
@@ -171,8 +169,7 @@ class MeetingCreate(CreateActionWithDependencies, MeetingPermissionMixin):
             self.execute_other_action(UserUpdate, action_data)
 
         # Add users to default group
-        if instance.get("user_ids"):
-            user_ids = instance.pop("user_ids")
+        if user_ids := instance.pop("user_ids", []):
             if not all(
                 user_id in committee.get("user_ids", []) for user_id in user_ids
             ):

--- a/openslides_backend/models/checker.py
+++ b/openslides_backend/models/checker.py
@@ -365,7 +365,7 @@ class Checker:
             self.errors.append(error)
             errors = True
         if diff := model_fields - all_collection_fields:
-            error = f"{collection}/{model['id']}: Invalid fields {', '.join(diff)}"
+            error = f"{collection}/{model['id']}: Invalid fields {', '.join(f'{field} (value: {model[field]})' for field in diff)}"
             self.errors.append(error)
             errors = True
         return errors

--- a/tests/system/action/meeting/test_clone.py
+++ b/tests/system/action/meeting/test_clone.py
@@ -250,6 +250,33 @@ class MeetingClone(BaseActionTestCase):
         organization = self.get_model("organization/1")
         self.assertCountEqual(organization["active_meeting_ids"], [1, 2])
 
+    def test_create_clone(self) -> None:
+        self.set_models(
+            {
+                "organization/1": {},
+                "committee/1": {"organization_id": 1, "user_ids": [2, 3]},
+                "user/2": {"committee_ids": [1]},
+                "user/3": {"committee_ids": [1]},
+            }
+        )
+        response = self.request(
+            "meeting.create",
+            {
+                "committee_id": 1,
+                "name": "meeting",
+                "description": "",
+                "location": "",
+                "start_time": 1633039200,
+                "end_time": 1633039200,
+                "user_ids": [2, 3],
+                "admin_ids": [],
+                "organization_tag_ids": [],
+            },
+        )
+        self.assert_status_code(response, 200)
+        response = self.request("meeting.clone", {"meeting_id": 1})
+        self.assert_status_code(response, 200)
+
     def test_permissions_both_okay(self) -> None:
         self.set_models(self.test_models)
         self.set_models(

--- a/tests/system/action/meeting/test_create.py
+++ b/tests/system/action/meeting/test_create.py
@@ -279,6 +279,10 @@ class MeetingCreateActionTest(BaseActionTestCase):
         self.assert_status_code(response, 400)
         assert "Only allowed to add users from committee." in response.json["message"]
 
+    def test_create_with_admins_empty_array(self) -> None:
+        meeting = self.basic_test({"admin_ids": []})
+        assert "admin_ids" not in meeting
+
     def test_create_no_permissions(self) -> None:
         self.set_models(
             {

--- a/tests/system/action/meeting/test_import.py
+++ b/tests/system/action/meeting/test_import.py
@@ -1050,7 +1050,10 @@ class MeetingImport(BaseActionTestCase):
         )
         response = self.request("meeting.import", request_data)
         self.assert_status_code(response, 400)
-        assert "mediafile/1: Invalid fields foobar" in response.json["message"]
+        assert (
+            "mediafile/1: Invalid fields foobar (value: test this)"
+            in response.json["message"]
+        )
 
     def test_bad_format_invalid_id_key(self) -> None:
         request_data = self.create_request_data({"tag": {"1": {"id": 2}}})


### PR DESCRIPTION
Bugfix for `meeting.create`. @GabrielInTheWorld I assume that you created the meeting you wanted to clone via this action. If so, please check if this solves your problem. If not, please provide a more detailed wayto reproduce the issue.