### PR TITLE
Fix relation handling bug in generic delete action

### DIFF
--- a/openslides_backend/action/actions/motion/create.py
+++ b/openslides_backend/action/actions/motion/create.py
@@ -20,7 +20,6 @@ class MotionCreate(MotionCreateBase):
 
     schema = DefaultSchema(Motion()).get_create_schema(
         optional_properties=[
-            "title",
             "number",
             "state_extension",
             "sort_parent_id",

--- a/openslides_backend/action/generics/delete.py
+++ b/openslides_backend/action/generics/delete.py
@@ -20,17 +20,13 @@ class DeleteAction(Action):
         """
         Takes care of on_delete handling.
         """
-        # TODO: Check if instance exists in DB and is not deleted. Ensure that meta_deleted field is added to locked_fields.
-
         # Update instance (by default this does nothing)
         instance = self.update_instance(instance)
 
         # Fetch db instance with all relevant fields
         this_fqid = FullQualifiedId(self.model.collection, instance["id"])
         relevant_fields = [
-            field.get_own_field_name()
-            for field in self.model.get_relation_fields()
-            if field.on_delete != OnDelete.SET_NULL
+            field.get_own_field_name() for field in self.model.get_relation_fields()
         ] + ["meta_deleted"]
         db_instance = self.datastore.get(
             fqid=this_fqid,
@@ -43,7 +39,8 @@ class DeleteAction(Action):
                 structured_fields += list(
                     self.get_all_structured_fields(field, db_instance)
                 )
-        db_instance.update(self.datastore.get(this_fqid, structured_fields))
+        if structured_fields:
+            db_instance.update(self.datastore.get(this_fqid, structured_fields))
 
         # Update instance and set relation fields to None.
         # Gather all delete actions with action data and also all models to be deleted

--- a/tests/system/action/base.py
+++ b/tests/system/action/base.py
@@ -93,6 +93,7 @@ class BaseActionTestCase(BaseSystemTestCase):
                     "group_ids": [base, base + 1, base + 2],
                     "default_group_id": base,
                     "admin_group_id": base + 1,
+                    "motions_default_workflow_id": base,
                     "committee_id": committee_id,
                     "is_active_in_organization_id": 1,
                 },
@@ -107,6 +108,17 @@ class BaseActionTestCase(BaseSystemTestCase):
                 f"group/{base+2}": {
                     "meeting_id": base,
                 },
+                f"motion_workflow/{base}": {
+                    "meeting_id": base,
+                    "default_workflow_meeting_id": base,
+                    "state_ids": [base],
+                    "first_state_id": base,
+                },
+                f"motion_state/{base}": {
+                    "meeting_id": base,
+                    "workflow_id": base,
+                    "first_state_of_workflow_id": base,
+                },
                 f"committee/{committee_id}": {
                     "organization_id": 1,
                     "name": f"Commitee{committee_id}",
@@ -115,6 +127,7 @@ class BaseActionTestCase(BaseSystemTestCase):
                 "organization/1": {
                     "limit_of_meetings": 0,
                     "active_meeting_ids": [base],
+                    "enable_electronic_voting": True,
                 },
             }
         )


### PR DESCRIPTION
Tricky bug in the generic delete: When deleting a model with a template relation field, the reverse relation was sometimes not updated correctly. Root cause for this was that too few fields were fetched from the datastore when calculating the reverse relations so they were assumed to be empty. The reason this error only occured when the user was a submitter of some motion is that through a second mistake all fields were fetched from the datastore when actually none should have been fetched (if `[]` is given as `mapped_fields` to the `get` method, it is interpreted as "give me the whole model). So there needed to be two template relation fields in the model for this error to occur, one which was correctly fetched and one which was missed because of that.

@emanuelschuetze I would not want to write any migration for this, since it could potentially affect all delete actions, not only user. By deleting the invalid models (e.g. the poll with wrong `voted_ids`) and recreating them, everything should be working again as long as they don't go back to this exact point in time with the history mode. Alternatively, they can of course reset their instance, depending on how many data was already filled in.