### PR TITLE
Prevent announce-update job on forks

### DIFF
--- a/.github/workflows/create-issue-for-file-updates.yml
+++ b/.github/workflows/create-issue-for-file-updates.yml
@@ -13,6 +13,7 @@ jobs:
   announce-update:
     name: 'Announce updates'
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'OpenSlides'
     steps:
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
Prevents that the "announce-update" job was executed on forks.