### PR TITLE
Opentelemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,10 +122,10 @@ run-dev-otel: | start-dev-otel run-dev-attach
 # Build and run development container with local datastore and opentelemetry enabled and jaeger tracing (web UI binds to port 16686)
 
 start-dev-local-ds-otel:
-	USER_ID=$$(id -u $${USER}) GROUP_ID=$$(id -g $${USER}) docker-compose -f dev/docker-compose.dev.yml -f dev/dc.otel.yml -f dev/dc.otel.yml up --build --detach
+	USER_ID=$$(id -u $${USER}) GROUP_ID=$$(id -g $${USER}) docker-compose -f dev/docker-compose.dev.yml -f dev/dc.local-ds.yml -f dev/dc.otel.yml up --build --detach
 
 stop-dev-local-ds-otel:
-	docker-compose -f dev/docker-compose.dev.yml -f dev/dc.otel.yml -f dev/dc.otel.yml down --volumes
+	docker-compose -f dev/docker-compose.dev.yml -f dev/dc.local-ds.yml -f dev/dc.otel.yml down --volumes
 
 run-dev-local-ds-otel: | start-dev-local-ds-otel run-dev-attach
 

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,28 @@ run-dev-attach-local-ds:
 run-dev-local-ds run-bash-local-ds: | start-dev-local-ds run-dev-attach-local-ds
 
 
+# Build and run development container with opentelemetry enabled and jaeger tracing (web UI binds to port 16686)
+
+start-dev-otel:
+	USER_ID=$$(id -u $${USER}) GROUP_ID=$$(id -g $${USER}) docker-compose -f dev/docker-compose.dev.yml -f dev/dc.otel.yml up --build --detach
+
+stop-dev-otel:
+	docker-compose -f dev/docker-compose.dev.yml -f dev/dc.otel.yml down --volumes
+
+run-dev-otel: | start-dev-otel run-dev-attach
+
+
+# Build and run development container with local datastore and opentelemetry enabled and jaeger tracing (web UI binds to port 16686)
+
+start-dev-local-ds-otel:
+	USER_ID=$$(id -u $${USER}) GROUP_ID=$$(id -g $${USER}) docker-compose -f dev/docker-compose.dev.yml -f dev/dc.otel.yml -f dev/dc.otel.yml up --build --detach
+
+stop-dev-local-ds-otel:
+	docker-compose -f dev/docker-compose.dev.yml -f dev/dc.otel.yml -f dev/dc.otel.yml down --volumes
+
+run-dev-local-ds-otel: | start-dev-local-ds-otel run-dev-attach
+
+
 # Build standalone development container (not usable inside the docker container)
 
 build-dev:

--- a/dev/dc.otel.yml
+++ b/dev/dc.otel.yml
@@ -1,0 +1,22 @@
+version: "3"
+services:
+
+  collector:
+    image: otel/opentelemetry-collector:0.41.0
+    command: ["--config=/etc/otel-collector-config.yml"]
+    volumes:
+      - ./otel-collector-config.yml:/etc/otel-collector-config.yml
+    networks:
+      - datastore
+      - auth
+      - otel
+
+  jaeger:
+    image: jaegertracing/all-in-one
+    ports:
+      - "16686:16686"
+    networks:
+      - otel
+
+networks:
+  otel:

--- a/dev/dc.otel.yml
+++ b/dev/dc.otel.yml
@@ -1,5 +1,20 @@
 version: "3"
 services:
+  backend:
+    environment:
+      - OPENTELEMETRY_ENABLED=1
+  reader:
+    environment:
+      - OPENTELEMETRY_ENABLED=1
+  writer:
+    environment:
+      - OPENTELEMETRY_ENABLED=1
+  auth:
+    environment:
+      - OPENTELEMETRY_ENABLED=1
+  vote:
+    environment:
+      - OPENTELEMETRY_ENABLED=1
 
   collector:
     image: otel/opentelemetry-collector:0.41.0

--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -19,6 +19,7 @@ services:
             - ../global:/app/global
             - ../scripts:/app/scripts
         environment:
+            - OPENTELEMETRY_ENABLED=0
             - DATASTORE_READER_HOST=reader
             - DATASTORE_READER_PORT=9010
             - DATASTORE_WRITER_HOST=writer
@@ -41,6 +42,7 @@ services:
             - "9010:9010"
         environment:
             - OPENSLIDES_DEVELOPMENT=1
+            - OPENTELEMETRY_ENABLED=0
         depends_on:
             - postgresql
         networks:
@@ -57,6 +59,7 @@ services:
             - "9011:9011"
         environment:
             - OPENSLIDES_DEVELOPMENT=1
+            - OPENTELEMETRY_ENABLED=0
         depends_on:
             - postgresql
             - redis
@@ -72,6 +75,7 @@ services:
         ports:
             - "9004:9004"
         environment:
+            - OPENTELEMETRY_ENABLED=0
             - MESSAGE_BUS_HOST=redis
             - CACHE_HOST=cache
             - DATASTORE_READER_HOST=reader
@@ -96,6 +100,7 @@ services:
             - "9013:9013"
         environment:
             - OPENSLIDES_DEVELOPMENT=true
+            - OPENTELEMETRY_ENABLED=0
             - VOTE_HOST=vote
             - VOTE_PORT=9013
             - DATASTORE_READER_HOST=reader

--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -48,7 +48,8 @@ services:
             - postgresql
     writer:
         build:
-            context: "https://github.com/OpenSlides/openslides-datastore-service.git#main"
+            #context: "https://github.com/OpenSlides/openslides-datastore-service.git#main"
+            context: ../../openslides-datastore-service
             args:
                 MODULE: "writer"
                 PORT: "9011"

--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -48,8 +48,7 @@ services:
             - postgresql
     writer:
         build:
-            #context: "https://github.com/OpenSlides/openslides-datastore-service.git#main"
-            context: ../../openslides-datastore-service
+            context: "https://github.com/OpenSlides/openslides-datastore-service.git#main"
             args:
                 MODULE: "writer"
                 PORT: "9011"

--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -32,8 +32,7 @@ services:
             - auth
     reader:
         build:
-            #context: "https://github.com/OpenSlides/openslides-datastore-service.git#main"
-            context: ../../openslides-datastore-service
+            context: "https://github.com/OpenSlides/openslides-datastore-service.git#main"
             args:
                 MODULE: "reader"
                 PORT: "9010"
@@ -49,8 +48,7 @@ services:
             - postgresql
     writer:
         build:
-            #context: "https://github.com/OpenSlides/openslides-datastore-service.git#main"
-            context: ../../openslides-datastore-service
+            context: "https://github.com/OpenSlides/openslides-datastore-service.git#main"
             args:
                 MODULE: "writer"
                 PORT: "9011"

--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -19,7 +19,6 @@ services:
             - ../global:/app/global
             - ../scripts:/app/scripts
         environment:
-            - OPENTELEMETRY_ENABLED=0
             - DATASTORE_READER_HOST=reader
             - DATASTORE_READER_PORT=9010
             - DATASTORE_WRITER_HOST=writer
@@ -33,7 +32,8 @@ services:
             - auth
     reader:
         build:
-            context: "https://github.com/OpenSlides/openslides-datastore-service.git#main"
+            #context: "https://github.com/OpenSlides/openslides-datastore-service.git#main"
+            context: ../../openslides-datastore-service
             args:
                 MODULE: "reader"
                 PORT: "9010"
@@ -42,7 +42,6 @@ services:
             - "9010:9010"
         environment:
             - OPENSLIDES_DEVELOPMENT=1
-            - OPENTELEMETRY_ENABLED=0
         depends_on:
             - postgresql
         networks:
@@ -50,7 +49,8 @@ services:
             - postgresql
     writer:
         build:
-            context: "https://github.com/OpenSlides/openslides-datastore-service.git#main"
+            #context: "https://github.com/OpenSlides/openslides-datastore-service.git#main"
+            context: ../../openslides-datastore-service
             args:
                 MODULE: "writer"
                 PORT: "9011"
@@ -59,7 +59,6 @@ services:
             - "9011:9011"
         environment:
             - OPENSLIDES_DEVELOPMENT=1
-            - OPENTELEMETRY_ENABLED=0
         depends_on:
             - postgresql
             - redis
@@ -75,7 +74,6 @@ services:
         ports:
             - "9004:9004"
         environment:
-            - OPENTELEMETRY_ENABLED=0
             - MESSAGE_BUS_HOST=redis
             - CACHE_HOST=cache
             - DATASTORE_READER_HOST=reader
@@ -100,7 +98,6 @@ services:
             - "9013:9013"
         environment:
             - OPENSLIDES_DEVELOPMENT=true
-            - OPENTELEMETRY_ENABLED=0
             - VOTE_HOST=vote
             - VOTE_PORT=9013
             - DATASTORE_READER_HOST=reader

--- a/dev/otel-collector-config.yml
+++ b/dev/otel-collector-config.yml
@@ -1,0 +1,21 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+      grpc:
+
+exporters:
+  jaeger:
+    endpoint: jaeger:14250  
+    tls:
+      insecure: true
+
+processors:
+  batch:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [ jaeger]

--- a/dev/otel-collector-config.yml
+++ b/dev/otel-collector-config.yml
@@ -6,7 +6,7 @@ receivers:
 
 exporters:
   jaeger:
-    endpoint: jaeger:14250  
+    endpoint: jaeger:14250
     tls:
       insecure: true
 

--- a/dev/otel-collector-config.yml
+++ b/dev/otel-collector-config.yml
@@ -18,4 +18,4 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [ jaeger]
+      exporters: [jaeger]

--- a/openslides_backend/action/action_handler.py
+++ b/openslides_backend/action/action_handler.py
@@ -3,8 +3,8 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar
 
 import fastjsonschema
 
+from . import actions  # noqa
 from ..shared.env import is_dev_mode
-from ..shared.otel import make_span
 from ..shared.exceptions import (
     ActionException,
     DatastoreLockedException,
@@ -14,8 +14,8 @@ from ..shared.handlers.base_handler import BaseHandler
 from ..shared.interfaces.logging import LoggingModule
 from ..shared.interfaces.services import Services
 from ..shared.interfaces.write_request import WriteRequest
+from ..shared.otel import make_span
 from ..shared.schema import schema_version
-from . import actions  # noqa
 from .relations.relation_manager import RelationManager
 from .util.action_type import ActionType
 from .util.actions_map import actions_map

--- a/openslides_backend/action/action_handler.py
+++ b/openslides_backend/action/action_handler.py
@@ -130,7 +130,7 @@ class ActionHandler(BaseHandler):
                         error = cast(ActionError, exception.get_json())
                         results.append(error)
                     self.datastore.reset()
-        
+
         with make_span("finish action"):
             # execute cleanup methods
             for on_success in self.on_success:

--- a/openslides_backend/action/action_handler.py
+++ b/openslides_backend/action/action_handler.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar
 import fastjsonschema
 
 from ..shared.env import is_dev_mode
+from ..shared.otel import make_span
 from ..shared.exceptions import (
     ActionException,
     DatastoreLockedException,
@@ -102,41 +103,44 @@ class ActionHandler(BaseHandler):
         self.user_id = user_id
         self.internal = internal
 
-        try:
-            payload_schema(payload)
-        except fastjsonschema.JsonSchemaException as exception:
-            raise ActionException(exception.message)
+        with make_span("verify payload"):
+            try:
+                payload_schema(payload)
+            except fastjsonschema.JsonSchemaException as exception:
+                raise ActionException(exception.message)
 
-        results: ActionsResponseResults = []
-        if atomic:
-            results = self.execute_write_requests(self.parse_actions, payload)
-        else:
+        with make_span("write requests..."):
+            results: ActionsResponseResults = []
+            if atomic:
+                results = self.execute_write_requests(self.parse_actions, payload)
+            else:
 
-            def transform_to_list(
-                tuple: Tuple[Optional[WriteRequest], Optional[ActionResults]]
-            ) -> Tuple[List[WriteRequest], Optional[ActionResults]]:
-                return ([tuple[0]] if tuple[0] is not None else [], tuple[1])
+                def transform_to_list(
+                    tuple: Tuple[Optional[WriteRequest], Optional[ActionResults]]
+                ) -> Tuple[List[WriteRequest], Optional[ActionResults]]:
+                    return ([tuple[0]] if tuple[0] is not None else [], tuple[1])
 
-            for element in payload:
-                try:
-                    result = self.execute_write_requests(
-                        lambda e: transform_to_list(self.perform_action(e)), element
-                    )
-                    results.append(result)
-                except ActionException as exception:
-                    error = cast(ActionError, exception.get_json())
-                    results.append(error)
-                self.datastore.reset()
+                for element in payload:
+                    try:
+                        result = self.execute_write_requests(
+                            lambda e: transform_to_list(self.perform_action(e)), element
+                        )
+                        results.append(result)
+                    except ActionException as exception:
+                        error = cast(ActionError, exception.get_json())
+                        results.append(error)
+                    self.datastore.reset()
+        
+        with make_span("finish action"):
+            # execute cleanup methods
+            for on_success in self.on_success:
+                on_success()
 
-        # execute cleanup methods
-        for on_success in self.on_success:
-            on_success()
-
-        # Return action result
-        self.logger.debug("Request was successful. Send response now.")
-        return ActionsResponse(
-            success=True, message="Actions handled successfully", results=results
-        )
+            # Return action result
+            self.logger.debug("Request was successful. Send response now.")
+            return ActionsResponse(
+                success=True, message="Actions handled successfully", results=results
+            )
 
     def execute_write_requests(
         self,

--- a/openslides_backend/http/views/base_view.py
+++ b/openslides_backend/http/views/base_view.py
@@ -12,7 +12,6 @@ from ...shared.otel import make_span
 from ..http_exceptions import MethodNotAllowed, NotFound
 from ..request import Request
 
-
 ROUTE_OPTIONS_ATTR = "__route_options"
 
 RouteFunction = Callable[[Any, Request], Tuple[ResponseBody, Optional[str]]]

--- a/openslides_backend/http/views/base_view.py
+++ b/openslides_backend/http/views/base_view.py
@@ -88,14 +88,16 @@ class BaseView(View):
             predicate=lambda attr: inspect.ismethod(attr)
             and hasattr(attr, ROUTE_OPTIONS_ATTR),
         )
-        with make_span("base view") as span:
+        with make_span("base view"):
             for _, func in functions:
                 route_options_list = getattr(func, ROUTE_OPTIONS_ATTR)
                 for route_options in route_options_list:
                     if route_options["path"].match(request.environ["RAW_URI"]):
                         # Check request method
                         if request.method != route_options["method"]:
-                            raise MethodNotAllowed(valid_methods=[route_options["method"]])
+                            raise MethodNotAllowed(
+                                valid_methods=[route_options["method"]]
+                            )
                         self.logger.debug(f"Request method is {request.method}.")
 
                         if route_options["json"]:

--- a/openslides_backend/http/views/base_view.py
+++ b/openslides_backend/http/views/base_view.py
@@ -1,9 +1,11 @@
+import os
 import inspect
 import re
 from typing import Any, Callable, Dict, List, Optional, Pattern, Tuple, Union
 
 from werkzeug.exceptions import BadRequest as WerkzeugBadRequest
 
+from ...shared.env import is_truthy
 from ...shared.exceptions import View400Exception
 from ...shared.interfaces.logging import LoggingModule
 from ...shared.interfaces.services import Services
@@ -11,8 +13,9 @@ from ...shared.interfaces.wsgi import Headers, ResponseBody, View
 from ..http_exceptions import MethodNotAllowed, NotFound
 from ..request import Request
 
+if is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
+    from opentelemetry import trace
 
-from opentelemetry import trace
 
 ROUTE_OPTIONS_ATTR = "__route_options"
 
@@ -57,7 +60,8 @@ def route(
     return wrapper
 
 
-tracer = trace.get_tracer(__name__)
+if is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
+    tracer = trace.get_tracer(__name__)
 
 class BaseView(View):
     """
@@ -92,7 +96,7 @@ class BaseView(View):
             predicate=lambda attr: inspect.ismethod(attr)
             and hasattr(attr, ROUTE_OPTIONS_ATTR),
         )
-        with tracer.start_as_current_span("base view") as span:
+        def do_dispatch(request: Request) -> Tuple[ResponseBody, Optional[str]]:
             for _, func in functions:
                 route_options_list = getattr(func, ROUTE_OPTIONS_ATTR)
                 for route_options in route_options_list:
@@ -116,3 +120,9 @@ class BaseView(View):
 
                         return func(request)
             raise NotFound()
+
+        if is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
+            with tracer.start_as_current_span("base view") as span:
+                return do_dispatch(request)
+        else:
+            return do_dispatch(request)

--- a/openslides_backend/main.py
+++ b/openslides_backend/main.py
@@ -25,6 +25,7 @@ DEFAULT_ADDRESSES = {
     "PresenterView": "0.0.0.0:9003",
 }
 
+
 class OpenSlidesBackendGunicornApplication(BaseApplication):  # pragma: no cover
     """
     Standalone application class for Gunicorn. It prepares Gunicorn for using

--- a/openslides_backend/main.py
+++ b/openslides_backend/main.py
@@ -23,6 +23,18 @@ DEFAULT_ADDRESSES = {
     "PresenterView": "0.0.0.0:9003",
 }
 
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+    OTLPSpanExporter,
+)
+
+RequestsInstrumentor().instrument()
+
+
 
 class OpenSlidesBackendGunicornApplication(BaseApplication):  # pragma: no cover
     """
@@ -64,6 +76,19 @@ class OpenSlidesBackendGunicornApplication(BaseApplication):  # pragma: no cover
 
         # TODO: Fix this typing problem.
         logging_module: LoggingModule = logging  # type: ignore
+
+        span_exporter = OTLPSpanExporter(
+            # optional
+            endpoint="collector:4317",
+            # credentials=ChannelCredentials(credentials),
+            # headers=(("metadata", "metadata")),
+        )
+        tracer_provider = TracerProvider(
+            resource=Resource.create({SERVICE_NAME: "bakend"})
+        )
+        trace.set_tracer_provider(tracer_provider)
+        span_processor = BatchSpanProcessor(span_exporter)
+        tracer_provider.add_span_processor(span_processor)
 
         return create_wsgi_application(logging_module, self.view_name)
 

--- a/openslides_backend/main.py
+++ b/openslides_backend/main.py
@@ -25,8 +25,6 @@ DEFAULT_ADDRESSES = {
     "PresenterView": "0.0.0.0:9003",
 }
 
-otel_instrument_requests()
-
 class OpenSlidesBackendGunicornApplication(BaseApplication):  # pragma: no cover
     """
     Standalone application class for Gunicorn. It prepares Gunicorn for using
@@ -68,7 +66,10 @@ class OpenSlidesBackendGunicornApplication(BaseApplication):  # pragma: no cover
         # TODO: Fix this typing problem.
         logging_module: LoggingModule = logging  # type: ignore
 
+        print("PRE OTEL INIT")
+        otel_instrument_requests()
         otel_init("backend")
+        print("POST OTEL INIT")
         return create_wsgi_application(logging_module, self.view_name)
 
 

--- a/openslides_backend/main.py
+++ b/openslides_backend/main.py
@@ -80,9 +80,11 @@ class OpenSlidesBackendGunicornApplication(BaseApplication):  # pragma: no cover
         if is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
             collector_host = os.environ.get("OPENTELEMETRY_COLLECTOR_HOST", "collector")
             collector_port = os.environ.get("OPENTELEMETRY_COLLECTOR_PORT", "4317")
+            print("otel exporter endpoint: " + f"{collector_host}:{collector_port}")
             span_exporter = OTLPSpanExporter(
+                endpoint=f"http://{collector_host}:{collector_port}",
+                insecure=True
                 # optional
-                endpoint = f"{collector_host}:{collector_port}"
                 # credentials=ChannelCredentials(credentials),
                 # headers=(("metadata", "metadata")),
             )

--- a/openslides_backend/main.py
+++ b/openslides_backend/main.py
@@ -9,9 +9,11 @@ from typing import Any
 from datastore.reader.app import register_services
 from gunicorn.app.base import BaseApplication
 
-from .shared.env import is_dev_mode, is_truthy
+from .shared.env import is_dev_mode
 from .shared.interfaces.logging import LoggingModule
 from .shared.interfaces.wsgi import WSGIApplication
+from .shared.otel import init as otel_init
+from .shared.otel import instrument_requests as otel_instrument_requests
 
 register_services()
 
@@ -23,18 +25,7 @@ DEFAULT_ADDRESSES = {
     "PresenterView": "0.0.0.0:9003",
 }
 
-if is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
-    from opentelemetry import trace
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor
-    from opentelemetry.instrumentation.requests import RequestsInstrumentor
-    from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
-        OTLPSpanExporter,
-    )
-
-    RequestsInstrumentor().instrument()
-
+otel_instrument_requests()
 
 class OpenSlidesBackendGunicornApplication(BaseApplication):  # pragma: no cover
     """
@@ -77,24 +68,7 @@ class OpenSlidesBackendGunicornApplication(BaseApplication):  # pragma: no cover
         # TODO: Fix this typing problem.
         logging_module: LoggingModule = logging  # type: ignore
 
-        if is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
-            collector_host = os.environ.get("OPENTELEMETRY_COLLECTOR_HOST", "collector")
-            collector_port = os.environ.get("OPENTELEMETRY_COLLECTOR_PORT", "4317")
-            print("otel exporter endpoint: " + f"{collector_host}:{collector_port}")
-            span_exporter = OTLPSpanExporter(
-                endpoint=f"http://{collector_host}:{collector_port}",
-                insecure=True
-                # optional
-                # credentials=ChannelCredentials(credentials),
-                # headers=(("metadata", "metadata")),
-            )
-            tracer_provider = TracerProvider(
-                resource=Resource.create({SERVICE_NAME: "backend"})
-            )
-            trace.set_tracer_provider(tracer_provider)
-            span_processor = BatchSpanProcessor(span_exporter)
-            tracer_provider.add_span_processor(span_processor)
-
+        otel_init("backend")
         return create_wsgi_application(logging_module, self.view_name)
 
 

--- a/openslides_backend/main.py
+++ b/openslides_backend/main.py
@@ -9,7 +9,7 @@ from typing import Any
 from datastore.reader.app import register_services
 from gunicorn.app.base import BaseApplication
 
-from .shared.env import is_dev_mode
+from .shared.env import is_dev_mode, is_truthy
 from .shared.interfaces.logging import LoggingModule
 from .shared.interfaces.wsgi import WSGIApplication
 
@@ -23,17 +23,17 @@ DEFAULT_ADDRESSES = {
     "PresenterView": "0.0.0.0:9003",
 }
 
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.instrumentation.requests import RequestsInstrumentor
-from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
-    OTLPSpanExporter,
-)
+if is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.instrumentation.requests import RequestsInstrumentor
+    from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        OTLPSpanExporter,
+    )
 
-RequestsInstrumentor().instrument()
-
+    RequestsInstrumentor().instrument()
 
 
 class OpenSlidesBackendGunicornApplication(BaseApplication):  # pragma: no cover
@@ -77,18 +77,21 @@ class OpenSlidesBackendGunicornApplication(BaseApplication):  # pragma: no cover
         # TODO: Fix this typing problem.
         logging_module: LoggingModule = logging  # type: ignore
 
-        span_exporter = OTLPSpanExporter(
-            # optional
-            endpoint="collector:4317",
-            # credentials=ChannelCredentials(credentials),
-            # headers=(("metadata", "metadata")),
-        )
-        tracer_provider = TracerProvider(
-            resource=Resource.create({SERVICE_NAME: "bakend"})
-        )
-        trace.set_tracer_provider(tracer_provider)
-        span_processor = BatchSpanProcessor(span_exporter)
-        tracer_provider.add_span_processor(span_processor)
+        if is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
+            collector_host = os.environ.get("OPENTELEMETRY_COLLECTOR_HOST", "collector")
+            collector_port = os.environ.get("OPENTELEMETRY_COLLECTOR_PORT", "4317")
+            span_exporter = OTLPSpanExporter(
+                # optional
+                endpoint = f"{collector_host}:{collector_port}"
+                # credentials=ChannelCredentials(credentials),
+                # headers=(("metadata", "metadata")),
+            )
+            tracer_provider = TracerProvider(
+                resource=Resource.create({SERVICE_NAME: "backend"})
+            )
+            trace.set_tracer_provider(tracer_provider)
+            span_processor = BatchSpanProcessor(span_exporter)
+            tracer_provider.add_span_processor(span_processor)
 
         return create_wsgi_application(logging_module, self.view_name)
 

--- a/openslides_backend/main.py
+++ b/openslides_backend/main.py
@@ -66,10 +66,8 @@ class OpenSlidesBackendGunicornApplication(BaseApplication):  # pragma: no cover
         # TODO: Fix this typing problem.
         logging_module: LoggingModule = logging  # type: ignore
 
-        print("PRE OTEL INIT")
         otel_instrument_requests()
         otel_init("backend")
-        print("POST OTEL INIT")
         return create_wsgi_application(logging_module, self.view_name)
 
 

--- a/openslides_backend/shared/otel.py
+++ b/openslides_backend/shared/otel.py
@@ -1,6 +1,61 @@
-from datastore.shared.util.otel import *
+import os
+from contextlib import nullcontext
 
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+from .env import is_truthy
+
+"""
+Initializes the opentelemetry components and connection to the otel collector.
+"""
+def init(service_name):
+    if not is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
+        return
+
+    span_exporter = OTLPSpanExporter(
+        endpoint=f"http://collector:4317",
+        insecure=True
+        # optional
+        # credentials=ChannelCredentials(credentials),
+        # headers=(("metadata", "metadata")),
+    )
+    tracer_provider = TracerProvider(
+        resource=Resource.create({SERVICE_NAME: service_name})
+    )
+    trace.set_tracer_provider(tracer_provider)
+    span_processor = BatchSpanProcessor(span_exporter)
+    tracer_provider.add_span_processor(span_processor)
 
 def instrument_requests():
     RequestsInstrumentor().instrument()
+
+"""
+Returns a new child span to the currently active span.
+If OPENTELEMETRY_ENABLED is not truthy a nullcontext will be returned instead.
+So at any point in the code this function can be called in a with statement
+without any additional checking needed.
+
+Example:
+```
+with make_span("foo") as span:
+    ...
+    with make_span("bar") as subspan:
+        ...
+```
+"""
+
+def make_span(name, attributes=None):
+    if not is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
+        return nullcontext()
+
+    tracer = trace.get_tracer(__name__)
+    span = tracer.start_as_current_span(name)
+    if attributes is not None:
+        span.set_attributes(attributes)
+
+    return span

--- a/openslides_backend/shared/otel.py
+++ b/openslides_backend/shared/otel.py
@@ -48,7 +48,6 @@ with make_span("foo") as span:
         ...
 ```
 """
-
 def make_span(name, attributes=None):
     if not is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
         return nullcontext()

--- a/openslides_backend/shared/otel.py
+++ b/openslides_backend/shared/otel.py
@@ -1,0 +1,56 @@
+import os
+from contextlib import nullcontext
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+from .env import is_truthy
+
+"""
+Initializes the opentelemetry components and connection to the otel collector.
+"""
+def init(service_name):
+    if not is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
+        return
+
+    span_exporter = OTLPSpanExporter(
+        endpoint=f"http://collector:4317",
+        insecure=True
+        # optional
+        # credentials=ChannelCredentials(credentials),
+        # headers=(("metadata", "metadata")),
+    )
+    tracer_provider = TracerProvider(
+        resource=Resource.create({SERVICE_NAME: service_name})
+    )
+    trace.set_tracer_provider(tracer_provider)
+    span_processor = BatchSpanProcessor(span_exporter)
+    tracer_provider.add_span_processor(span_processor)
+
+def instrument_requests():
+    RequestsInstrumentor().instrument()
+
+"""
+Returns a new child span to the currently active span.
+If OPENTELEMETRY_ENABLED is not truthy a nullcontext will be returned instead.
+So at any point in the code this function can be called in a with statement
+without any additional checking needed.
+
+Example:
+```
+with make_span("foo") as span:
+    ...
+    with make_span("bar") as subspan:
+        ...
+```
+"""
+def make_span(name):
+    if not is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
+        return nullcontext()
+
+    tracer = trace.get_tracer(__name__)
+    return tracer.start_as_current_span(name)

--- a/openslides_backend/shared/otel.py
+++ b/openslides_backend/shared/otel.py
@@ -55,8 +55,6 @@ def make_span(name, attributes=None):
 
     #tracer = trace.get_tracer(__name__)
     tracer = trace.get_tracer_provider().get_tracer(__name__)
-    span = tracer.start_as_current_span(name)
-    if attributes is not None:
-        span.set_attributes(attributes)
+    span = tracer.start_as_current_span(name, attributes=attributes)
 
     return span

--- a/openslides_backend/shared/otel.py
+++ b/openslides_backend/shared/otel.py
@@ -2,13 +2,14 @@ import os
 from contextlib import nullcontext
 
 from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from .env import is_truthy
+
 
 """
 Initializes the opentelemetry components and connection to the otel collector.

--- a/openslides_backend/shared/otel.py
+++ b/openslides_backend/shared/otel.py
@@ -53,7 +53,8 @@ def make_span(name, attributes=None):
     if not is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
         return nullcontext()
 
-    tracer = trace.get_tracer(__name__)
+    #tracer = trace.get_tracer(__name__)
+    tracer = trace.get_tracer_provider().get_tracer(__name__)
     span = tracer.start_as_current_span(name)
     if attributes is not None:
         span.set_attributes(attributes)

--- a/openslides_backend/shared/otel.py
+++ b/openslides_backend/shared/otel.py
@@ -7,14 +7,15 @@ from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from typing import Any, Dict
 
 from .env import is_truthy
 
 
-"""
-Initializes the opentelemetry components and connection to the otel collector.
-"""
-def init(service_name):
+def init(service_name: str) -> None:
+    """
+    Initializes the opentelemetry components and connection to the otel collector.
+    """
     if not is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
         return
 
@@ -32,28 +33,29 @@ def init(service_name):
     span_processor = BatchSpanProcessor(span_exporter)
     tracer_provider.add_span_processor(span_processor)
 
-def instrument_requests():
+
+def instrument_requests() -> None:
     RequestsInstrumentor().instrument()
 
-"""
-Returns a new child span to the currently active span.
-If OPENTELEMETRY_ENABLED is not truthy a nullcontext will be returned instead.
-So at any point in the code this function can be called in a with statement
-without any additional checking needed.
 
-Example:
-```
-with make_span("foo") as span:
-    ...
-    with make_span("bar") as subspan:
+def make_span(name: str, attributes: Dict[str, str] = None) -> Any:
+    """
+    Returns a new child span to the currently active span.
+    If OPENTELEMETRY_ENABLED is not truthy a nullcontext will be returned instead.
+    So at any point in the code this function can be called in a with statement
+    without any additional checking needed.
+
+    Example:
+    ```
+    with make_span("foo") as span:
         ...
-```
-"""
-def make_span(name, attributes=None):
+        with make_span("bar") as subspan:
+            ...
+    ```
+    """
     if not is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
         return nullcontext()
 
-    #tracer = trace.get_tracer(__name__)
     tracer = trace.get_tracer_provider().get_tracer(__name__)
     span = tracer.start_as_current_span(name, attributes=attributes)
 

--- a/openslides_backend/shared/otel.py
+++ b/openslides_backend/shared/otel.py
@@ -1,56 +1,6 @@
-import os
-from contextlib import nullcontext
+from datastore.shared.util.otel import *
 
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
-from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-
-from .env import is_truthy
-
-"""
-Initializes the opentelemetry components and connection to the otel collector.
-"""
-def init(service_name):
-    if not is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
-        return
-
-    span_exporter = OTLPSpanExporter(
-        endpoint=f"http://collector:4317",
-        insecure=True
-        # optional
-        # credentials=ChannelCredentials(credentials),
-        # headers=(("metadata", "metadata")),
-    )
-    tracer_provider = TracerProvider(
-        resource=Resource.create({SERVICE_NAME: service_name})
-    )
-    trace.set_tracer_provider(tracer_provider)
-    span_processor = BatchSpanProcessor(span_exporter)
-    tracer_provider.add_span_processor(span_processor)
 
 def instrument_requests():
     RequestsInstrumentor().instrument()
-
-"""
-Returns a new child span to the currently active span.
-If OPENTELEMETRY_ENABLED is not truthy a nullcontext will be returned instead.
-So at any point in the code this function can be called in a with statement
-without any additional checking needed.
-
-Example:
-```
-with make_span("foo") as span:
-    ...
-    with make_span("bar") as subspan:
-        ...
-```
-"""
-def make_span(name):
-    if not is_truthy(os.environ.get("OPENTELEMETRY_ENABLED", "false")):
-        return nullcontext()
-
-    tracer = trace.get_tracer(__name__)
-    return tracer.start_as_current_span(name)

--- a/requirements/partial/requirements_production.txt
+++ b/requirements/partial/requirements_production.txt
@@ -13,3 +13,4 @@ opentelemetry-exporter-otlp
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-instrumentation-requests
+opentelemetry-instrumentation-flask

--- a/requirements/partial/requirements_production.txt
+++ b/requirements/partial/requirements_production.txt
@@ -13,4 +13,3 @@ opentelemetry-exporter-otlp
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-flask

--- a/requirements/partial/requirements_production.txt
+++ b/requirements/partial/requirements_production.txt
@@ -9,3 +9,7 @@ bleach==4.1.0
 PyPDF2==1.26.0
 lxml==4.7.1
 git+https://github.com/OpenSlides/openslides-auth-service.git@9e252f33ccde41137a0a7174e8958d8fa3beb2f1#egg=authlib&subdirectory=auth/libraries/pip-auth # authlib
+opentelemetry-exporter-otlp
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-instrumentation-requests


### PR DESCRIPTION
This is the kinda more serious and up-to-date version of #1121 .

In addition to ostcars PR otel can be turned on/off via env var.
For this I put otel-related functionality into a seperate module, which handles initiation and span creation.
Feel free to extend. E.g. I can imagine the `make_span` method could use some more parameters at some point.

Also I adjusted the compose-files and added suitable make targets to be able to view traces for the dev-stack.