### PR TITLE
Fix typo in permissions of check_mediafile_id presenter.

### DIFF
--- a/openslides_backend/presenter/check_mediafile_id.py
+++ b/openslides_backend/presenter/check_mediafile_id.py
@@ -125,7 +125,7 @@ class CheckMediafileId(BasePresenter):
                 self.datastore,
                 self.user_id,
                 CommitteeManagementLevel.CAN_MANAGE,
-                meeting["committe_id"],
+                meeting["committee_id"],
             ):
                 return True
         return False


### PR DESCRIPTION
Fixes a typo. 