### PR TITLE
Add some meeting defaults to models and meeting.create.

### DIFF
--- a/global/meta/models.yml
+++ b/global/meta/models.yml
@@ -1183,6 +1183,7 @@ meeting:
     restriction_mode: B
   assignment_poll_default_method:
     type: string
+    default: Y
     restriction_mode: B
   assignment_poll_default_100_percent_base:
     type: string

--- a/openslides_backend/action/actions/meeting/create.py
+++ b/openslides_backend/action/actions/meeting/create.py
@@ -143,6 +143,7 @@ class MeetingCreate(CreateActionWithDependencies, MeetingPermissionMixin):
             Collection("group"), action_results[0]["id"]  # type: ignore
         )
         fqid_admin_group = FullQualifiedId(Collection("group"), action_results[1]["id"])  # type: ignore
+        fqid_delegates_group = FullQualifiedId(Collection("group"), action_results[2]["id"])  # type: ignore
         assert (
             self.datastore.additional_relation_models[fqid_default_group]["name"]
             == "Default"
@@ -151,8 +152,15 @@ class MeetingCreate(CreateActionWithDependencies, MeetingPermissionMixin):
             self.datastore.additional_relation_models[fqid_admin_group]["name"]
             == "Admin"
         )
+        assert (
+            self.datastore.additional_relation_models[fqid_delegates_group]["name"]
+            == "Delegates"
+        )
+
         instance["default_group_id"] = fqid_default_group.id
         instance["admin_group_id"] = fqid_admin_group.id
+        instance["assignment_poll_default_group_ids"] = [fqid_delegates_group.id]
+        instance["motion_poll_default_group_ids"] = [fqid_delegates_group.id]
 
         # Add user to admin group
         if admin_ids := instance.pop("admin_ids", []):

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -4,7 +4,7 @@ from openslides_backend.models import fields
 from openslides_backend.models.base import Model
 from openslides_backend.shared.patterns import Collection
 
-MODELS_YML_CHECKSUM = "a4d98010a398caff1bd09c5aee0e6fbf"
+MODELS_YML_CHECKSUM = "040786ec5990128497bb829e5fe06df1"
 
 
 class Organization(Model):
@@ -514,7 +514,7 @@ class Meeting(Model):
     )
     assignment_poll_sort_poll_result_by_votes = fields.BooleanField(default=True)
     assignment_poll_default_type = fields.CharField(default="analog")
-    assignment_poll_default_method = fields.CharField()
+    assignment_poll_default_method = fields.CharField(default="Y")
     assignment_poll_default_100_percent_base = fields.CharField(default="valid")
     assignment_poll_default_group_ids = fields.RelationListField(
         to={Collection("group"): "used_as_assignment_poll_default_id"}

--- a/tests/system/action/meeting/test_create.py
+++ b/tests/system/action/meeting/test_create.py
@@ -62,6 +62,8 @@ class MeetingCreateActionTest(BaseActionTestCase):
                 "projector_countdown_warning_time": 0,
                 "organization_tag_ids": [3],
                 "is_active_in_organization_id": 1,
+                "assignment_poll_default_group_ids": [4],
+                "motion_poll_default_group_ids": [4],
                 **{
                     f"default_projector_${name}_id": 1
                     for name in meeting_projector_default_replacements
@@ -201,6 +203,10 @@ class MeetingCreateActionTest(BaseActionTestCase):
         assert meeting.get("start_time") == 1608120653
         assert meeting.get("end_time") == 1608121653
         assert meeting.get("url_name") == "JWdYZqDX"
+
+        # check two defaults:
+        assert meeting.get("assignment_poll_default_type") == "analog"
+        assert meeting.get("assignment_poll_default_method") == "Y"
 
     def test_create_check_users(self) -> None:
         meeting = self.basic_test({"user_ids": [2]})


### PR DESCRIPTION
Add  some tests. The default of `assignment_poll_default_type` was already `analog`. Add a test for this too.