### PR TITLE
#1130 Second migration

### DIFF
--- a/global/data/initial-data.json
+++ b/global/data/initial-data.json
@@ -1,5 +1,5 @@
 {
-    "_migration_index": 20,
+    "_migration_index": 21,
     "organization": {
         "1": {
             "id": 1,

--- a/migrations/migrations/0020_2nd_migration_seq_numbers.py
+++ b/migrations/migrations/0020_2nd_migration_seq_numbers.py
@@ -1,0 +1,69 @@
+from collections import defaultdict
+from typing import Dict, List, Optional, cast
+
+from datastore.migrations import BaseEvent, BaseMigration, CreateEvent
+from datastore.shared.typing import JSON
+from datastore.shared.util import KEYSEPARATOR, collection_from_fqid
+
+
+class Migration(BaseMigration):
+    """
+    This migration renumbers all `<collection>/sequential_number` to get them unique.
+    """
+
+    target_migration_index = 21
+
+    collections = (
+        "assignment",
+        "motion",
+        "motion_block",
+        "motion_category",
+        "motion_workflow",
+        "poll",
+        "projector",
+        "topic",
+        "list_of_speakers",
+        "motion_statute_paragraph",
+        "motion_comment_section",
+    )
+    field = "sequential_number"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.sequential_numbers_map: Dict[str, Dict[int, int]] = {}
+
+    def migrate_event(
+        self,
+        event: BaseEvent,
+    ) -> Optional[List[BaseEvent]]:
+        collection = collection_from_fqid(event.fqid)
+        if collection in self.collections and isinstance(event, CreateEvent):
+            event.data[self.field] = self.get_default(event, collection)
+            return [event]
+        else:
+            return None
+
+    def get_default(self, event: BaseEvent, collection: str) -> JSON:
+        if not self.sequential_numbers_map:
+            self.init_sequential_numbers_map()
+        self.sequential_numbers_map[collection][
+            cast(int, event.data["meeting_id"])
+        ] += 1
+        return self.sequential_numbers_map[collection][
+            cast(int, event.data["meeting_id"])
+        ]
+
+    def init_sequential_numbers_map(self) -> None:
+        self.sequential_numbers_map = {}
+        for collection in self.collections:
+            self.sequential_numbers_map[collection] = defaultdict(int)
+            ids = self.new_accessor.get_all_ids_for_collection(collection)
+            for id_ in ids:
+                fqid = collection + KEYSEPARATOR + str(id_)
+                data, _ = self.new_accessor.get_model_ignore_deleted(fqid)
+                if self.sequential_numbers_map[collection][
+                    cast(int, data["meeting_id"])
+                ] < cast(int, data.get("sequential_number", 0)):
+                    self.sequential_numbers_map[collection][
+                        cast(int, data["meeting_id"])
+                    ] = cast(int, data["sequential_number"])

--- a/migrations/tests/test_0020_2nd_migration_seq_numbers.py
+++ b/migrations/tests/test_0020_2nd_migration_seq_numbers.py
@@ -19,6 +19,8 @@ def test_migration_all(clear_datastore, write, finalize, assert_model):
 
     for collection in COLLECTIONS:
         write(
+            {"type": "create", "fqid": "meeting/1", "fields": {"id": 1}},
+            {"type": "create", "fqid": "meeting/2", "fields": {"id": 2}},
             {
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "1",
@@ -28,7 +30,7 @@ def test_migration_all(clear_datastore, write, finalize, assert_model):
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "2",
                 "fields": {"id": 2, "meeting_id": 1, "sequential_number": 1},
-            }
+            },
         )
 
         finalize("0020_2nd_migration_seq_numbers")
@@ -153,7 +155,7 @@ def test_assignment_two_stages(migrate, write, finalize, assert_model):
             "type": "create",
             "fqid": "assignment" + KEYSEPARATOR + "4",
             "fields": {"id": 4, "meeting_id": 1, "sequential_number": 14},
-        }
+        },
     )
 
     finalize("0020_2nd_migration_seq_numbers")

--- a/migrations/tests/test_0020_2nd_migration_seq_numbers.py
+++ b/migrations/tests/test_0020_2nd_migration_seq_numbers.py
@@ -2,6 +2,7 @@ from datastore.shared.util import KEYSEPARATOR
 
 COLLECTIONS = (
     "assignment",
+    "motion",
     "motion_block",
     "motion_category",
     "motion_workflow",
@@ -21,18 +22,16 @@ def test_migration_all(clear_datastore, write, finalize, assert_model):
             {
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "1",
-                "fields": {"id": 1, "meeting_id": 1},
-            }
-        )
-        write(
+                "fields": {"id": 1, "meeting_id": 1, "sequential_number": 1},
+            },
             {
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "2",
-                "fields": {"id": 2, "meeting_id": 1},
+                "fields": {"id": 2, "meeting_id": 1, "sequential_number": 1},
             }
         )
 
-        finalize("0010_add_sequential_numbers")
+        finalize("0020_2nd_migration_seq_numbers")
 
         assert_model(
             collection + KEYSEPARATOR + "1",
@@ -51,7 +50,7 @@ def test_migration_all(clear_datastore, write, finalize, assert_model):
                 "sequential_number": 2,
                 "meeting_id": 1,
                 "meta_deleted": False,
-                "meta_position": 2,
+                "meta_position": 1,
             },
         )
         clear_datastore()
@@ -65,32 +64,26 @@ def test_migration_motion_block_more_objects(
             {
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "1",
-                "fields": {"id": 1, "meeting_id": 1},
-            }
-        )
-        write(
+                "fields": {"id": 1, "meeting_id": 1, "sequential_number": 1},
+            },
             {
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "2",
-                "fields": {"id": 2, "meeting_id": 1},
-            }
-        )
-        write(
+                "fields": {"id": 2, "meeting_id": 1, "sequential_number": 1},
+            },
             {
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "3",
-                "fields": {"id": 3, "meeting_id": 2},
-            }
-        )
-        write(
+                "fields": {"id": 3, "meeting_id": 2, "sequential_number": 1},
+            },
             {
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "4",
-                "fields": {"id": 4, "meeting_id": 2},
-            }
+                "fields": {"id": 4, "meeting_id": 2, "sequential_number": 1},
+            },
         )
 
-        finalize("0010_add_sequential_numbers")
+        finalize("0020_2nd_migration_seq_numbers")
 
         assert_model(
             collection + KEYSEPARATOR + "1",
@@ -109,7 +102,7 @@ def test_migration_motion_block_more_objects(
                 "sequential_number": 2,
                 "meeting_id": 1,
                 "meta_deleted": False,
-                "meta_position": 2,
+                "meta_position": 1,
             },
         )
         assert_model(
@@ -119,7 +112,7 @@ def test_migration_motion_block_more_objects(
                 "sequential_number": 1,
                 "meeting_id": 2,
                 "meta_deleted": False,
-                "meta_position": 3,
+                "meta_position": 1,
             },
         )
 
@@ -130,46 +123,40 @@ def test_migration_motion_block_more_objects(
                 "sequential_number": 2,
                 "meeting_id": 2,
                 "meta_deleted": False,
-                "meta_position": 4,
+                "meta_position": 1,
             },
         )
         clear_datastore()
 
 
 def test_assignment_two_stages(migrate, write, finalize, assert_model):
-    write({"type": "create", "fqid": "meeting/1", "fields": {"id": 1}})
-    write({"type": "create", "fqid": "meeting/2", "fields": {"id": 2}})
     write(
         {
             "type": "create",
             "fqid": "assignment" + KEYSEPARATOR + "1",
-            "fields": {"id": 1, "meeting_id": 1},
-        }
-    )
-    write(
+            "fields": {"id": 1, "meeting_id": 1, "sequential_number": 11},
+        },
         {
             "type": "create",
             "fqid": "assignment" + KEYSEPARATOR + "2",
-            "fields": {"id": 2, "meeting_id": 1},
-        }
+            "fields": {"id": 2, "meeting_id": 1, "sequential_number": 12},
+        },
     )
-    migrate("0010_add_sequential_numbers")
+    migrate("0020_2nd_migration_seq_numbers")
     write(
         {
             "type": "create",
             "fqid": "assignment" + KEYSEPARATOR + "3",
-            "fields": {"id": 3, "meeting_id": 1},
-        }
-    )
-    write(
+            "fields": {"id": 3, "meeting_id": 1, "sequential_number": 13},
+        },
         {
             "type": "create",
             "fqid": "assignment" + KEYSEPARATOR + "4",
-            "fields": {"id": 4, "meeting_id": 1},
+            "fields": {"id": 4, "meeting_id": 1, "sequential_number": 14},
         }
     )
 
-    finalize("0010_add_sequential_numbers")
+    finalize("0020_2nd_migration_seq_numbers")
 
     assert_model(
         "assignment" + KEYSEPARATOR + "1",
@@ -178,7 +165,7 @@ def test_assignment_two_stages(migrate, write, finalize, assert_model):
             "sequential_number": 1,
             "meeting_id": 1,
             "meta_deleted": False,
-            "meta_position": 3,
+            "meta_position": 1,
         },
     )
     assert_model(
@@ -188,7 +175,7 @@ def test_assignment_two_stages(migrate, write, finalize, assert_model):
             "sequential_number": 2,
             "meeting_id": 1,
             "meta_deleted": False,
-            "meta_position": 4,
+            "meta_position": 1,
         },
     )
     assert_model(
@@ -198,7 +185,7 @@ def test_assignment_two_stages(migrate, write, finalize, assert_model):
             "sequential_number": 3,
             "meeting_id": 1,
             "meta_deleted": False,
-            "meta_position": 5,
+            "meta_position": 2,
         },
     )
 
@@ -207,93 +194,6 @@ def test_assignment_two_stages(migrate, write, finalize, assert_model):
         {
             "id": 4,
             "sequential_number": 4,
-            "meeting_id": 1,
-            "meta_deleted": False,
-            "meta_position": 6,
-        },
-    )
-
-
-def test_assignment_only_2_position(migrate, write, finalize, assert_model):
-    write(
-        {
-            "type": "create",
-            "fqid": "assignment" + KEYSEPARATOR + "1",
-            "fields": {"id": 1, "meeting_id": 1},
-        },
-        {
-            "type": "create",
-            "fqid": "assignment" + KEYSEPARATOR + "2",
-            "fields": {"id": 2, "meeting_id": 2},
-        },
-        {
-            "type": "create",
-            "fqid": "assignment" + KEYSEPARATOR + "3",
-            "fields": {"id": 3, "meeting_id": 2},
-        },
-    )
-    write(
-        {
-            "type": "create",
-            "fqid": "assignment" + KEYSEPARATOR + "4",
-            "fields": {"id": 4, "meeting_id": 1},
-        },
-        {
-            "type": "create",
-            "fqid": "assignment" + KEYSEPARATOR + "5",
-            "fields": {"id": 5, "meeting_id": 1},
-        },
-    )
-
-    finalize("0010_add_sequential_numbers")
-
-    assert_model(
-        "assignment" + KEYSEPARATOR + "1",
-        {
-            "id": 1,
-            "sequential_number": 1,
-            "meeting_id": 1,
-            "meta_deleted": False,
-            "meta_position": 1,
-        },
-    )
-    assert_model(
-        "assignment" + KEYSEPARATOR + "2",
-        {
-            "id": 2,
-            "sequential_number": 1,
-            "meeting_id": 2,
-            "meta_deleted": False,
-            "meta_position": 1,
-        },
-    )
-    assert_model(
-        "assignment" + KEYSEPARATOR + "3",
-        {
-            "id": 3,
-            "sequential_number": 2,
-            "meeting_id": 2,
-            "meta_deleted": False,
-            "meta_position": 1,
-        },
-    )
-
-    assert_model(
-        "assignment" + KEYSEPARATOR + "4",
-        {
-            "id": 4,
-            "sequential_number": 2,
-            "meeting_id": 1,
-            "meta_deleted": False,
-            "meta_position": 2,
-        },
-    )
-
-    assert_model(
-        "assignment" + KEYSEPARATOR + "5",
-        {
-            "id": 5,
-            "sequential_number": 3,
             "meeting_id": 1,
             "meta_deleted": False,
             "meta_position": 2,


### PR DESCRIPTION
Repeats the migration 0010_add_sequential_numbers, because there are not unique sequence_numbers under special circumstances.