### PR TITLE
Issue1144 delete projection with historical projector in meeting.delete

### DIFF
--- a/openslides_backend/action/action.py
+++ b/openslides_backend/action/action.py
@@ -102,6 +102,7 @@ class Action(BaseAction, metaclass=SchemaProvider):
         relation_manager: RelationManager,
         logging: LoggingModule,
         skip_archived_meeting_check: bool = False,
+        parent_action: str = "",
     ) -> None:
         self.services = services
         self.auth = services.authentication()
@@ -117,6 +118,7 @@ class Action(BaseAction, metaclass=SchemaProvider):
             )
         else:
             self.skip_archived_meeting_check = skip_archived_meeting_check
+        self.parent_action = parent_action
         self.write_requests = []
         self.results = []
 
@@ -559,6 +561,7 @@ class Action(BaseAction, metaclass=SchemaProvider):
             self.relation_manager,
             self.logging,
             skip_archived_meeting_check,
+            self.name,
         )
         write_request, action_results = action.perform(
             action_data, self.user_id, internal=True

--- a/openslides_backend/action/actions/assignment_candidate/delete.py
+++ b/openslides_backend/action/actions/assignment_candidate/delete.py
@@ -30,7 +30,10 @@ class AssignmentCandidateDelete(PermissionMixin, DeleteAction):
             ),
             mapped_fields=["phase"],
         )
-        if assignment.get("phase") == "finished":
+        if (
+            assignment.get("phase") == "finished"
+            and self.parent_action != "meeting.delete"
+        ):
             raise ActionException(
                 "It is not permitted to remove a candidate from a finished assignment!"
             )

--- a/openslides_backend/action/actions/projection/delete.py
+++ b/openslides_backend/action/actions/projection/delete.py
@@ -27,7 +27,7 @@ class ProjectionDelete(DeleteAction):
         if not (
             projection.get("current_projector_id")
             or projection.get("preview_projector_id")
-            or self.parent_action == "meeting.delete" # Issue1144
+            or self.parent_action == "meeting.delete"  # Issue1144
         ):
             raise ActionException(
                 f"Projection {instance['id']} must have a current_projector_id or a preview_projector_id."

--- a/openslides_backend/action/actions/projection/delete.py
+++ b/openslides_backend/action/actions/projection/delete.py
@@ -27,8 +27,9 @@ class ProjectionDelete(DeleteAction):
         if not (
             projection.get("current_projector_id")
             or projection.get("preview_projector_id")
+            or self.parent_action == "meeting.delete" # Issue1144
         ):
             raise ActionException(
-                "Projection must have a current_projector_id or a preview_projector_id."
+                f"Projection {instance['id']} must have a current_projector_id or a preview_projector_id."
             )
         return instance

--- a/openslides_backend/action/actions/projector/delete.py
+++ b/openslides_backend/action/actions/projector/delete.py
@@ -26,8 +26,10 @@ class ProjectorDelete(DeleteAction):
             ["used_as_reference_projector_meeting_id", "meeting_id"],
         )
         if (
-            meeting_id := projector.get("used_as_reference_projector_meeting_id")
-        ) and not self.is_meeting_deleted(meeting_id):
+            (meeting_id := projector.get("used_as_reference_projector_meeting_id"))
+            and not self.is_meeting_deleted(meeting_id)
+            and self.parent_action != "meeting.delete"
+        ):
             raise ActionException(
                 "A used as reference projector is not allowed to delete."
             )

--- a/openslides_backend/action/actions/projector_countdown/delete.py
+++ b/openslides_backend/action/actions/projector_countdown/delete.py
@@ -30,7 +30,11 @@ class ProjectorCountdownDelete(DeleteAction):
         meeting_id = projector_countdown.get(
             "used_as_list_of_speaker_countdown_meeting_id"
         ) or projector_countdown.get("used_as_poll_countdown_meeting_id")
-        if meeting_id and not self.is_meeting_deleted(meeting_id):
+        if (
+            meeting_id
+            and not self.is_meeting_deleted(meeting_id)
+            and self.parent_action != "meeting.delete"
+        ):
             raise ActionException(
                 "List of speakers or poll countdown is not allowed to delete."
             )

--- a/tests/system/action/meeting/test_delete.py
+++ b/tests/system/action/meeting/test_delete.py
@@ -43,6 +43,7 @@ class MeetingDeleteActionTest(BaseActionTestCase):
             {
                 "user/1": {
                     "committee_$1_management_level": "can_manage",
+                    "committee_$_management_level": ["1"],
                     "organization_management_level": "can_manage_users",
                 }
             }
@@ -53,6 +54,22 @@ class MeetingDeleteActionTest(BaseActionTestCase):
 
     def test_delete_full_meeting(self) -> None:
         self.load_example_data()
+        self.set_models(
+            {
+                "meeting/1": {"all_projection_ids": [1, 2, 3, 4, 5]},
+                "projection/5": {
+                    "current_projector_id": None,
+                    "preview_projector_id": None,
+                    "history_projector_id": 1,
+                    "content_object_id": "assignment/1",
+                    "stable": False,
+                    "type": None,
+                    "weight": 1,
+                    "options": {},
+                    "meeting_id": 1,
+                },
+            }
+        )
         response = self.request("meeting.delete", {"id": 1})
         self.assert_status_code(response, 200)
         self.assert_model_deleted(
@@ -102,7 +119,7 @@ class MeetingDeleteActionTest(BaseActionTestCase):
             self.assert_model_deleted(f"mediafile/{i+1}")
         for i in range(2):
             self.assert_model_deleted(f"projector/{i+1}")
-        for i in range(4):
+        for i in range(5):
             self.assert_model_deleted(f"projection/{i+1}")
         self.assert_model_deleted("projector_message/1")
         for i in range(2):

--- a/tests/system/action/projection/test_delete.py
+++ b/tests/system/action/projection/test_delete.py
@@ -8,7 +8,7 @@ class ProjectionDelete(BaseActionTestCase):
         self.set_models(
             {
                 "meeting/1": {
-                    "all_projection_ids": [12, 13],
+                    "all_projection_ids": [12, 13, 14],
                     "projector_ids": [1],
                     "is_active_in_organization_id": 1,
                 },
@@ -38,10 +38,10 @@ class ProjectionDelete(BaseActionTestCase):
         response = self.request("projection.delete", {"id": 14})
         self.assert_status_code(response, 400)
         assert (
-            "Projection must have a current_projector_id or a preview_projector_id."
+            "Projection 14 must have a current_projector_id or a preview_projector_id."
             in response.json["message"]
         )
-        self.assert_model_exists("projection/13")
+        self.assert_model_exists("projection/14")
 
     def test_delete_no_permissions(self) -> None:
         self.base_permission_test({}, "projection.delete", {"id": 12})


### PR DESCRIPTION
Allows projection.delete on meeting.delete-action, even without current_ or preview_projector_id. This coontinues to be forbidden for a single projection.delete