### PR TITLE
Strip user names and add tests.

### DIFF
--- a/openslides_backend/action/actions/user/create.py
+++ b/openslides_backend/action/actions/user/create.py
@@ -78,16 +78,11 @@ class UserCreate(
         count = 0
 
         while True:
-            possible_space = (
-                " " if instance.get("first_name") and instance.get("last_name") else ""
-            )
-            new_username = (
-                instance.get("first_name", "")
-                + possible_space
-                + instance.get("last_name", "")
+            new_username = instance.get("first_name", "") + instance.get(
+                "last_name", ""
             )
             if count > 0:
-                new_username += f" {count}"
+                new_username += str(count)
 
             result = self.datastore.filter(
                 Collection("user"),

--- a/openslides_backend/action/actions/user/user_mixin.py
+++ b/openslides_backend/action/actions/user/user_mixin.py
@@ -31,6 +31,8 @@ class LimitOfUserMixin(Action):
 class UserMixin(CheckForArchivedMeetingMixin):
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
         instance = super().update_instance(instance)
+        for field in ("username", "first_name", "last_name"):
+            self.strip_field(field, instance)
         user_fqid = FullQualifiedId(Collection("user"), instance["id"])
         if "username" in instance:
             result = self.datastore.filter(
@@ -51,6 +53,10 @@ class UserMixin(CheckForArchivedMeetingMixin):
         if "username" in instance and not instance["username"].strip():
             raise ActionException("This username is forbidden.")
         return instance
+
+    def strip_field(self, field: str, instance: Dict[str, Any]) -> None:
+        if instance.get(field):
+            instance[field] = instance[field].strip()
 
     def check_vote_delegated__to_id(
         self, instance: Dict[str, Any], user_fqid: FullQualifiedId

--- a/tests/system/action/user/test_create.py
+++ b/tests/system/action/user/test_create.py
@@ -40,11 +40,11 @@ class UserCreateActionTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 200)
-        self.assert_model_exists("user/2", {"username": "John Smith"})
+        self.assert_model_exists("user/2", {"username": "JohnSmith"})
 
     def test_create_first_name_and_count(self) -> None:
         self.set_models(
-            {"user/2": {"username": "John"}, "user/3": {"username": "John 1"}}
+            {"user/2": {"username": "John"}, "user/3": {"username": "John1"}}
         )
         response = self.request(
             "user.create",
@@ -54,7 +54,7 @@ class UserCreateActionTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 200)
-        self.assert_model_exists("user/4", {"username": "John 2"})
+        self.assert_model_exists("user/4", {"username": "John2"})
 
     def test_create_some_more_fields(self) -> None:
         """
@@ -343,6 +343,25 @@ class UserCreateActionTest(BaseActionTestCase):
                 "meeting_ids": None,
                 "organization_management_level": None,
                 "committee_$_management_level": None,
+            },
+        )
+
+    def test_create_strip_spaces(self) -> None:
+        response = self.request(
+            "user.create",
+            {
+                "username": " username test ",
+                "first_name": " first name test ",
+                "last_name": " last name test ",
+            },
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "user/2",
+            {
+                "username": "username test",
+                "first_name": "first name test",
+                "last_name": "last name test",
             },
         )
 

--- a/tests/system/action/user/test_update.py
+++ b/tests/system/action/user/test_update.py
@@ -1349,3 +1349,23 @@ class UserUpdateActionTest(BaseActionTestCase):
         self.assert_status_code(response, 200)
         user = self.get_model("user/1")
         assert "default_vote_weight" not in user
+
+    def test_update_strip_space(self) -> None:
+        response = self.request(
+            "user.update",
+            {
+                "id": 1,
+                "username": " username test ",
+                "first_name": " first name test ",
+                "last_name": " last name test ",
+            },
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "user/1",
+            {
+                "username": "username test",
+                "first_name": "first name test",
+                "last_name": "last name test",
+            },
+        )

--- a/tests/system/action/user/test_update_self.py
+++ b/tests/system/action/user/test_update_self.py
@@ -99,3 +99,18 @@ class UserUpdateSelfActionTest(BaseActionTestCase):
         model = self.get_model("user/1")
         assert model.get("username") == "username_srtgb123"
         assert "This username is forbidden." in response.json["message"]
+
+    def test_update_self_strip_space(self) -> None:
+        response = self.request(
+            "user.update_self",
+            {
+                "username": " username test ",
+            },
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "user/1",
+            {
+                "username": "username test",
+            },
+        )


### PR DESCRIPTION
Strip space from first_name, last_name, username.
Add tests to check this.
Update the generate_username code. No separate space in generated usernames.