### PR TITLE
Issue1150 Use execute_action_internally

### DIFF
--- a/openslides_backend/action/action.py
+++ b/openslides_backend/action/action.py
@@ -102,7 +102,6 @@ class Action(BaseAction, metaclass=SchemaProvider):
         relation_manager: RelationManager,
         logging: LoggingModule,
         skip_archived_meeting_check: bool = False,
-        parent_action: str = "",
     ) -> None:
         self.services = services
         self.auth = services.authentication()
@@ -118,7 +117,6 @@ class Action(BaseAction, metaclass=SchemaProvider):
             )
         else:
             self.skip_archived_meeting_check = skip_archived_meeting_check
-        self.parent_action = parent_action
         self.write_requests = []
         self.results = []
 
@@ -561,7 +559,6 @@ class Action(BaseAction, metaclass=SchemaProvider):
             self.relation_manager,
             self.logging,
             skip_archived_meeting_check,
-            self.name,
         )
         write_request, action_results = action.perform(
             action_data, self.user_id, internal=True

--- a/openslides_backend/action/actions/assignment_candidate/delete.py
+++ b/openslides_backend/action/actions/assignment_candidate/delete.py
@@ -30,9 +30,8 @@ class AssignmentCandidateDelete(PermissionMixin, DeleteAction):
             ),
             mapped_fields=["phase", "meeting_id"],
         )
-        if (
-            assignment.get("phase") == "finished"
-            and not self.is_meeting_deleted(assignment.get("meeting_id"))
+        if assignment.get("phase") == "finished" and not self.is_meeting_deleted(
+            assignment.get("meeting_id", 0)
         ):
             raise ActionException(
                 "It is not permitted to remove a candidate from a finished assignment!"

--- a/openslides_backend/action/actions/assignment_candidate/delete.py
+++ b/openslides_backend/action/actions/assignment_candidate/delete.py
@@ -28,11 +28,11 @@ class AssignmentCandidateDelete(PermissionMixin, DeleteAction):
             FullQualifiedId(
                 Collection("assignment"), assignment_candidate["assignment_id"]
             ),
-            mapped_fields=["phase"],
+            mapped_fields=["phase", "meeting_id"],
         )
         if (
             assignment.get("phase") == "finished"
-            and self.parent_action != "meeting.delete"
+            and not self.is_meeting_deleted(assignment.get("meeting_id"))
         ):
             raise ActionException(
                 "It is not permitted to remove a candidate from a finished assignment!"

--- a/openslides_backend/action/actions/projection/delete.py
+++ b/openslides_backend/action/actions/projection/delete.py
@@ -27,7 +27,7 @@ class ProjectionDelete(DeleteAction):
         if not (
             projection.get("current_projector_id")
             or projection.get("preview_projector_id")
-            or self.is_meeting_deleted(projection.get("meeting_id"))
+            or self.is_meeting_deleted(projection.get("meeting_id", 0))
         ):
             raise ActionException(
                 f"Projection {instance['id']} must have a current_projector_id or a preview_projector_id."

--- a/openslides_backend/action/actions/projection/delete.py
+++ b/openslides_backend/action/actions/projection/delete.py
@@ -22,12 +22,12 @@ class ProjectionDelete(DeleteAction):
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
         projection = self.datastore.get(
             FullQualifiedId(self.model.collection, instance["id"]),
-            ["current_projector_id", "preview_projector_id"],
+            ["current_projector_id", "preview_projector_id", "meeting_id"],
         )
         if not (
             projection.get("current_projector_id")
             or projection.get("preview_projector_id")
-            or self.parent_action == "meeting.delete"  # Issue1144
+            or self.is_meeting_deleted(projection.get("meeting_id"))
         ):
             raise ActionException(
                 f"Projection {instance['id']} must have a current_projector_id or a preview_projector_id."

--- a/openslides_backend/action/actions/projector/delete.py
+++ b/openslides_backend/action/actions/projector/delete.py
@@ -26,9 +26,8 @@ class ProjectorDelete(DeleteAction):
             ["used_as_reference_projector_meeting_id", "meeting_id"],
         )
         if (
-            (meeting_id := projector.get("used_as_reference_projector_meeting_id"))
-            and not self.is_meeting_deleted(meeting_id)
-        ):
+            meeting_id := projector.get("used_as_reference_projector_meeting_id")
+        ) and not self.is_meeting_deleted(meeting_id):
             raise ActionException(
                 "A used as reference projector is not allowed to delete."
             )

--- a/openslides_backend/action/actions/projector/delete.py
+++ b/openslides_backend/action/actions/projector/delete.py
@@ -28,7 +28,6 @@ class ProjectorDelete(DeleteAction):
         if (
             (meeting_id := projector.get("used_as_reference_projector_meeting_id"))
             and not self.is_meeting_deleted(meeting_id)
-            and self.parent_action != "meeting.delete"
         ):
             raise ActionException(
                 "A used as reference projector is not allowed to delete."

--- a/openslides_backend/action/actions/projector_countdown/delete.py
+++ b/openslides_backend/action/actions/projector_countdown/delete.py
@@ -33,7 +33,6 @@ class ProjectorCountdownDelete(DeleteAction):
         if (
             meeting_id
             and not self.is_meeting_deleted(meeting_id)
-            and self.parent_action != "meeting.delete"
         ):
             raise ActionException(
                 "List of speakers or poll countdown is not allowed to delete."

--- a/openslides_backend/action/actions/projector_countdown/delete.py
+++ b/openslides_backend/action/actions/projector_countdown/delete.py
@@ -30,10 +30,7 @@ class ProjectorCountdownDelete(DeleteAction):
         meeting_id = projector_countdown.get(
             "used_as_list_of_speaker_countdown_meeting_id"
         ) or projector_countdown.get("used_as_poll_countdown_meeting_id")
-        if (
-            meeting_id
-            and not self.is_meeting_deleted(meeting_id)
-        ):
+        if meeting_id and not self.is_meeting_deleted(meeting_id):
             raise ActionException(
                 "List of speakers or poll countdown is not allowed to delete."
             )

--- a/tests/system/action/base.py
+++ b/tests/system/action/base.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 from openslides_backend.action.relations.relation_manager import RelationManager
 from openslides_backend.action.util.actions_map import actions_map
 from openslides_backend.action.util.crypto import get_random_string
-from openslides_backend.action.util.typing import Payload
+from openslides_backend.action.util.typing import ActionResults, Payload
 from openslides_backend.http.views.action_view import ActionView
 from openslides_backend.permissions.management_levels import (
     CommitteeManagementLevel,
@@ -61,7 +61,7 @@ class BaseActionTestCase(BaseSystemTestCase):
 
     def execute_action_internally(
         self, action_name: str, data: Dict[str, Any], user_id: int = 0
-    ) -> None:
+    ) -> Optional[ActionResults]:
         """
         Shorthand to execute an action internally where all permissions etc. are ignored.
         Useful when an action is just execute for the end result and not for testing it.
@@ -72,10 +72,13 @@ class BaseActionTestCase(BaseSystemTestCase):
         )
         action_data = deepcopy(data)
         with self.datastore.get_database_context():
-            write_request, _ = action.perform([action_data], user_id, internal=True)
+            write_request, result = action.perform(
+                [action_data], user_id, internal=True
+            )
         if write_request:
             self.datastore.write(write_request)
         self.datastore.reset()
+        return result
 
     def create_meeting(self, base: int = 1) -> None:
         """

--- a/tests/system/action/meeting/test_clone.py
+++ b/tests/system/action/meeting/test_clone.py
@@ -535,7 +535,7 @@ class MeetingClone(BaseActionTestCase):
     def test_clone_with_created_topic_and_agenda_type(self) -> None:
         self.set_models(self.test_models)
 
-        response = self.request(
+        self.execute_action_internally(
             "topic.create",
             {
                 "meeting_id": 1,
@@ -544,8 +544,7 @@ class MeetingClone(BaseActionTestCase):
                 "agenda_duration": 60,
             },
         )
-        self.assert_status_code(response, 200)
-        topic_fqid = f'topic/{response.json["results"][0][0]["id"]}'
+        topic_fqid = "topic/1"
         topic = self.get_model(topic_fqid)
         self.assertNotIn("agenda_type", topic)
         self.assertNotIn("agenda_duration", topic)

--- a/tests/system/action/meeting/test_clone.py
+++ b/tests/system/action/meeting/test_clone.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List, cast
 from unittest.mock import MagicMock
 
 from openslides_backend.models.models import AgendaItem
@@ -427,7 +427,7 @@ class MeetingClone(BaseActionTestCase):
                 "user/3": {"committee_ids": [1]},
             }
         )
-        response = self.request(
+        self.execute_action_internally(
             "meeting.create",
             {
                 "committee_id": 1,
@@ -441,7 +441,6 @@ class MeetingClone(BaseActionTestCase):
                 "organization_tag_ids": [],
             },
         )
-        self.assert_status_code(response, 200)
         response = self.request("meeting.clone", {"meeting_id": 1})
         self.assert_status_code(response, 200)
 
@@ -535,7 +534,7 @@ class MeetingClone(BaseActionTestCase):
     def test_clone_with_created_topic_and_agenda_type(self) -> None:
         self.set_models(self.test_models)
 
-        self.execute_action_internally(
+        result = self.execute_action_internally(
             "topic.create",
             {
                 "meeting_id": 1,
@@ -544,7 +543,7 @@ class MeetingClone(BaseActionTestCase):
                 "agenda_duration": 60,
             },
         )
-        topic_fqid = "topic/1"
+        topic_fqid = f"topic/{cast(List[Dict[str, int]], result)[0]['id']}"
         topic = self.get_model(topic_fqid)
         self.assertNotIn("agenda_type", topic)
         self.assertNotIn("agenda_duration", topic)


### PR DESCRIPTION
Missing part from review of #1151
Maybe there is more to do on meeting.clone problem:

motion/48: Invalid fields workflow_id (value: 5)  After simple amendment motion on new crated meeting