### PR TITLE
Internal action routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ General schema for internal routes: `/internal/<route>`
 * `/system/action/handle_request`: Main route of the service, is used to execute actions.
 * `/system/action/handle_separately`: Same function as `handle_request`, but the request is not executed atomically,
   meaning each action is executed and the result sent to the datastore separately.
+* `/internal/handle_request`: Same as the first route, but only for internal usage: All permission checks are skipped
+  and created write requests will have id -1.
 * `/internal/health`: Returns a list of all possible actions with their respective JSON schema.
 * `/internal/migrations`: Provides remote access to the migration tool.
 

--- a/openslides_backend/action/action.py
+++ b/openslides_backend/action/action.py
@@ -125,6 +125,7 @@ class Action(BaseAction, metaclass=SchemaProvider):
         """
         Entrypoint to perform the action.
         """
+        # breakpoint()
         self.user_id = user_id
         self.index = 0
         for instance in action_data:

--- a/openslides_backend/action/action.py
+++ b/openslides_backend/action/action.py
@@ -125,7 +125,6 @@ class Action(BaseAction, metaclass=SchemaProvider):
         """
         Entrypoint to perform the action.
         """
-        # breakpoint()
         self.user_id = user_id
         self.index = 0
         for instance in action_data:

--- a/openslides_backend/action/action_handler.py
+++ b/openslides_backend/action/action_handler.py
@@ -88,13 +88,18 @@ class ActionHandler(BaseHandler):
             yield name, info
 
     def handle_request(
-        self, payload: Payload, user_id: int, atomic: bool = True
+        self,
+        payload: Payload,
+        user_id: int,
+        atomic: bool = True,
+        internal: bool = False,
     ) -> ActionsResponse:
         """
         Takes payload and user id and handles this request by validating and
         parsing all actions. In the end it sends everything to the event store.
         """
         self.user_id = user_id
+        self.internal = internal
 
         try:
             payload_schema(payload)
@@ -212,7 +217,9 @@ class ActionHandler(BaseHandler):
 
         try:
             with self.datastore.get_database_context():
-                write_request, results = action.perform(action_data, self.user_id)
+                write_request, results = action.perform(
+                    action_data, self.user_id, internal=self.internal
+                )
             if write_request:
                 action.validate_required_fields(write_request)
 

--- a/openslides_backend/http/views/action_view.py
+++ b/openslides_backend/http/views/action_view.py
@@ -40,6 +40,17 @@ class ActionView(BaseView):
         self.logger.debug("Action request finished successfully.")
         return response, access_token
 
+    @route("handle_request", internal=True)
+    def internal_action_route(
+        self, request: Request
+    ) -> Tuple[ResponseBody, Optional[str]]:
+        self.logger.debug("Start dispatching internal action request.")
+        assert_migration_index()
+        handler = ActionHandler(logging=self.logging, services=self.services)
+        response = handler.handle_request(request.json, -1, internal=True)
+        self.logger.debug("Internal action request finished successfully.")
+        return response, None
+
     @route("migrations", internal=True)
     def migrations_route(self, request: Request) -> Tuple[ResponseBody, Optional[str]]:
         self.logger.debug("Start executing migrations request.")

--- a/tests/system/action/test_action_command_format.py
+++ b/tests/system/action/test_action_command_format.py
@@ -16,6 +16,7 @@ class GeneralActionCommandFormat(BaseActionTestCase):
         logger = Mock()
         handler = ActionHandler(self.services, logger)
         handler.user_id = 1
+        handler.internal = False
         return handler
 
     def test_parse_actions_create_2_actions(self) -> None:

--- a/tests/system/action/test_internal_actions.py
+++ b/tests/system/action/test_internal_actions.py
@@ -43,3 +43,10 @@ class TestInternalActions(BaseActionTestCase):
         self.assert_status_code(response, 200)
         model = self.get_model("user/1")
         assert self.auth.is_equals("new_password", model["password"])
+
+    def test_internal_organization_initial_import(self) -> None:
+        self.datastore.truncate_db()
+        response = self.internal_request("organization.initial_import", {})
+        self.assert_status_code(response, 200)
+        self.assert_model_exists("organization/1")
+        self.assert_model_exists("user/1", {"username": "superadmin"})

--- a/tests/system/action/test_internal_actions.py
+++ b/tests/system/action/test_internal_actions.py
@@ -1,0 +1,45 @@
+from typing import Any, Dict
+
+from openslides_backend.http.views.action_view import ActionView
+from tests.system.util import get_route_path
+from tests.util import Response
+
+from .base import BaseActionTestCase
+
+
+class TestInternalActions(BaseActionTestCase):
+    """
+    Uses the anonymous client to call the internal action route. This should skip all permission checks, so the requests
+    still succeed.
+    Just rudimentary tests that the actions generally succeed since if that's the case, everything should be handled
+    analogously to the external case, which is already test sufficiently in the special test cases for the actions.
+    """
+
+    def internal_request(self, action: str, data: Dict[str, Any]) -> Response:
+        return self.anon_client.post(
+            get_route_path(ActionView.internal_action_route),
+            json=[{"action": action, "data": [data]}],
+        )
+
+    def test_internal_user_create(self) -> None:
+        response = self.internal_request("user.create", {"username": "test"})
+        self.assert_status_code(response, 200)
+        self.assert_model_exists("user/2", {"username": "test"})
+
+    def test_internal_user_update(self) -> None:
+        response = self.internal_request("user.update", {"id": 1, "username": "test"})
+        self.assert_status_code(response, 200)
+        self.assert_model_exists("user/1", {"username": "test"})
+
+    def test_internal_user_delete(self) -> None:
+        response = self.internal_request("user.delete", {"id": 1})
+        self.assert_status_code(response, 200)
+        self.assert_model_deleted("user/1")
+
+    def test_internal_user_set_password(self) -> None:
+        response = self.internal_request(
+            "user.set_password", {"id": 1, "password": "new_password"}
+        )
+        self.assert_status_code(response, 200)
+        model = self.get_model("user/1")
+        assert self.auth.is_equals("new_password", model["password"])

--- a/tests/system/action/test_internal_actions.py
+++ b/tests/system/action/test_internal_actions.py
@@ -46,7 +46,7 @@ class TestInternalActions(BaseActionTestCase):
 
     def test_internal_organization_initial_import(self) -> None:
         self.datastore.truncate_db()
-        response = self.internal_request("organization.initial_import", {})
+        response = self.internal_request("organization.initial_import", {"data": {}})
         self.assert_status_code(response, 200)
         self.assert_model_exists("organization/1")
         self.assert_model_exists("user/1", {"username": "superadmin"})


### PR DESCRIPTION
closes #987 

All actions are now accessible via `/internal/handle_request`. I tested the actions `user.{create,update,delete,set_password}` which work. Not all actions will work though: The user id is set to -1*, so any action which needs to access the request user will fail. If the manage service needs access to such an action, we'll need to revisit this, but for now it works.

\* This is somewhat arbitrary, but we need a value which can be written into the DS for the generated write requests. A value >= 1 is not suitable since these represent real users, while 0 might lead to confusion since it generally stands for the anonymous user. So I chose -1. Another possibility would be to make the user id not required in the SQL schema and then just leave it empty for such requests. I don't really care which of these possibilities we choose, do you have any thoughts?