### PR TITLE
Add poll.stop performance test & improve general test performance

### DIFF
--- a/openslides_backend/http/views/action_view.py
+++ b/openslides_backend/http/views/action_view.py
@@ -4,9 +4,9 @@ from typing import Optional, Tuple
 from ...action.action_handler import ActionHandler
 from ...migration_handler import assert_migration_index
 from ...migration_handler.migration_handler import MigrationHandler
+from ...services.auth.adapter import AUTHENTICATION_HEADER, COOKIE_NAME
 from ...shared.env import DEV_PASSWORD
 from ...shared.exceptions import ServerError
-from ...services.auth.adapter import AUTHENTICATION_HEADER, COOKIE_NAME
 from ...shared.interfaces.wsgi import ResponseBody
 from ..http_exceptions import Unauthorized
 from ..request import Request

--- a/openslides_backend/http/views/action_view.py
+++ b/openslides_backend/http/views/action_view.py
@@ -33,8 +33,8 @@ class ActionView(BaseView):
         )
         # Set Headers and Cookies in services.
         self.services.vote().set_authentication(
-            request.headers[AUTHENTICATION_HEADER],
-            request.cookies[COOKIE_NAME],
+            request.headers.get(AUTHENTICATION_HEADER),
+            request.cookies.get(COOKIE_NAME),
         )
 
         # Handle request.

--- a/openslides_backend/http/views/action_view.py
+++ b/openslides_backend/http/views/action_view.py
@@ -6,6 +6,7 @@ from ...migration_handler import assert_migration_index
 from ...migration_handler.migration_handler import MigrationHandler
 from ...shared.env import DEV_PASSWORD
 from ...shared.exceptions import ServerError
+from ...services.auth.adapter import AUTHENTICATION_HEADER, COOKIE_NAME
 from ...shared.interfaces.wsgi import ResponseBody
 from ..http_exceptions import Unauthorized
 from ..request import Request
@@ -31,7 +32,10 @@ class ActionView(BaseView):
             request.headers, request.cookies
         )
         # Set Headers and Cookies in services.
-        self.services.vote().set_authentication(request.headers, request.cookies)
+        self.services.vote().set_authentication(
+            request.headers[AUTHENTICATION_HEADER],
+            request.cookies[COOKIE_NAME],
+        )
 
         # Handle request.
         handler = ActionHandler(self.env, self.services, self.logging)

--- a/openslides_backend/services/vote/adapter.py
+++ b/openslides_backend/services/vote/adapter.py
@@ -51,7 +51,9 @@ class VoteAdapter(VoteService):
             )
             raise VoteServiceException(f"Cannot reach the vote service on {endpoint}.")
 
-    def set_authentication(self, access_token: str, refresh_id: str) -> None:
+    def set_authentication(
+        self, access_token: Optional[str], refresh_id: Optional[str]
+    ) -> None:
         self.access_token = access_token
         self.refresh_id = refresh_id
 

--- a/openslides_backend/services/vote/adapter.py
+++ b/openslides_backend/services/vote/adapter.py
@@ -6,7 +6,6 @@ from authlib import AUTHENTICATION_HEADER, COOKIE_NAME
 
 from ...shared.exceptions import VoteServiceException
 from ...shared.interfaces.logging import LoggingModule
-from ...shared.interfaces.wsgi import Headers
 from .interface import VoteService
 
 
@@ -33,7 +32,7 @@ class VoteAdapter(VoteService):
     def make_request(
         self, endpoint: str, payload: Optional[Dict[str, Any]] = None
     ) -> Any:
-        if not self.access_token or not self.cookie:
+        if not self.access_token or not self.refresh_id:
             raise VoteServiceException("You must be logged in to vote")
         payload_json = json.dumps(payload, separators=(",", ":")) if payload else None
         try:
@@ -44,7 +43,7 @@ class VoteAdapter(VoteService):
                     "Content-Type": "application/json",
                     AUTHENTICATION_HEADER: self.access_token,
                 },
-                cookies={COOKIE_NAME: self.cookie},
+                cookies={COOKIE_NAME: self.refresh_id},
             )
         except requests.exceptions.ConnectionError as e:
             self.logger.error(
@@ -52,9 +51,9 @@ class VoteAdapter(VoteService):
             )
             raise VoteServiceException(f"Cannot reach the vote service on {endpoint}.")
 
-    def set_authentication(self, headers: Headers, cookies: Dict) -> None:
-        self.access_token = headers.get(AUTHENTICATION_HEADER, None)
-        self.cookie = cookies.get(COOKIE_NAME, "")
+    def set_authentication(self, access_token: str, refresh_id: str) -> None:
+        self.access_token = access_token
+        self.refresh_id = refresh_id
 
     def start(self, id: int) -> None:
         endpoint = self.get_endpoint("create", id)

--- a/openslides_backend/services/vote/interface.py
+++ b/openslides_backend/services/vote/interface.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, Protocol
 
-from ...shared.interfaces import Headers
-
 
 class VoteService(Protocol):
     """
@@ -20,5 +18,5 @@ class VoteService(Protocol):
     def clear_all(self) -> None:
         """Only for testing purposes."""
 
-    def set_authentication(self, headers: Headers, cookies: Dict) -> None:
+    def set_authentication(self, access_token: str, refresh_id: str) -> None:
         """Set the needed authentication details from the request data."""

--- a/openslides_backend/services/vote/interface.py
+++ b/openslides_backend/services/vote/interface.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Protocol
+from typing import Any, Dict, Optional, Protocol
 
 
 class VoteService(Protocol):
@@ -18,5 +18,7 @@ class VoteService(Protocol):
     def clear_all(self) -> None:
         """Only for testing purposes."""
 
-    def set_authentication(self, access_token: str, refresh_id: str) -> None:
+    def set_authentication(
+        self, access_token: Optional[str], refresh_id: Optional[str]
+    ) -> None:
         """Set the needed authentication details from the request data."""

--- a/tests/system/action/assignment_candidate/test_create.py
+++ b/tests/system/action/assignment_candidate/test_create.py
@@ -9,7 +9,7 @@ DEFAULT_PASSWORD = "password"
 class AssignmentCandidateCreateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model: Dict[str, Dict[str, Any]] = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "user/110": {
                 "username": "test_Xcdfgee",
                 "is_active": True,
@@ -101,7 +101,7 @@ class AssignmentCandidateCreateActionTest(BaseActionTestCase):
         self.user_id = self.create_user("user")
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "assignment_candidate.create", {"assignment_id": 111, "user_id": 110}
         )
@@ -120,7 +120,7 @@ class AssignmentCandidateCreateActionTest(BaseActionTestCase):
                 Permissions.Assignment.CAN_MANAGE,
             ],
         )
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "assignment_candidate.create", {"assignment_id": 111, "user_id": 110}
         )
@@ -129,7 +129,7 @@ class AssignmentCandidateCreateActionTest(BaseActionTestCase):
     def test_create_both_permissions_self(self) -> None:
         self.create_meeting()
         self.user_id = 110
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_user_groups(self.user_id, [3])
         self.set_group_permissions(
             3,
@@ -147,7 +147,7 @@ class AssignmentCandidateCreateActionTest(BaseActionTestCase):
     def test_create_no_permissions_self(self) -> None:
         self.create_meeting()
         self.user_id = 110
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_user_groups(self.user_id, [3])
         self.login(self.user_id)
         response = self.request(
@@ -157,10 +157,10 @@ class AssignmentCandidateCreateActionTest(BaseActionTestCase):
         assert "Missing Permission: assignment.can_manage" in response.json["message"]
 
     def test_create_permissions_no_voting_self(self) -> None:
-        self.permission_test_model["assignment/111"]["phase"] = "search"
+        self.permission_test_models["assignment/111"]["phase"] = "search"
         self.create_meeting()
         self.user_id = 110
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_user_groups(self.user_id, [3])
         self.set_group_permissions(
             3,

--- a/tests/system/action/assignment_candidate/test_delete.py
+++ b/tests/system/action/assignment_candidate/test_delete.py
@@ -9,7 +9,7 @@ DEFAULT_PASSWORD = "password"
 class AssignmentCandidateDeleteActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model: Dict[str, Dict[str, Any]] = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {
                 "name": "name_JhlFOAfK",
                 "assignment_candidate_ids": [111],
@@ -138,7 +138,7 @@ class AssignmentCandidateDeleteActionTest(BaseActionTestCase):
         self.user_id = self.create_user("user")
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request("assignment_candidate.delete", {"id": 111})
         self.assert_status_code(response, 403)
         assert "Missing Permission: assignment.can_manage" in response.json["message"]
@@ -155,14 +155,14 @@ class AssignmentCandidateDeleteActionTest(BaseActionTestCase):
                 Permissions.Assignment.CAN_MANAGE,
             ],
         )
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request("assignment_candidate.delete", {"id": 111})
         self.assert_status_code(response, 200)
 
     def test_delete_both_permissions_self(self) -> None:
         self.create_meeting()
         self.user_id = 110
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_user_groups(self.user_id, [3])
         self.set_group_permissions(
             3,
@@ -178,7 +178,7 @@ class AssignmentCandidateDeleteActionTest(BaseActionTestCase):
     def test_delete_no_permissions_self(self) -> None:
         self.create_meeting()
         self.user_id = 110
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_user_groups(self.user_id, [3])
         self.login(self.user_id)
         response = self.request("assignment_candidate.delete", {"id": 111})
@@ -186,7 +186,7 @@ class AssignmentCandidateDeleteActionTest(BaseActionTestCase):
         assert "Missing Permission: assignment.can_manage" in response.json["message"]
 
     def test_delete_permission_no_voting(self) -> None:
-        self.permission_test_model["assignment/111"]["phase"] = "search"
+        self.permission_test_models["assignment/111"]["phase"] = "search"
         self.create_meeting()
         self.user_id = self.create_user("user")
         self.login(self.user_id)
@@ -197,6 +197,6 @@ class AssignmentCandidateDeleteActionTest(BaseActionTestCase):
                 Permissions.Assignment.CAN_NOMINATE_OTHER,
             ],
         )
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request("assignment_candidate.delete", {"id": 111})
         self.assert_status_code(response, 200)

--- a/tests/system/action/assignment_candidate/test_sort.py
+++ b/tests/system/action/assignment_candidate/test_sort.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class AssignmentCandidateSortActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "assignment/222": {"title": "title_SNLGsvIV", "meeting_id": 1},
             "user/233": {"username": "username_233"},
             "user/234": {"username": "username_234"},
@@ -105,14 +107,14 @@ class AssignmentCandidateSortActionTest(BaseActionTestCase):
 
     def test_create_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "assignment_candidate.sort",
             {"assignment_id": 222, "candidate_ids": [32, 31]},
         )
 
     def test_create_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "assignment_candidate.sort",
             {"assignment_id": 222, "candidate_ids": [32, 31]},
             Permissions.Assignment.CAN_MANAGE,

--- a/tests/system/action/base.py
+++ b/tests/system/action/base.py
@@ -179,7 +179,9 @@ class BaseActionTestCase(BaseSystemTestCase):
         Create a user with the given username, groups and organization management level.
         """
         partitioned_groups = self._fetch_groups(group_ids)
-        id = self.datastore.reserve_id(Collection("user"))
+        id = 1
+        while f"user/{id}" in self.created_fqids:
+            id += 1
         self.set_models(
             {
                 f"user/{id}": self._get_user_data(
@@ -304,7 +306,7 @@ class BaseActionTestCase(BaseSystemTestCase):
 
     def base_permission_test(
         self,
-        models: Dict[str, Any],
+        models: Dict[str, Dict[str, Any]],
         action: str,
         action_data: Dict[str, Any],
         permission: Optional[Union[Permission, OrganizationManagementLevel]] = None,

--- a/tests/system/action/base.py
+++ b/tests/system/action/base.py
@@ -182,21 +182,9 @@ class BaseActionTestCase(BaseSystemTestCase):
         id = self.datastore.reserve_id(Collection("user"))
         self.set_models(
             {
-                f"user/{id}": {
-                    "username": username,
-                    "organization_management_level": organization_management_level,
-                    "is_active": True,
-                    "default_password": DEFAULT_PASSWORD,
-                    "password": self.auth.hash(DEFAULT_PASSWORD),
-                    "group_$_ids": list(
-                        str(meeting_id) for meeting_id in partitioned_groups.keys()
-                    ),
-                    "meeting_ids": list(partitioned_groups.keys()),
-                    **{
-                        f"group_${meeting_id}_ids": [group["id"] for group in groups]
-                        for meeting_id, groups in partitioned_groups.items()
-                    },
-                },
+                f"user/{id}": self._get_user_data(
+                    username, partitioned_groups, organization_management_level
+                ),
                 **{
                     f"group/{group['id']}": {
                         "user_ids": list(set(group.get("user_ids", []) + [id]))
@@ -207,6 +195,28 @@ class BaseActionTestCase(BaseSystemTestCase):
             }
         )
         return id
+
+    def _get_user_data(
+        self,
+        username: str,
+        partitioned_groups: Dict[int, List[Dict[str, Any]]] = {},
+        organization_management_level: Optional[OrganizationManagementLevel] = None,
+    ) -> Dict[str, Any]:
+        return {
+            "username": username,
+            "organization_management_level": organization_management_level,
+            "is_active": True,
+            "default_password": DEFAULT_PASSWORD,
+            "password": self.auth.hash(DEFAULT_PASSWORD),
+            "group_$_ids": list(
+                str(meeting_id) for meeting_id in partitioned_groups.keys()
+            ),
+            "meeting_ids": list(partitioned_groups.keys()),
+            **{
+                f"group_${meeting_id}_ids": [group["id"] for group in groups]
+                for meeting_id, groups in partitioned_groups.items()
+            },
+        }
 
     def create_user_for_meeting(self, meeting_id: int) -> int:
         meeting = self.get_model(f"meeting/{meeting_id}")
@@ -270,15 +280,6 @@ class BaseActionTestCase(BaseSystemTestCase):
                 },
             }
         )
-
-    def login(self, user_id: int) -> None:
-        """
-        Login the given user by fetching the default password from the datastore.
-        """
-        user = self.get_model(f"user/{user_id}")
-        assert user.get("default_password")
-        self.client.login(user["username"], user["default_password"])
-        self.vote_service.set_authentication(self.client.headers, self.client.cookies)
 
     @with_database_context
     def _fetch_groups(self, group_ids: List[int]) -> Dict[int, List[Dict[str, Any]]]:

--- a/tests/system/action/chat_group/test_sort.py
+++ b/tests/system/action/chat_group/test_sort.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class ChatGroupSortActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "organization/1": {"enable_chat": True},
             "meeting/1": {"is_active_in_organization_id": 1},
             "chat_group/31": {

--- a/tests/system/action/list_of_speakers/test_delete_all_speakers.py
+++ b/tests/system/action/list_of_speakers/test_delete_all_speakers.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class ListOfSpeakersDeleteAllSpeakersActionTester(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {"speaker_ids": [1], "is_active_in_organization_id": 1},
             "list_of_speakers/111": {
                 "closed": False,
@@ -49,14 +51,14 @@ class ListOfSpeakersDeleteAllSpeakersActionTester(BaseActionTestCase):
 
     def test_delete_all_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "list_of_speakers.delete_all_speakers",
             {"id": 111},
         )
 
     def test_delete_all_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "list_of_speakers.delete_all_speakers",
             {"id": 111},
             Permissions.ListOfSpeakers.CAN_MANAGE,

--- a/tests/system/action/list_of_speakers/test_re_add_last.py
+++ b/tests/system/action/list_of_speakers/test_re_add_last.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class ListOfSpeakersReAddLastActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "user/42": {"username": "test_username42", "speaker_$222_ids": [222]},
             "user/43": {"username": "test_username43", "speaker_$222_ids": [223]},
             "user/44": {"username": "test_username43", "speaker_$222_ids": [224]},
@@ -279,14 +281,14 @@ class ListOfSpeakersReAddLastActionTest(BaseActionTestCase):
 
     def test_re_add_last_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "list_of_speakers.re_add_last",
             {"id": 111},
         )
 
     def test_re_add_last_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "list_of_speakers.re_add_last",
             {"id": 111},
             Permissions.ListOfSpeakers.CAN_MANAGE,

--- a/tests/system/action/list_of_speakers/test_update.py
+++ b/tests/system/action/list_of_speakers/test_update.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class ListOfSpeakersUpdateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "list_of_speakers/111": {"closed": False, "meeting_id": 1},
         }
 
@@ -43,14 +45,14 @@ class ListOfSpeakersUpdateActionTest(BaseActionTestCase):
 
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "list_of_speakers.update",
             {"id": 111, "closed": True},
         )
 
     def test_update_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "list_of_speakers.update",
             {"id": 111, "closed": True},
             Permissions.ListOfSpeakers.CAN_MANAGE,

--- a/tests/system/action/mediafile/test_create_directory.py
+++ b/tests/system/action/mediafile/test_create_directory.py
@@ -8,7 +8,7 @@ from tests.system.action.base import BaseActionTestCase
 class MediafileCreateDirectoryActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model: Dict[str, Dict[str, Any]] = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "group/7": {
                 "name": "group_LxAHErRs",
                 "user_ids": [],
@@ -442,7 +442,7 @@ class MediafileCreateDirectoryActionTest(BaseActionTestCase):
 
     def test_create_directory_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.create_directory",
             {
                 "owner_id": "meeting/1",
@@ -453,7 +453,7 @@ class MediafileCreateDirectoryActionTest(BaseActionTestCase):
 
     def test_create_directory_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.create_directory",
             {
                 "owner_id": "meeting/1",
@@ -465,7 +465,7 @@ class MediafileCreateDirectoryActionTest(BaseActionTestCase):
 
     def test_create_directory_no_permissions_orga_owner(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.create_directory",
             {
                 "owner_id": "organization/1",
@@ -475,7 +475,7 @@ class MediafileCreateDirectoryActionTest(BaseActionTestCase):
 
     def test_create_directory_permissions_orga_owner(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.create_directory",
             {
                 "owner_id": "organization/1",

--- a/tests/system/action/mediafile/test_delete.py
+++ b/tests/system/action/mediafile/test_delete.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.management_levels import OrganizationManagementLevel
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
@@ -6,7 +8,7 @@ from tests.system.action.base import BaseActionTestCase
 class MediafileDeleteActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {
                 "logo_$place_id": 222,
                 "logo_$_id": ["place"],
@@ -187,31 +189,31 @@ class MediafileDeleteActionTest(BaseActionTestCase):
 
     def test_delete_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.delete",
             {"id": 222},
         )
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.delete",
             {"id": 222},
             Permissions.Mediafile.CAN_MANAGE,
         )
 
     def test_delete_orga_no_permissions(self) -> None:
-        self.permission_test_model["mediafile/222"]["owner_id"] = "organization/1"
+        self.permission_test_models["mediafile/222"]["owner_id"] = "organization/1"
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.delete",
             {"id": 222},
         )
 
     def test_delete_orga_permission(self) -> None:
-        self.permission_test_model["mediafile/222"]["owner_id"] = "organization/1"
+        self.permission_test_models["mediafile/222"]["owner_id"] = "organization/1"
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.delete",
             {"id": 222},
             OrganizationManagementLevel.CAN_MANAGE_ORGANIZATION,

--- a/tests/system/action/mediafile/test_move.py
+++ b/tests/system/action/mediafile/test_move.py
@@ -8,7 +8,7 @@ from tests.system.action.base import BaseActionTestCase
 class MediafileMoveActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model: Dict[str, Dict[str, Any]] = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "mediafile/7": {"owner_id": "meeting/1", "is_directory": True},
             "mediafile/8": {"owner_id": "meeting/1", "is_directory": True},
         }
@@ -213,33 +213,33 @@ class MediafileMoveActionTest(BaseActionTestCase):
 
     def test_move_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.move",
             {"owner_id": "meeting/1", "ids": [8], "parent_id": 7},
         )
 
     def test_move_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.move",
             {"owner_id": "meeting/1", "ids": [8], "parent_id": 7},
             Permissions.Mediafile.CAN_MANAGE,
         )
 
     def test_move_no_permissions_orga(self) -> None:
-        self.permission_test_model["mediafile/7"]["owner_id"] = "organization/1"
-        self.permission_test_model["mediafile/8"]["owner_id"] = "organization/1"
+        self.permission_test_models["mediafile/7"]["owner_id"] = "organization/1"
+        self.permission_test_models["mediafile/8"]["owner_id"] = "organization/1"
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.move",
             {"owner_id": "organization/1", "ids": [8], "parent_id": 7},
         )
 
     def test_move_permissions_orga(self) -> None:
-        self.permission_test_model["mediafile/7"]["owner_id"] = "organization/1"
-        self.permission_test_model["mediafile/8"]["owner_id"] = "organization/1"
+        self.permission_test_models["mediafile/7"]["owner_id"] = "organization/1"
+        self.permission_test_models["mediafile/8"]["owner_id"] = "organization/1"
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.move",
             {"owner_id": "organization/1", "ids": [8], "parent_id": 7},
             OrganizationManagementLevel.CAN_MANAGE_ORGANIZATION,

--- a/tests/system/action/mediafile/test_update.py
+++ b/tests/system/action/mediafile/test_update.py
@@ -8,7 +8,7 @@ from tests.system.action.base import BaseActionTestCase
 class MediafileUpdateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model: Dict[str, Dict[str, Any]] = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {"name": "meeting_1", "is_active_in_organization_id": 1},
             "group/7": {"name": "group_LxAHErRs", "user_ids": [], "meeting_id": 1},
             "mediafile/111": {"title": "title_srtgb123", "owner_id": "meeting/1"},
@@ -515,8 +515,8 @@ class MediafileUpdateActionTest(BaseActionTestCase):
         )
 
     def test_update_access_group_with_orga_owner(self) -> None:
-        self.permission_test_model["mediafile/111"]["owner_id"] = "organization/1"
-        self.set_models(self.permission_test_model)
+        self.permission_test_models["mediafile/111"]["owner_id"] = "organization/1"
+        self.set_models(self.permission_test_models)
         response = self.request(
             "mediafile.update", {"id": 111, "access_group_ids": [7]}
         )
@@ -527,8 +527,8 @@ class MediafileUpdateActionTest(BaseActionTestCase):
         )
 
     def test_update_access_group_different_owner(self) -> None:
-        self.permission_test_model["group/7"]["meeting_id"] = 2
-        self.set_models(self.permission_test_model)
+        self.permission_test_models["group/7"]["meeting_id"] = 2
+        self.set_models(self.permission_test_models)
         response = self.request(
             "mediafile.update",
             {"id": 111, "access_group_ids": [7]},
@@ -537,7 +537,7 @@ class MediafileUpdateActionTest(BaseActionTestCase):
         assert "Owner and access groups don't match." in response.json["message"]
 
     def test_update_token_payload_check_orga_owner(self) -> None:
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "mediafile.update",
             {"id": 111, "token": "test"},
@@ -605,31 +605,31 @@ class MediafileUpdateActionTest(BaseActionTestCase):
 
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.update",
             {"id": 111, "title": "title_Xcdfgee", "access_group_ids": [7]},
         )
 
     def test_update_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.update",
             {"id": 111, "title": "title_Xcdfgee", "access_group_ids": [7]},
             Permissions.Mediafile.CAN_MANAGE,
         )
 
     def test_update_no_permissions_orga_owner(self) -> None:
-        self.permission_test_model["mediafile/111"]["owner_id"] = "organization/1"
+        self.permission_test_models["mediafile/111"]["owner_id"] = "organization/1"
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.update",
             {"id": 111, "title": "title_Xcdfgee"},
         )
 
     def test_update_permissions_orga_owner(self) -> None:
-        self.permission_test_model["mediafile/111"]["owner_id"] = "organization/1"
+        self.permission_test_models["mediafile/111"]["owner_id"] = "organization/1"
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "mediafile.update",
             {"id": 111, "title": "title_Xcdfgee"},
             OrganizationManagementLevel.CAN_MANAGE_ORGANIZATION,

--- a/tests/system/action/meeting/test_delete_all_speakers_of_all_lists.py
+++ b/tests/system/action/meeting/test_delete_all_speakers_of_all_lists.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MeetingDeleteAllSpeakersOfAllListsActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "list_of_speakers/11": {"meeting_id": 1, "speaker_ids": [1]},
             "speaker/1": {"list_of_speakers_id": 11, "meeting_id": 1},
             "meeting/1": {
@@ -104,14 +106,14 @@ class MeetingDeleteAllSpeakersOfAllListsActionTest(BaseActionTestCase):
 
     def test_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "meeting.delete_all_speakers_of_all_lists",
             {"id": 1},
         )
 
     def test_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "meeting.delete_all_speakers_of_all_lists",
             {"id": 1},
             Permissions.ListOfSpeakers.CAN_MANAGE,

--- a/tests/system/action/meeting/test_set_font.py
+++ b/tests/system/action/meeting/test_set_font.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MeetingSetFontActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {"name": "name_meeting1", "is_active_in_organization_id": 1},
             "mediafile/17": {
                 "is_directory": False,
@@ -77,14 +79,14 @@ class MeetingSetFontActionTest(BaseActionTestCase):
 
     def test_set_font_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "meeting.set_font",
             {"id": 1, "mediafile_id": 17, "place": "web_header"},
         )
 
     def test_set_font_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "meeting.set_font",
             {"id": 1, "mediafile_id": 17, "place": "web_header"},
             Permissions.Meeting.CAN_MANAGE_LOGOS_AND_FONTS,

--- a/tests/system/action/meeting/test_set_logo.py
+++ b/tests/system/action/meeting/test_set_logo.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MeetingSetLogoActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {"name": "name_meeting1", "is_active_in_organization_id": 1},
             "mediafile/17": {
                 "is_directory": False,
@@ -77,14 +79,14 @@ class MeetingSetLogoActionTest(BaseActionTestCase):
 
     def test_set_logo_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "meeting.set_logo",
             {"id": 1, "mediafile_id": 17, "place": "web_header"},
         )
 
     def test_set_logo_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "meeting.set_logo",
             {"id": 1, "mediafile_id": 17, "place": "web_header"},
             Permissions.Meeting.CAN_MANAGE_LOGOS_AND_FONTS,

--- a/tests/system/action/meeting/test_unset_font.py
+++ b/tests/system/action/meeting/test_unset_font.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MediafileUnsetFontActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {
                 "name": "name_meeting1",
                 "font_$header_id": 17,
@@ -52,14 +54,14 @@ class MediafileUnsetFontActionTest(BaseActionTestCase):
 
     def test_unset_font_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "meeting.unset_font",
             {"id": 1, "place": "web_header"},
         )
 
     def test_unset_font_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "meeting.unset_font",
             {"id": 1, "place": "web_header"},
             Permissions.Meeting.CAN_MANAGE_LOGOS_AND_FONTS,

--- a/tests/system/action/meeting/test_unset_logo.py
+++ b/tests/system/action/meeting/test_unset_logo.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MediafileUnsetLogoActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {
                 "name": "name_meeting1",
                 "logo_$place_id": 17,
@@ -85,14 +87,14 @@ class MediafileUnsetLogoActionTest(BaseActionTestCase):
 
     def test_unset_logo_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "meeting.unset_logo",
             {"id": 1, "place": "web_header"},
         )
 
     def test_unset_logo_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "meeting.unset_logo",
             {"id": 1, "place": "web_header"},
             Permissions.Meeting.CAN_MANAGE_LOGOS_AND_FONTS,

--- a/tests/system/action/motion/test_create.py
+++ b/tests/system/action/motion/test_create.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCreateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_workflow/12": {
                 "name": "name_workflow1",
                 "first_state_id": 34,
@@ -297,7 +299,7 @@ class MotionCreateActionTest(BaseActionTestCase):
         assert submitter_2.get("weight") == 2
 
     def test_create_missing_origin_id(self) -> None:
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.create_meeting()
         response = self.request(
             "motion.create",
@@ -315,7 +317,7 @@ class MotionCreateActionTest(BaseActionTestCase):
         )
 
     def test_create_amendment(self) -> None:
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_models(
             {
                 "meeting/1": {
@@ -348,7 +350,7 @@ class MotionCreateActionTest(BaseActionTestCase):
 
     def test_create_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.create",
             {
                 "title": "test_Xcdfgee",
@@ -360,7 +362,7 @@ class MotionCreateActionTest(BaseActionTestCase):
 
     def test_create_permission_simple_fields(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.create",
             {
                 "title": "test_Xcdfgee",
@@ -377,7 +379,7 @@ class MotionCreateActionTest(BaseActionTestCase):
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
         self.set_group_permissions(3, [Permissions.Motion.CAN_CREATE])
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion.create",
             {
@@ -399,7 +401,7 @@ class MotionCreateActionTest(BaseActionTestCase):
         self.set_group_permissions(
             3, [Permissions.Motion.CAN_CREATE, Permissions.Motion.CAN_MANAGE]
         )
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion.create",
             {
@@ -418,7 +420,7 @@ class MotionCreateActionTest(BaseActionTestCase):
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
         self.set_group_permissions(3, [Permissions.Motion.CAN_CREATE])
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_models({"motion/3": {"meeting_id": 1}})
         response = self.request(
             "motion.create",
@@ -444,7 +446,7 @@ class MotionCreateActionTest(BaseActionTestCase):
         self.set_group_permissions(
             3, [Permissions.Motion.CAN_CREATE, Permissions.Motion.CAN_CREATE_AMENDMENTS]
         )
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_models(
             {
                 "motion/3": {"meeting_id": 1, "category_id": 56, "block_id": 57},
@@ -480,7 +482,7 @@ class MotionCreateActionTest(BaseActionTestCase):
                 Permissions.Motion.CAN_MANAGE,
             ],
         )
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_models(
             {
                 "motion/3": {
@@ -517,7 +519,7 @@ class MotionCreateActionTest(BaseActionTestCase):
         self.set_group_permissions(
             3, [Permissions.Motion.CAN_CREATE, Permissions.Motion.CAN_CREATE_AMENDMENTS]
         )
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_models(
             {
                 "motion/3": {"meeting_id": 1, "category_id": 12, "block_id": 13},
@@ -547,7 +549,7 @@ class MotionCreateActionTest(BaseActionTestCase):
         self.set_group_permissions(
             3, [Permissions.Motion.CAN_CREATE, Permissions.Motion.CAN_CREATE_AMENDMENTS]
         )
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_models(
             {
                 "motion/3": {"meeting_id": 1, "category_id": 12, "block_id": 13},

--- a/tests/system/action/motion/test_delete.py
+++ b/tests/system/action/motion/test_delete.py
@@ -7,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionDeleteActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model: Dict[str, Dict[str, Any]] = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {"motion_ids": [111], "is_active_in_organization_id": 1},
             "motion/111": {
                 "title": "title_srtgb123",
@@ -74,14 +74,14 @@ class MotionDeleteActionTest(BaseActionTestCase):
 
     def test_delete_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.delete",
             {"id": 111},
         )
 
     def test_delete_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.delete",
             {"id": 111},
             Permissions.Motion.CAN_MANAGE,
@@ -91,8 +91,8 @@ class MotionDeleteActionTest(BaseActionTestCase):
         self.create_meeting()
         self.user_id = self.create_user("user")
         self.login(self.user_id)
-        self.permission_test_model["motion_submitter/12"]["user_id"] = self.user_id
-        self.set_models(self.permission_test_model)
+        self.permission_test_models["motion_submitter/12"]["user_id"] = self.user_id
+        self.set_models(self.permission_test_models)
         self.set_user_groups(self.user_id, [3])
         response = self.request("motion.delete", {"id": 111})
         self.assert_status_code(response, 200)

--- a/tests/system/action/motion/test_follow_recommendation.py
+++ b/tests/system/action/motion/test_follow_recommendation.py
@@ -1,4 +1,5 @@
 import time
+from typing import Any, Dict
 
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
@@ -7,7 +8,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionFollowRecommendationActionText(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_state/76": {
                 "meeting_id": 1,
                 "name": "test0",
@@ -176,14 +177,14 @@ class MotionFollowRecommendationActionText(BaseActionTestCase):
 
     def test_follow_recommendation_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.follow_recommendation",
             {"id": 22},
         )
 
     def test_follow_recommendation_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.follow_recommendation",
             {"id": 22},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion/test_reset_recommendation.py
+++ b/tests/system/action/motion/test_reset_recommendation.py
@@ -1,4 +1,5 @@
 import time
+from typing import Any, Dict
 
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
@@ -7,7 +8,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionResetRecommendationActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_state/77": {
                 "meeting_id": 1,
                 "name": "test1",
@@ -92,14 +93,14 @@ class MotionResetRecommendationActionTest(BaseActionTestCase):
 
     def test_reset_recommendation_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.reset_recommendation",
             {"id": 22},
         )
 
     def test_reset_recommendation_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.reset_recommendation",
             {"id": 22},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion/test_reset_state.py
+++ b/tests/system/action/motion/test_reset_state.py
@@ -1,4 +1,5 @@
 import time
+from typing import Any, Dict
 
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
@@ -7,7 +8,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionResetStateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_workflow/1": {
                 "meeting_id": 1,
                 "name": "test1",
@@ -153,14 +154,14 @@ class MotionResetStateActionTest(BaseActionTestCase):
 
     def test_reset_state_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.reset_state",
             {"id": 22},
         )
 
     def test_reset_state_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.reset_state",
             {"id": 22},
             Permissions.Motion.CAN_MANAGE_METADATA,

--- a/tests/system/action/motion/test_set_recommendation.py
+++ b/tests/system/action/motion/test_set_recommendation.py
@@ -1,4 +1,5 @@
 import time
+from typing import Any, Dict
 
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
@@ -7,7 +8,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionSetRecommendationActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_workflow/34": {
                 "meeting_id": 1,
             },
@@ -107,14 +108,14 @@ class MotionSetRecommendationActionTest(BaseActionTestCase):
 
     def test_set_recommendat_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.set_recommendation",
             {"id": 22, "recommendation_id": 77},
         )
 
     def test_set_recommendat_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.set_recommendation",
             {"id": 22, "recommendation_id": 77},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion/test_set_state.py
+++ b/tests/system/action/motion/test_set_state.py
@@ -8,7 +8,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionSetStateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model: Dict[str, Dict[str, Any]] = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_state/76": {
                 "meeting_id": 1,
                 "name": "test0",
@@ -148,14 +148,14 @@ class MotionSetStateActionTest(BaseActionTestCase):
 
     def test_set_state_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.set_state",
             {"id": 22, "state_id": 76},
         )
 
     def test_set_state_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.set_state",
             {"id": 22, "state_id": 76},
             Permissions.Motion.CAN_MANAGE_METADATA,
@@ -165,8 +165,8 @@ class MotionSetStateActionTest(BaseActionTestCase):
         self.create_meeting()
         self.user_id = self.create_user("user")
         self.login(self.user_id)
-        self.permission_test_model["motion_submitter/12"]["user_id"] = self.user_id
-        self.set_models(self.permission_test_model)
+        self.permission_test_models["motion_submitter/12"]["user_id"] = self.user_id
+        self.set_models(self.permission_test_models)
         self.set_user_groups(self.user_id, [3])
         response = self.request("motion.set_state", {"id": 22, "state_id": 76})
         self.assert_status_code(response, 200)

--- a/tests/system/action/motion/test_set_support_self.py
+++ b/tests/system/action/motion/test_set_support_self.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionSetSupportSelfActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion/1": {
                 "title": "motion_1",
                 "meeting_id": 1,
@@ -186,14 +188,14 @@ class MotionSetSupportSelfActionTest(BaseActionTestCase):
 
     def test_set_support_self_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.set_support_self",
             {"motion_id": 1, "support": True},
         )
 
     def test_set_support_self_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.set_support_self",
             {"motion_id": 1, "support": True},
             Permissions.Motion.CAN_SUPPORT,

--- a/tests/system/action/motion/test_sort.py
+++ b/tests/system/action/motion/test_sort.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionSortActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion/22": {"meeting_id": 1, "title": "test1"},
         }
 
@@ -193,14 +195,14 @@ class MotionSortActionTest(BaseActionTestCase):
 
     def test_sort_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.sort",
             {"meeting_id": 1, "tree": [{"id": 22}]},
         )
 
     def test_sort_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.sort",
             {"meeting_id": 1, "tree": [{"id": 22}]},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion/test_update.py
+++ b/tests/system/action/motion/test_update.py
@@ -7,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionUpdateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model: Dict[str, Dict[str, Any]] = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion/111": {
                 "meeting_id": 1,
                 "title": "title_srtgb123",
@@ -379,7 +379,7 @@ class MotionUpdateActionTest(BaseActionTestCase):
         self.user_id = self.create_user("user")
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion.update",
             {
@@ -394,7 +394,7 @@ class MotionUpdateActionTest(BaseActionTestCase):
 
     def test_update_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion.update",
             {
                 "id": 111,
@@ -411,7 +411,7 @@ class MotionUpdateActionTest(BaseActionTestCase):
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
         self.set_group_permissions(3, [Permissions.Motion.CAN_MANAGE_METADATA])
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion.update",
             {
@@ -430,7 +430,7 @@ class MotionUpdateActionTest(BaseActionTestCase):
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
         self.set_group_permissions(3, [Permissions.Motion.CAN_MANAGE_METADATA])
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_models({"motion_category/2": {"meeting_id": 1}})
         response = self.request(
             "motion.update",
@@ -446,8 +446,8 @@ class MotionUpdateActionTest(BaseActionTestCase):
         self.user_id = self.create_user("user")
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
-        self.permission_test_model["motion_submitter/1"]["user_id"] = self.user_id
-        self.set_models(self.permission_test_model)
+        self.permission_test_models["motion_submitter/1"]["user_id"] = self.user_id
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion.update",
             {
@@ -465,8 +465,8 @@ class MotionUpdateActionTest(BaseActionTestCase):
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
         self.set_group_permissions(3, [Permissions.Motion.CAN_MANAGE_METADATA])
-        self.permission_test_model["motion_submitter/1"]["user_id"] = self.user_id
-        self.set_models(self.permission_test_model)
+        self.permission_test_models["motion_submitter/1"]["user_id"] = self.user_id
+        self.set_models(self.permission_test_models)
         self.set_models({"motion_category/2": {"meeting_id": 1}})
         response = self.request(
             "motion.update",

--- a/tests/system/action/motion_category/test_delete.py
+++ b/tests/system/action/motion_category/test_delete.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCategorySystemTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_category/111": {"name": "name_srtgb123", "meeting_id": 1}
         }
 
@@ -52,12 +54,12 @@ class MotionCategorySystemTest(BaseActionTestCase):
 
     def test_delete_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model, "motion_category.delete", {"id": 111}
+            self.permission_test_models, "motion_category.delete", {"id": 111}
         )
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_category.delete",
             {"id": 111},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion_category/test_number_motions.py
+++ b/tests/system/action/motion_category/test_number_motions.py
@@ -1,4 +1,5 @@
 import time
+from typing import Any, Dict
 
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
@@ -7,7 +8,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCategoryNumberMotionsTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {
                 "name": "meeting_1",
                 "motion_category_ids": [111],
@@ -29,7 +30,7 @@ class MotionCategoryNumberMotionsTest(BaseActionTestCase):
 
     def test_good_single_motion(self) -> None:
         check_time = round(time.time())
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion_category.number_motions",
             {
@@ -455,14 +456,14 @@ class MotionCategoryNumberMotionsTest(BaseActionTestCase):
 
     def test_number_motions_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_category.number_motions",
             {"id": 111},
         )
 
     def test_number_motions_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_category.number_motions",
             {"id": 111},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion_category/test_sort.py
+++ b/tests/system/action/motion_category/test_sort.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCategorySortActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_category/22": {"meeting_id": 1},
         }
 
@@ -200,14 +202,14 @@ class MotionCategorySortActionTest(BaseActionTestCase):
 
     def test_sort_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_category.sort",
             {"meeting_id": 1, "tree": [{"id": 22}]},
         )
 
     def test_sort_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_category.sort",
             {"meeting_id": 1, "tree": [{"id": 22}]},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion_category/test_sort_motions_in_categories.py
+++ b/tests/system/action/motion_category/test_sort_motions_in_categories.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCategorySortMotionsInCategoriesActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_category/222": {
                 "meeting_id": 1,
             },
@@ -69,14 +71,14 @@ class MotionCategorySortMotionsInCategoriesActionTest(BaseActionTestCase):
 
     def test_sort_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_category.sort_motions_in_category",
             {"id": 222, "motion_ids": [32, 31]},
         )
 
     def test_sort_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_category.sort_motions_in_category",
             {"id": 222, "motion_ids": [32, 31]},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion_category/test_update.py
+++ b/tests/system/action/motion_category/test_update.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCategorySystemTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion/89": {"meeting_id": 1},
             "motion_category/111": {
                 "name": "name_srtgb123",
@@ -91,7 +93,7 @@ class MotionCategorySystemTest(BaseActionTestCase):
 
     def test_update_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_category.update",
             {
                 "id": 111,
@@ -101,7 +103,7 @@ class MotionCategorySystemTest(BaseActionTestCase):
 
     def test_update_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_category.update",
             {
                 "id": 111,

--- a/tests/system/action/motion_change_recommendation/test_delete.py
+++ b/tests/system/action/motion_change_recommendation/test_delete.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionChangeRecommendationActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_change_recommendation/111": {"meeting_id": 1}
         }
 
@@ -33,14 +35,14 @@ class MotionChangeRecommendationActionTest(BaseActionTestCase):
 
     def test_delete_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_change_recommendation.delete",
             {"id": 111},
         )
 
     def test_delete_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_change_recommendation.delete",
             {"id": 111},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion_change_recommendation/test_update.py
+++ b/tests/system/action/motion_change_recommendation/test_update.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionChangeRecommendationActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion/25": {
                 "title": "title_pheK0Ja3ai",
                 "statute_paragraph_id": None,
@@ -87,7 +89,7 @@ class MotionChangeRecommendationActionTest(BaseActionTestCase):
 
     def test_update_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_change_recommendation.update",
             {
                 "id": 111,
@@ -97,7 +99,7 @@ class MotionChangeRecommendationActionTest(BaseActionTestCase):
 
     def test_update_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_change_recommendation.update",
             {
                 "id": 111,

--- a/tests/system/action/motion_comment/test_create.py
+++ b/tests/system/action/motion_comment/test_create.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCommentCreateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion/357": {"title": "title_YIDYXmKj", "meeting_id": 1},
             "motion_comment_section/78": {"meeting_id": 1, "write_group_ids": [3]},
         }
@@ -70,27 +72,29 @@ class MotionCommentCreateActionTest(BaseActionTestCase):
 
     def test_create_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_comment.create",
             {"comment": "test_Xcdfgee", "motion_id": 357, "section_id": 78},
         )
 
     def test_create_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_comment.create",
             {"comment": "test_Xcdfgee", "motion_id": 357, "section_id": 78},
             Permissions.Motion.CAN_SEE,
         )
 
     def test_create_no_permission_cause_write_group(self) -> None:
-        self.permission_test_model["motion_comment_section/78"]["write_group_ids"] = [2]
+        self.permission_test_models["motion_comment_section/78"]["write_group_ids"] = [
+            2
+        ]
         self.create_meeting()
         self.user_id = self.create_user("user")
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
         self.set_group_permissions(3, [Permissions.Motion.CAN_SEE])
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion_comment.create",
             {"comment": "test_Xcdfgee", "motion_id": 357, "section_id": 78},

--- a/tests/system/action/motion_comment/test_delete.py
+++ b/tests/system/action/motion_comment/test_delete.py
@@ -7,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCommentDeleteActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model: Dict[str, Dict[str, Any]] = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_comment/111": {"meeting_id": 1, "section_id": 78},
             "motion_comment_section/78": {
                 "meeting_id": 1,
@@ -41,27 +41,29 @@ class MotionCommentDeleteActionTest(BaseActionTestCase):
 
     def test_delete_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_comment.delete",
             {"id": 111},
         )
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_comment.delete",
             {"id": 111},
             Permissions.Motion.CAN_SEE,
         )
 
     def test_update_no_permission_cause_write_group(self) -> None:
-        self.permission_test_model["motion_comment_section/78"]["write_group_ids"] = [2]
+        self.permission_test_models["motion_comment_section/78"]["write_group_ids"] = [
+            2
+        ]
         self.create_meeting()
         self.user_id = self.create_user("user")
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
         self.set_group_permissions(3, [Permissions.Motion.CAN_SEE])
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion_comment.delete",
             {"id": 111},

--- a/tests/system/action/motion_comment/test_update.py
+++ b/tests/system/action/motion_comment/test_update.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCommentUpdateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_comment/111": {
                 "comment": "comment_srtgb123",
                 "meeting_id": 1,
@@ -56,7 +58,7 @@ class MotionCommentUpdateActionTest(BaseActionTestCase):
 
     def test_update_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_comment.update",
             {"id": 111, "comment": "comment_Xcdfgee"},
         )
@@ -67,7 +69,7 @@ class MotionCommentUpdateActionTest(BaseActionTestCase):
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
         self.set_group_permissions(3, [Permissions.Motion.CAN_SEE])
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion_comment.update",
             {"comment": "test_Xcdfgee", "id": 111},
@@ -75,13 +77,15 @@ class MotionCommentUpdateActionTest(BaseActionTestCase):
         self.assert_status_code(response, 200)
 
     def test_update_no_permission_cause_write_group(self) -> None:
-        self.permission_test_model["motion_comment_section/78"]["write_group_ids"] = [2]
+        self.permission_test_models["motion_comment_section/78"]["write_group_ids"] = [
+            2
+        ]
         self.create_meeting()
         self.user_id = self.create_user("user")
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
         self.set_group_permissions(3, [Permissions.Motion.CAN_SEE])
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion_comment.update",
             {"comment": "test_Xcdfgee", "id": 111},
@@ -97,7 +101,7 @@ class MotionCommentUpdateActionTest(BaseActionTestCase):
         self.user_id = self.create_user("user")
         self.set_user_groups(self.user_id, [2])
         self.login(self.user_id)
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion_comment.update",
             {"comment": "test_Xcdfgee", "id": 111},

--- a/tests/system/action/motion_comment_section/test_delete.py
+++ b/tests/system/action/motion_comment_section/test_delete.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCommentSectionActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_comment_section/111": {
                 "name": "name_srtgb123",
                 "meeting_id": 1,
@@ -59,14 +61,14 @@ class MotionCommentSectionActionTest(BaseActionTestCase):
 
     def test_delete_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_comment_section.delete",
             {"id": 111},
         )
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_comment_section.delete",
             {"id": 111},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion_comment_section/test_sort.py
+++ b/tests/system/action/motion_comment_section/test_sort.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCommentSectionSortActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_comment_section/31": {
                 "meeting_id": 1,
                 "name": "name_loisueb",
@@ -93,14 +95,14 @@ class MotionCommentSectionSortActionTest(BaseActionTestCase):
 
     def test_sort_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_comment_section.sort",
             {"meeting_id": 1, "motion_comment_section_ids": [32, 31]},
         )
 
     def test_sort_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_comment_section.sort",
             {"meeting_id": 1, "motion_comment_section_ids": [32, 31]},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion_comment_section/test_update.py
+++ b/tests/system/action/motion_comment_section/test_update.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCommentSectionActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_comment_section/111": {
                 "name": "name_srtgb123",
                 "meeting_id": 1,
@@ -68,7 +70,7 @@ class MotionCommentSectionActionTest(BaseActionTestCase):
 
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_comment_section.update",
             {
                 "id": 111,
@@ -80,7 +82,7 @@ class MotionCommentSectionActionTest(BaseActionTestCase):
 
     def test_update_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_comment_section.update",
             {
                 "id": 111,

--- a/tests/system/action/motion_state/test_create.py
+++ b/tests/system/action/motion_state/test_create.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionStateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_workflow/42": {
                 "name": "test_name_fjwnq8d8tje8",
                 "meeting_id": 1,
@@ -240,14 +242,14 @@ class MotionStateActionTest(BaseActionTestCase):
 
     def test_create_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_state.create",
             {"name": "test_Xcdfgee", "workflow_id": 42},
         )
 
     def test_create_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_state.create",
             {"name": "test_Xcdfgee", "workflow_id": 42},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion_state/test_delete.py
+++ b/tests/system/action/motion_state/test_delete.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionStateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_state/111": {"name": "name_srtgb123", "meeting_id": 1}
         }
 
@@ -62,14 +64,14 @@ class MotionStateActionTest(BaseActionTestCase):
 
     def test_delete_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_state.delete",
             {"id": 111},
         )
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_state.delete",
             {"id": 111},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion_state/test_sort.py
+++ b/tests/system/action/motion_state/test_sort.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionStateSort(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "organization/1": {"active_meeting_ids": [1]},
             "meeting/1": {
                 "motion_state_ids": [1, 2, 3],

--- a/tests/system/action/motion_state/test_update.py
+++ b/tests/system/action/motion_state/test_update.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionStateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_workflow/110": {
                 "name": "name_Ycefgee",
                 "state_ids": [111],
@@ -141,14 +143,14 @@ class MotionStateActionTest(BaseActionTestCase):
 
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_state.update",
             {"id": 111, "name": "name_Xcdfgee"},
         )
 
     def test_update_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_state.update",
             {"id": 111, "name": "name_Xcdfgee"},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion_statute_paragraph/test_delete.py
+++ b/tests/system/action/motion_statute_paragraph/test_delete.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,9 @@ from tests.system.action.base import BaseActionTestCase
 class MotionStatuteParagraphActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {"motion_statute_paragraph/111": {"meeting_id": 1}}
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
+            "motion_statute_paragraph/111": {"meeting_id": 1}
+        }
 
     def test_delete_correct(self) -> None:
         self.set_models(
@@ -31,14 +35,14 @@ class MotionStatuteParagraphActionTest(BaseActionTestCase):
 
     def test_delete_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_statute_paragraph.delete",
             {"id": 111},
         )
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_statute_paragraph.delete",
             {"id": 111},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion_statute_paragraph/test_sort.py
+++ b/tests/system/action/motion_statute_paragraph/test_sort.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionStatuteParagraphSortActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_statute_paragraph/31": {
                 "meeting_id": 1,
                 "title": "title_loisueb",
@@ -93,14 +95,14 @@ class MotionStatuteParagraphSortActionTest(BaseActionTestCase):
 
     def test_sort_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_statute_paragraph.sort",
             {"meeting_id": 1, "statute_paragraph_ids": [32, 31]},
         )
 
     def test_sort_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_statute_paragraph.sort",
             {"meeting_id": 1, "statute_paragraph_ids": [32, 31]},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion_statute_paragraph/test_update.py
+++ b/tests/system/action/motion_statute_paragraph/test_update.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionStatuteParagraphActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion_statute_paragraph/111": {
                 "title": "title_srtgb123",
                 "meeting_id": 1,
@@ -51,14 +53,14 @@ class MotionStatuteParagraphActionTest(BaseActionTestCase):
 
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_statute_paragraph.update",
             {"id": 111, "title": "title_Xcdfgee", "text": "text_blablabla"},
         )
 
     def test_update_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_statute_paragraph.update",
             {"id": 111, "title": "title_Xcdfgee", "text": "text_blablabla"},
             Permissions.Motion.CAN_MANAGE,

--- a/tests/system/action/motion_submitter/test_create.py
+++ b/tests/system/action/motion_submitter/test_create.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionSubmitterCreateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion/357": {"title": "title_YIDYXmKj", "meeting_id": 1},
             "user/78": {"username": "username_loetzbfg", "meeting_ids": [1]},
         }
@@ -156,14 +158,14 @@ class MotionSubmitterCreateActionTest(BaseActionTestCase):
 
     def test_create_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_submitter.create",
             {"motion_id": 357, "user_id": 78},
         )
 
     def test_create_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_submitter.create",
             {"motion_id": 357, "user_id": 78},
             Permissions.Motion.CAN_MANAGE_METADATA,

--- a/tests/system/action/motion_submitter/test_delete.py
+++ b/tests/system/action/motion_submitter/test_delete.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionSubmitterDeleteActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {
                 "motion_submitter_ids": [111],
                 "is_active_in_organization_id": 1,
@@ -53,14 +55,14 @@ class MotionSubmitterDeleteActionTest(BaseActionTestCase):
 
     def test_delete_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_submitter.delete",
             {"id": 111},
         )
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_submitter.delete",
             {"id": 111},
             Permissions.Motion.CAN_MANAGE_METADATA,

--- a/tests/system/action/motion_submitter/test_sort.py
+++ b/tests/system/action/motion_submitter/test_sort.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class MotionSubmitterSortActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "motion/222": {"meeting_id": 1},
             "motion_submitter/31": {"motion_id": 222, "meeting_id": 1},
             "motion_submitter/32": {"motion_id": 222, "meeting_id": 1},
@@ -64,14 +66,14 @@ class MotionSubmitterSortActionTest(BaseActionTestCase):
 
     def test_sort_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_submitter.sort",
             {"motion_id": 222, "motion_submitter_ids": [32, 31]},
         )
 
     def test_sort_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "motion_submitter.sort",
             {"motion_id": 222, "motion_submitter_ids": [32, 31]},
             Permissions.Motion.CAN_MANAGE_METADATA,

--- a/tests/system/action/option/test_update.py
+++ b/tests/system/action/option/test_update.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class OptionUpdateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "poll/65": {
                 "type": "analog",
                 "state": "created",
@@ -162,14 +164,14 @@ class OptionUpdateActionTest(BaseActionTestCase):
 
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "option.update",
             {"id": 57, "Y": "1.000000", "N": "2.000000", "A": "3.000000"},
         )
 
     def test_update_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "option.update",
             {"id": 57, "Y": "1.000000", "N": "2.000000", "A": "3.000000"},
             Permissions.Poll.CAN_MANAGE,

--- a/tests/system/action/poll/test_publish.py
+++ b/tests/system/action/poll/test_publish.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class PollPublishActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "poll/1": {"state": "finished", "meeting_id": 1},
         }
 
@@ -58,11 +60,13 @@ class PollPublishActionTest(BaseActionTestCase):
         )
 
     def test_publish_no_permissions(self) -> None:
-        self.base_permission_test(self.permission_test_model, "poll.publish", {"id": 1})
+        self.base_permission_test(
+            self.permission_test_models, "poll.publish", {"id": 1}
+        )
 
     def test_publish_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "poll.publish",
             {"id": 1},
             Permissions.Poll.CAN_MANAGE,

--- a/tests/system/action/poll/test_reset.py
+++ b/tests/system/action/poll/test_reset.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class PollResetActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "poll/1": {
                 "state": "started",
                 "option_ids": [1],
@@ -86,11 +88,11 @@ class PollResetActionTest(BaseActionTestCase):
         assert option_2.get("abstain") == "0.000000"
 
     def test_reset_no_permissions(self) -> None:
-        self.base_permission_test(self.permission_test_model, "poll.reset", {"id": 1})
+        self.base_permission_test(self.permission_test_models, "poll.reset", {"id": 1})
 
     def test_reset_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "poll.reset",
             {"id": 1},
             Permissions.Poll.CAN_MANAGE,

--- a/tests/system/action/poll/test_stop.py
+++ b/tests/system/action/poll/test_stop.py
@@ -1,3 +1,6 @@
+from time import time
+from typing import Any, Dict
+
 from openslides_backend.models.models import Poll
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import DEFAULT_PASSWORD, BaseActionTestCase
@@ -8,7 +11,7 @@ from tests.system.util import performance
 class PollStopActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.test_models = {
+        self.test_models: Dict[str, Dict[str, Any]] = {
             "poll/1": {"state": Poll.STATE_STARTED, "meeting_id": 1},
             "meeting/1": {"is_active_in_organization_id": 1},
         }
@@ -229,12 +232,11 @@ class PollStopActionTest(BaseActionTestCase):
             response = self.vote_service.vote({"id": 1, "value": {"1": "Y"}})
             self.assert_status_code(response, 200)
         self.client.login(ADMIN_USERNAME, ADMIN_PASSWORD)
-        from time import time
 
         start = time()
         response = self.request("poll.stop", {"id": 1})
-        end = time() - start
-        print("Time: %.2fs" % end)
+        diff = time() - start
+        print("Time: %.2fs" % diff)
         self.assert_status_code(response, 200)
         poll = self.get_model("poll/1")
         assert poll["voted_ids"] == user_ids

--- a/tests/system/action/poll/test_stop.py
+++ b/tests/system/action/poll/test_stop.py
@@ -1,6 +1,8 @@
 from openslides_backend.models.models import Poll
 from openslides_backend.permissions.permissions import Permissions
-from tests.system.action.base import BaseActionTestCase
+from tests.system.action.base import DEFAULT_PASSWORD, BaseActionTestCase
+from tests.system.base import ADMIN_PASSWORD, ADMIN_USERNAME
+from tests.system.util import performance
 
 
 class PollStopActionTest(BaseActionTestCase):
@@ -190,3 +192,49 @@ class PollStopActionTest(BaseActionTestCase):
             {"id": 1},
             Permissions.Poll.CAN_MANAGE,
         )
+
+    @performance
+    def test_stop_performance(self) -> None:
+        USER_COUNT = 100
+        user_ids = list(range(2, USER_COUNT + 2))
+        self.set_models(
+            {
+                "poll/1": {
+                    "type": Poll.TYPE_NAMED,
+                    "pollmethod": "YN",
+                    "state": Poll.STATE_STARTED,
+                    "option_ids": [1],
+                    "meeting_id": 1,
+                    "entitled_group_ids": [3],
+                },
+                "option/1": {"meeting_id": 1, "poll_id": 1},
+                **{
+                    f"user/{i}": {
+                        **self._get_user_data(f"user{i}", {1: [{"id": 3}]}),
+                        "is_present_in_meeting_ids": [1],
+                    }
+                    for i in user_ids
+                },
+                "group/3": {"user_ids": user_ids, "meeting_id": 1},
+                "meeting/1": {
+                    "user_ids": user_ids,
+                    "group_ids": [3],
+                    "is_active_in_organization_id": 1,
+                },
+            }
+        )
+        self.start_poll(1)
+        for i in user_ids:
+            self.client.login(f"user{i}", DEFAULT_PASSWORD)
+            response = self.vote_service.vote({"id": 1, "value": {"1": "Y"}})
+            self.assert_status_code(response, 200)
+        self.client.login(ADMIN_USERNAME, ADMIN_PASSWORD)
+        from time import time
+
+        start = time()
+        response = self.request("poll.stop", {"id": 1})
+        end = time() - start
+        print("Time: %.2fs" % end)
+        self.assert_status_code(response, 200)
+        poll = self.get_model("poll/1")
+        assert poll["voted_ids"] == user_ids

--- a/tests/system/action/projection/test_update_options.py
+++ b/tests/system/action/projection/test_update_options.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class ProjectionUpdateOptions(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.test_models = {
+        self.test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {"name": "bla", "is_active_in_organization_id": 1},
             "projector/23": {"meeting_id": 1, "current_projection_ids": [33]},
             "projection/33": {"meeting_id": 1, "current_projector_id": 23},

--- a/tests/system/action/projector/test_toggle.py
+++ b/tests/system/action/projector/test_toggle.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class ProjectorToggle(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "projector/23": {"meeting_id": 1, "current_projection_ids": []},
             "poll/788": {"meeting_id": 1},
         }
@@ -112,14 +114,14 @@ class ProjectorToggle(BaseActionTestCase):
 
     def test_toggle_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "projector.toggle",
             {"ids": [23], "content_object_id": "poll/788", "meeting_id": 1},
         )
 
     def test_toggle_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "projector.toggle",
             {"ids": [23], "content_object_id": "poll/788", "meeting_id": 1},
             Permissions.Projector.CAN_MANAGE,

--- a/tests/system/action/projector/test_update.py
+++ b/tests/system/action/projector/test_update.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class ProjectorUpdate(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "projector/111": {"name": "name_srtgb123", "meeting_id": 1},
         }
 
@@ -260,7 +262,7 @@ class ProjectorUpdate(BaseActionTestCase):
 
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "projector.update",
             {
                 "id": 111,
@@ -271,7 +273,7 @@ class ProjectorUpdate(BaseActionTestCase):
 
     def test_update_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "projector.update",
             {
                 "id": 111,

--- a/tests/system/action/projector_message/test_delete.py
+++ b/tests/system/action/projector_message/test_delete.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -14,7 +16,7 @@ class ProjectorMessageDelete(BaseActionTestCase):
                 "projector_message/2": {"meeting_id": 2, "message": "test1"},
             }
         )
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "projector_message/2": {"meeting_id": 1, "message": "test1"},
         }
 
@@ -32,14 +34,14 @@ class ProjectorMessageDelete(BaseActionTestCase):
 
     def test_delete_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "projector_message.delete",
             {"id": 2},
         )
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "projector_message.delete",
             {"id": 2},
             Permissions.Projector.CAN_MANAGE,

--- a/tests/system/action/projector_message/test_update.py
+++ b/tests/system/action/projector_message/test_update.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -14,7 +16,7 @@ class ProjectorMessageUpdate(BaseActionTestCase):
                 "projector_message/2": {"meeting_id": 2, "message": "test1"},
             }
         )
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "projector_message/2": {"meeting_id": 1, "message": "test1"},
         }
 
@@ -38,14 +40,14 @@ class ProjectorMessageUpdate(BaseActionTestCase):
 
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "projector_message.update",
             {"id": 2, "message": "geredegerede"},
         )
 
     def test_update_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "projector_message.update",
             {"id": 2, "message": "geredegerede"},
             Permissions.Projector.CAN_MANAGE,

--- a/tests/system/action/speaker/test_delete.py
+++ b/tests/system/action/speaker/test_delete.py
@@ -9,7 +9,7 @@ DEFAULT_PASSWORD = "password"
 class SpeakerDeleteActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model: Dict[str, Dict[str, Any]] = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {"speaker_ids": [890], "is_active_in_organization_id": 1},
             "user/7": {
                 "username": "test_username1",
@@ -80,12 +80,12 @@ class SpeakerDeleteActionTest(BaseActionTestCase):
 
     def test_delete_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model, "speaker.delete", {"id": 890}
+            self.permission_test_models, "speaker.delete", {"id": 890}
         )
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "speaker.delete",
             {"id": 890},
             Permissions.ListOfSpeakers.CAN_MANAGE,
@@ -94,7 +94,7 @@ class SpeakerDeleteActionTest(BaseActionTestCase):
     def test_delete_self(self) -> None:
         self.create_meeting()
         self.user_id = 7
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.login(self.user_id)
         self.set_user_groups(self.user_id, [3])
         response = self.request("speaker.delete", {"id": 890})

--- a/tests/system/action/speaker/test_end_speech.py
+++ b/tests/system/action/speaker/test_end_speech.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class SpeakerEndSpeachTester(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {
                 "list_of_speakers_couple_countdown": True,
                 "list_of_speakers_countdown_id": 11,
@@ -154,12 +156,12 @@ class SpeakerEndSpeachTester(BaseActionTestCase):
 
     def test_end_speech_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model, "speaker.end_speech", {"id": 890}
+            self.permission_test_models, "speaker.end_speech", {"id": 890}
         )
 
     def test_end_speech_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "speaker.end_speech",
             {"id": 890},
             Permissions.ListOfSpeakers.CAN_MANAGE,

--- a/tests/system/action/speaker/test_sort.py
+++ b/tests/system/action/speaker/test_sort.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class SpeakerSortActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "list_of_speakers/222": {"meeting_id": 1},
             "speaker/31": {"list_of_speakers_id": 222, "meeting_id": 1},
             "speaker/32": {"list_of_speakers_id": 222, "meeting_id": 1},
@@ -61,14 +63,14 @@ class SpeakerSortActionTest(BaseActionTestCase):
 
     def test_sort_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "speaker.sort",
             {"list_of_speakers_id": 222, "speaker_ids": [32, 31]},
         )
 
     def test_sort_permisions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "speaker.sort",
             {"list_of_speakers_id": 222, "speaker_ids": [32, 31]},
             Permissions.ListOfSpeakers.CAN_MANAGE,

--- a/tests/system/action/speaker/test_speak.py
+++ b/tests/system/action/speaker/test_speak.py
@@ -1,4 +1,5 @@
 import time
+from typing import Any, Dict
 
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
@@ -7,7 +8,7 @@ from tests.system.action.base import BaseActionTestCase
 class SpeakerSpeakTester(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "user/7": {"username": "test_username1"},
             "list_of_speakers/23": {"speaker_ids": [890], "meeting_id": 1},
             "speaker/890": {
@@ -153,12 +154,12 @@ class SpeakerSpeakTester(BaseActionTestCase):
 
     def test_speak_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model, "speaker.speak", {"id": 890}
+            self.permission_test_models, "speaker.speak", {"id": 890}
         )
 
     def test_speak_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "speaker.speak",
             {"id": 890},
             Permissions.ListOfSpeakers.CAN_MANAGE,

--- a/tests/system/action/speaker/test_update.py
+++ b/tests/system/action/speaker/test_update.py
@@ -7,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class SpeakerUpdateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model: Dict[str, Dict[str, Any]] = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {
                 "list_of_speakers_enable_pro_contra_speech": True,
                 "is_active_in_organization_id": 1,
@@ -39,18 +39,18 @@ class SpeakerUpdateActionTest(BaseActionTestCase):
         assert model.get("speech_state") == "pro"
 
     def test_update_same_speech_state(self) -> None:
-        self.permission_test_model["speaker/890"]["speech_state"] = "pro"
-        self.set_models(self.permission_test_model)
+        self.permission_test_models["speaker/890"]["speech_state"] = "pro"
+        self.set_models(self.permission_test_models)
         response = self.request("speaker.update", {"id": 890, "speech_state": "pro"})
         self.assert_status_code(response, 200)
         model = self.get_model("speaker/890")
         assert model.get("speech_state") == "pro"
 
     def test_update_contribution_ok(self) -> None:
-        self.permission_test_model["meeting/1"][
+        self.permission_test_models["meeting/1"][
             "list_of_speakers_can_set_contribution_self"
         ] = True
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request(
             "speaker.update", {"id": 890, "speech_state": "contribution"}
         )
@@ -60,8 +60,8 @@ class SpeakerUpdateActionTest(BaseActionTestCase):
 
     def test_update_contribution_fail(self) -> None:
         self.create_meeting()
-        self.permission_test_model["speaker/890"]["user_id"] = 1
-        self.set_models(self.permission_test_model)
+        self.permission_test_models["speaker/890"]["user_id"] = 1
+        self.set_models(self.permission_test_models)
         self.set_models({"user/1": {"organization_management_level": None}})
         self.set_user_groups(1, [3])
         self.set_group_permissions(3, [Permissions.ListOfSpeakers.CAN_SEE])
@@ -73,39 +73,39 @@ class SpeakerUpdateActionTest(BaseActionTestCase):
         assert "Self contribution is not allowed" in response.json["message"]
 
     def test_update_pro_contra_ok(self) -> None:
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request("speaker.update", {"id": 890, "speech_state": "pro"})
         self.assert_status_code(response, 200)
         model = self.get_model("speaker/890")
         assert model.get("speech_state") == "pro"
 
     def test_update_pro_contra_fail(self) -> None:
-        self.permission_test_model["meeting/1"][
+        self.permission_test_models["meeting/1"][
             "list_of_speakers_enable_pro_contra_speech"
         ] = False
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request("speaker.update", {"id": 890, "speech_state": "pro"})
         self.assert_status_code(response, 400)
 
     def test_update_unset_contribution_ok(self) -> None:
-        self.permission_test_model["speaker/890"]["speech_state"] = "contribution"
-        self.permission_test_model["meeting/1"][
+        self.permission_test_models["speaker/890"]["speech_state"] = "contribution"
+        self.permission_test_models["meeting/1"][
             "list_of_speakers_can_set_contribution_self"
         ] = True
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request("speaker.update", {"id": 890, "speech_state": None})
         self.assert_status_code(response, 200)
         model = self.get_model("speaker/890")
         assert model.get("speech_state") is None
 
     def test_update_unset_contribution_fail(self) -> None:
-        self.permission_test_model["speaker/890"]["speech_state"] = "contribution"
-        self.permission_test_model["meeting/1"][
+        self.permission_test_models["speaker/890"]["speech_state"] = "contribution"
+        self.permission_test_models["meeting/1"][
             "list_of_speakers_can_set_contribution_self"
         ] = False
         self.create_meeting()
-        self.permission_test_model["speaker/890"]["user_id"] = 1
-        self.set_models(self.permission_test_model)
+        self.permission_test_models["speaker/890"]["user_id"] = 1
+        self.set_models(self.permission_test_models)
         self.set_models({"user/1": {"organization_management_level": None}})
         self.set_user_groups(1, [3])
         self.set_group_permissions(3, [Permissions.ListOfSpeakers.CAN_SEE])
@@ -114,19 +114,19 @@ class SpeakerUpdateActionTest(BaseActionTestCase):
         assert "Self contribution is not allowed" in response.json["message"]
 
     def test_update_unset_pro_contra_ok(self) -> None:
-        self.permission_test_model["speaker/890"]["speech_state"] = "contra"
-        self.set_models(self.permission_test_model)
+        self.permission_test_models["speaker/890"]["speech_state"] = "contra"
+        self.set_models(self.permission_test_models)
         response = self.request("speaker.update", {"id": 890, "speech_state": None})
         self.assert_status_code(response, 200)
         model = self.get_model("speaker/890")
         assert model.get("speech_state") is None
 
     def test_update_unset_pro_contra_fail(self) -> None:
-        self.permission_test_model["speaker/890"]["speech_state"] = "contra"
-        self.permission_test_model["meeting/1"][
+        self.permission_test_models["speaker/890"]["speech_state"] = "contra"
+        self.permission_test_models["meeting/1"][
             "list_of_speakers_enable_pro_contra_speech"
         ] = False
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         response = self.request("speaker.update", {"id": 890, "speech_state": None})
         self.assert_status_code(response, 400)
         assert "Pro/Contra is not enabled" in response.json["message"]
@@ -152,14 +152,14 @@ class SpeakerUpdateActionTest(BaseActionTestCase):
 
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "speaker.update",
             {"id": 890, "speech_state": "pro"},
         )
 
     def test_update_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "speaker.update",
             {"id": 890, "speech_state": "pro"},
             Permissions.ListOfSpeakers.CAN_MANAGE,
@@ -167,7 +167,7 @@ class SpeakerUpdateActionTest(BaseActionTestCase):
 
     def test_update_check_request_user_is_user_not_can_see(self) -> None:
         self.create_meeting()
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_models(
             {
                 "user/1": {"organization_management_level": None},
@@ -179,7 +179,7 @@ class SpeakerUpdateActionTest(BaseActionTestCase):
 
     def test_update_check_request_user_is_user_permission(self) -> None:
         self.create_meeting()
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_models(
             {
                 "user/1": {"organization_management_level": None},
@@ -193,7 +193,7 @@ class SpeakerUpdateActionTest(BaseActionTestCase):
 
     def test_update_can_see_but_not_request_user_eq_user(self) -> None:
         self.create_meeting()
-        self.set_models(self.permission_test_model)
+        self.set_models(self.permission_test_models)
         self.set_models(
             {
                 "user/1": {"organization_management_level": None},

--- a/tests/system/action/test_general.py
+++ b/tests/system/action/test_general.py
@@ -101,7 +101,9 @@ class TestWSGIWithMigrations(BaseActionTestCase):
 
     @patch("migrations.get_backend_migration_index")
     def test_request_missing_migrations(self, gbmi: Any) -> None:
-        write_request = self.get_create_request("topic/1", {"title": "dummy"})
+        write_request = self.get_write_request(
+            self.get_create_events("topic/1", {"title": "dummy"})
+        )
         write_request.migration_index = 5
         with self.datastore.get_database_context():
             self.datastore.write(write_request)
@@ -118,7 +120,9 @@ class TestWSGIWithMigrations(BaseActionTestCase):
 
     @patch("migrations.get_backend_migration_index")
     def test_request_misconfigured_migrations(self, gbmi: Any) -> None:
-        write_request = self.get_create_request("topic/1", {"title": "dummy"})
+        write_request = self.get_write_request(
+            self.get_create_events("topic/1", {"title": "dummy"})
+        )
         write_request.migration_index = 6
         with self.datastore.get_database_context():
             self.datastore.write(write_request)

--- a/tests/system/action/topic/test_delete.py
+++ b/tests/system/action/topic/test_delete.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class TopicDeleteActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "topic/111": {"title": "title_srtgb123", "meeting_id": 1}
         }
 
@@ -105,12 +107,12 @@ class TopicDeleteActionTest(BaseActionTestCase):
 
     def test_delete_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model, "topic.delete", {"id": 111}
+            self.permission_test_models, "topic.delete", {"id": 111}
         )
 
     def test_delete_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "topic.delete",
             {"id": 111},
             Permissions.AgendaItem.CAN_MANAGE,

--- a/tests/system/action/topic/test_update.py
+++ b/tests/system/action/topic/test_update.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -5,7 +7,7 @@ from tests.system.action.base import BaseActionTestCase
 class TopicUpdateTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_model = {
+        self.permission_test_models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {"name": "test", "is_active_in_organization_id": 1},
             "topic/1": {"title": "test", "meeting_id": 1},
         }
@@ -71,14 +73,14 @@ class TopicUpdateTest(BaseActionTestCase):
 
     def test_update_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "topic.update",
             {"id": 1, "title": "test2", "text": "text"},
         )
 
     def test_update_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_model,
+            self.permission_test_models,
             "topic.update",
             {"id": 1, "title": "test2", "text": "text"},
             Permissions.AgendaItem.CAN_MANAGE,

--- a/tests/system/presenter/test_check_mediafile_id.py
+++ b/tests/system/presenter/test_check_mediafile_id.py
@@ -41,7 +41,7 @@ class TestCheckMediafileId(BasePresenterTestCase):
             },
         )
         self.create_model("meeting/1")
-        self.client.headers.clear()
+        self.client.auth_data.pop("access_token", None)
         status_code, data = self.request("check_mediafile_id", {"mediafile_id": 1})
         self.assertEqual(status_code, 200)
         self.assertEqual(data, {"ok": True, "filename": "the filename"})

--- a/tests/system/presenter/test_get_users.py
+++ b/tests/system/presenter/test_get_users.py
@@ -198,6 +198,6 @@ class TestGetUsers(BasePresenterTestCase):
         self.assertEqual(data, {"users": [1]})
 
     def test_request_without_token(self) -> None:
-        self.client.headers.clear()
+        self.client.auth_data.pop("access_token", None)
         status_code, data = self.request("get_users", {})
         self.assertEqual(status_code, 403)

--- a/tests/system/util.py
+++ b/tests/system/util.py
@@ -1,8 +1,9 @@
 import copy
 import os
-from typing import Any, Dict, Type
+from typing import Any, Callable, Dict, Type
 from unittest.mock import MagicMock, Mock
 
+import pytest
 from dependency_injector import providers
 from requests.models import Response as RequestsResponse
 
@@ -11,7 +12,7 @@ from openslides_backend.http.views.base_view import ROUTE_OPTIONS_ATTR, RouteFun
 from openslides_backend.services.media.interface import MediaService
 from openslides_backend.services.vote.adapter import VoteAdapter
 from openslides_backend.services.vote.interface import VoteService
-from openslides_backend.shared.env import Environment
+from openslides_backend.shared.env import Environment, is_truthy
 from openslides_backend.shared.exceptions import MediaServiceException
 from openslides_backend.shared.interfaces.wsgi import Headers, View, WSGIApplication
 from openslides_backend.wsgi import OpenSlidesBackendServices, OpenSlidesBackendWSGI
@@ -92,3 +93,10 @@ def get_route_path(route_function: RouteFunction, name: str = "") -> str:
         if route_options["raw_path"].endswith(name):
             return route_options["raw_path"]
     raise ValueError(f"Route {name} does not exist")
+
+
+def performance(func: Callable) -> Callable:
+    return pytest.mark.skipif(
+        not is_truthy(os.environ.get("OPENSLIDES_PERFORMANCE_TESTS", "")),
+        reason="Performance tests are disabled.",
+    )(func)


### PR DESCRIPTION
Also slightly improves test performance by saving the login for each test. Slight time reduction (with profiling):
before: 439.51s (0:07:19)
after: 412.46s (0:06:52)