### PR TITLE
Improved reader cache

### DIFF
--- a/openslides_backend/action/action.py
+++ b/openslides_backend/action/action.py
@@ -184,7 +184,6 @@ class Action(BaseAction, metaclass=SchemaProvider):
         """
         Checks permission by requesting permission service or using internal check.
         """
-        # switch between internal and external permission service
         if self.permission:
             if type(self.permission) == OrganizationManagementLevel:
                 if has_organization_management_level(

--- a/openslides_backend/action/action.py
+++ b/openslides_backend/action/action.py
@@ -256,7 +256,6 @@ class Action(BaseAction, metaclass=SchemaProvider):
             identifier = "id"
             if self.permission_id:
                 identifier = self.permission_id
-            # breakpoint()
             db_instance = self.datastore.get(
                 FullQualifiedId(model.collection, instance[identifier]),
                 ["meeting_id"],

--- a/openslides_backend/action/action.py
+++ b/openslides_backend/action/action.py
@@ -126,6 +126,10 @@ class Action(BaseAction, metaclass=SchemaProvider):
         """
         self.user_id = user_id
         self.index = 0
+
+        # prefetch as much data as possible
+        self.prefetch(action_data)
+
         for instance in action_data:
             self.validate_instance(instance)
             self.check_for_archived_meeting(instance)
@@ -170,6 +174,11 @@ class Action(BaseAction, metaclass=SchemaProvider):
             return (final_write_request, None)
 
         return (final_write_request, self.results)
+
+    def prefetch(self, action_data: ActionData) -> None:
+        """
+        Implement in subclasses to prefetch data for the action.
+        """
 
     def check_permissions(self, instance: Dict[str, Any]) -> None:
         """

--- a/openslides_backend/action/action.py
+++ b/openslides_backend/action/action.py
@@ -247,6 +247,7 @@ class Action(BaseAction, metaclass=SchemaProvider):
             identifier = "id"
             if self.permission_id:
                 identifier = self.permission_id
+            # breakpoint()
             db_instance = self.datastore.get(
                 FullQualifiedId(model.collection, instance[identifier]),
                 ["meeting_id"],

--- a/openslides_backend/action/action_handler.py
+++ b/openslides_backend/action/action_handler.py
@@ -231,7 +231,7 @@ class ActionHandler(BaseHandler):
                 write_request.locked_fields = self.datastore.locked_fields
                 # reset locked fields, but not changed models - these might be needed
                 # by another action
-                self.datastore.locked_fields = {}
+                self.datastore.reset(hard=False)
 
             # add on_success routine
             if on_success := action.get_on_success(action_data):

--- a/openslides_backend/action/actions/option/update.py
+++ b/openslides_backend/action/actions/option/update.py
@@ -204,5 +204,5 @@ class OptionUpdateAction(UpdateAction):
         content_object_id = poll.get("content_object_id", "")
         meeting_id = poll["meeting_id"]
         check_poll_or_option_perms(
-            self.name, content_object_id, self.datastore, self.user_id, meeting_id
+            content_object_id, self.datastore, self.user_id, meeting_id
         )

--- a/openslides_backend/action/actions/poll/mixins.py
+++ b/openslides_backend/action/actions/poll/mixins.py
@@ -28,12 +28,11 @@ class PollPermissionMixin(Action):
             content_object_id = poll.get("content_object_id", "")
             meeting_id = poll["meeting_id"]
         check_poll_or_option_perms(
-            self.name, content_object_id, self.datastore, self.user_id, meeting_id
+            content_object_id, self.datastore, self.user_id, meeting_id
         )
 
 
 def check_poll_or_option_perms(
-    action_name: str,
     content_object_id: str,
     datastore: DatastoreService,
     user_id: int,

--- a/openslides_backend/action/actions/poll/stop.py
+++ b/openslides_backend/action/actions/poll/stop.py
@@ -1,17 +1,14 @@
-from typing import Any, Callable, Dict, Tuple, Optional
+from typing import Any, Callable, Dict
 
 from ....models.models import Poll
+from ....services.datastore.commands import GetManyRequest
 from ....shared.exceptions import ActionException
-from ....shared.patterns import FullQualifiedId, Collection
+from ....shared.patterns import Collection, FullQualifiedId
 from ...generics.update import UpdateAction
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
 from ...util.typing import ActionData
 from .mixins import PollPermissionMixin, StopControl
-
-from ....services.datastore.commands import GetManyRequest
-from ....shared.interfaces.write_request import WriteRequest
-from ...util.typing import ActionResults
 
 
 @register_action("poll.stop")
@@ -23,20 +20,55 @@ class PollStopAction(StopControl, UpdateAction, PollPermissionMixin):
     model = Poll()
     schema = DefaultSchema(Poll()).get_update_schema()
 
-    def perform(
-        self, action_data: ActionData, user_id: int, internal: bool = False
-    ) -> Tuple[Optional[WriteRequest], Optional[ActionResults]]:
-        self.prefetch(action_data, user_id)
-        return super().perform(action_data, user_id, internal)
-    
-    def prefetch(self, action_data: ActionData, user_id: int) -> None:
-        result = self.datastore.get_many([
-            GetManyRequest(Collection("meeting"), [1], ["is_active_in_organization_id", "name", 'poll_couple_countdown', 'poll_countdown_id', 'users_enable_vote_weight', "vote_ids"]),
-            GetManyRequest(Collection("group"), [3], ["user_ids"]),
-            GetManyRequest(Collection("poll"), [1], ["content_object_id", "meeting_id", "state", "voted_ids", 'pollmethod', 'global_option_id', 'entitled_group_ids']),
-            GetManyRequest(Collection("option"), [1], ["meeting_id", "vote_ids"]),
-            GetManyRequest(Collection("user"), list(range(1, 102)), ['group_$1_ids', 'organization_management_level', "vote_$_ids", 'vote_$1_ids', 'vote_delegated_vote_$_ids', 'vote_delegated_vote_$1_ids', 'poll_voted_$_ids', 'poll_voted_$1_ids', "is_present_in_meeting_ids", "vote_delegated_$_to_id", "vote_delegated_$1_to_id"])
-        ])
+    def prefetch(self, action_data: ActionData) -> None:
+        self.datastore.get_many(
+            [
+                GetManyRequest(
+                    Collection("meeting"),
+                    [1],
+                    [
+                        "is_active_in_organization_id",
+                        "name",
+                        "poll_couple_countdown",
+                        "poll_countdown_id",
+                        "users_enable_vote_weight",
+                        "vote_ids",
+                    ],
+                ),
+                GetManyRequest(Collection("group"), [3], ["user_ids"]),
+                GetManyRequest(
+                    Collection("poll"),
+                    [1],
+                    [
+                        "content_object_id",
+                        "meeting_id",
+                        "state",
+                        "voted_ids",
+                        "pollmethod",
+                        "global_option_id",
+                        "entitled_group_ids",
+                    ],
+                ),
+                GetManyRequest(Collection("option"), [1], ["meeting_id", "vote_ids"]),
+                GetManyRequest(
+                    Collection("user"),
+                    list(range(1, 102)),
+                    [
+                        "group_$1_ids",
+                        "organization_management_level",
+                        "vote_$_ids",
+                        "vote_$1_ids",
+                        "vote_delegated_vote_$_ids",
+                        "vote_delegated_vote_$1_ids",
+                        "poll_voted_$_ids",
+                        "poll_voted_$1_ids",
+                        "is_present_in_meeting_ids",
+                        "vote_delegated_$_to_id",
+                        "vote_delegated_$1_to_id",
+                    ],
+                ),
+            ]
+        )
 
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
         poll = self.datastore.get(

--- a/openslides_backend/action/actions/poll/stop.py
+++ b/openslides_backend/action/actions/poll/stop.py
@@ -1,13 +1,17 @@
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Tuple, Optional
 
 from ....models.models import Poll
 from ....shared.exceptions import ActionException
-from ....shared.patterns import FullQualifiedId
+from ....shared.patterns import FullQualifiedId, Collection
 from ...generics.update import UpdateAction
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
 from ...util.typing import ActionData
 from .mixins import PollPermissionMixin, StopControl
+
+from ....services.datastore.commands import GetManyRequest
+from ....shared.interfaces.write_request import WriteRequest
+from ...util.typing import ActionResults
 
 
 @register_action("poll.stop")
@@ -18,6 +22,21 @@ class PollStopAction(StopControl, UpdateAction, PollPermissionMixin):
 
     model = Poll()
     schema = DefaultSchema(Poll()).get_update_schema()
+
+    def perform(
+        self, action_data: ActionData, user_id: int, internal: bool = False
+    ) -> Tuple[Optional[WriteRequest], Optional[ActionResults]]:
+        self.prefetch(action_data, user_id)
+        return super().perform(action_data, user_id, internal)
+    
+    def prefetch(self, action_data: ActionData, user_id: int) -> None:
+        result = self.datastore.get_many([
+            GetManyRequest(Collection("meeting"), [1], ["is_active_in_organization_id", "name", 'poll_couple_countdown', 'poll_countdown_id', 'users_enable_vote_weight', "vote_ids"]),
+            GetManyRequest(Collection("group"), [3], ["user_ids"]),
+            GetManyRequest(Collection("poll"), [1], ["content_object_id", "meeting_id", "state", "voted_ids", 'pollmethod', 'global_option_id', 'entitled_group_ids']),
+            GetManyRequest(Collection("option"), [1], ["meeting_id", "vote_ids"]),
+            GetManyRequest(Collection("user"), list(range(1, 102)), ['group_$1_ids', 'organization_management_level', "vote_$_ids", 'vote_$1_ids', 'vote_delegated_vote_$_ids', 'vote_delegated_vote_$1_ids', 'poll_voted_$_ids', 'poll_voted_$1_ids', "is_present_in_meeting_ids", "vote_delegated_$_to_id", "vote_delegated_$1_to_id"])
+        ])
 
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
         poll = self.datastore.get(

--- a/openslides_backend/action/actions/vote/create.py
+++ b/openslides_backend/action/actions/vote/create.py
@@ -1,3 +1,7 @@
+from openslides_backend.action.util.typing import ActionData
+from openslides_backend.services.datastore.commands import GetManyRequest
+from openslides_backend.shared.patterns import Collection
+
 from ....models.models import Vote
 from ...mixins.create_action_with_inferred_meeting import (
     CreateActionWithInferredMeeting,
@@ -25,3 +29,51 @@ class VoteCreate(CreateActionWithInferredMeeting):
     )
 
     relation_field_for_meeting = "option_id"
+
+    def prefetch(self, action_data: ActionData) -> None:
+        result = self.datastore.get_many(
+            [
+                GetManyRequest(
+                    Collection("option"),
+                    list({instance["option_id"] for instance in action_data}),
+                    ["meeting_id", "vote_ids"],
+                ),
+            ]
+        )
+        fields = [
+            "is_present_in_meeting_ids",
+            "organization_management_level",
+            "group_$_ids",
+            "vote_$_ids",
+            "poll_voted_$_ids",
+            "vote_delegated_$_to_id",
+            "vote_delegated_vote_$_ids",
+        ]
+        for option in result[Collection("option")].values():
+            fields.extend(
+                (
+                    f"group_${option['meeting_id']}_ids",
+                    f"vote_${option['meeting_id']}_ids",
+                    f"poll_voted_${option['meeting_id']}_ids",
+                    f"vote_delegated_${option['meeting_id']}_to_id",
+                    f"vote_delegated_vote_${option['meeting_id']}_ids",
+                )
+            )
+        self.datastore.get_many(
+            [
+                GetManyRequest(
+                    Collection("user"),
+                    list(
+                        {
+                            user_id
+                            for instance in action_data
+                            for user_id in (
+                                instance["user_id"],
+                                instance["delegated_user_id"],
+                            )
+                        }
+                    ),
+                    fields,
+                ),
+            ]
+        )

--- a/openslides_backend/action/actions/vote/create.py
+++ b/openslides_backend/action/actions/vote/create.py
@@ -68,9 +68,10 @@ class VoteCreate(CreateActionWithInferredMeeting):
                             user_id
                             for instance in action_data
                             for user_id in (
-                                instance["user_id"],
-                                instance["delegated_user_id"],
+                                instance.get("user_id"),
+                                instance.get("delegated_user_id"),
                             )
+                            if user_id is not None
                         }
                     ),
                     fields,

--- a/openslides_backend/services/datastore/adapter.py
+++ b/openslides_backend/services/datastore/adapter.py
@@ -445,5 +445,5 @@ class DatastoreAdapter(BaseDatastoreService):
         self.logger.debug("Start TRUNCATE_DB request to datastore")
         self.retrieve(command)
 
-    def reset(self) -> None:
+    def reset(self, hard: bool = True) -> None:
         self.locked_fields = {}

--- a/openslides_backend/services/datastore/adapter.py
+++ b/openslides_backend/services/datastore/adapter.py
@@ -437,8 +437,6 @@ class DatastoreAdapter(BaseDatastoreService):
             f"Write request: {write_requests}"
         )
         self.retrieve(command)
-        # from json import loads
-        # WriteHandler().write(loads(command.data))
 
     def truncate_db(self) -> None:
         command = commands.TruncateDb()

--- a/openslides_backend/services/datastore/cache_adapter.py
+++ b/openslides_backend/services/datastore/cache_adapter.py
@@ -10,9 +10,7 @@ from ...shared.patterns import Collection, FullQualifiedId
 from ...shared.typing import ModelMap
 from .adapter import DatastoreAdapter
 from .commands import GetManyRequest
-from .interface import Engine, LockResult, PartialModel
-
-MappedFieldsPerFqid = Dict[FullQualifiedId, List[str]]
+from .interface import Engine, LockResult, MappedFieldsPerFqid, PartialModel
 
 
 class CacheDatastoreAdapter(DatastoreAdapter):

--- a/openslides_backend/services/datastore/cache_adapter.py
+++ b/openslides_backend/services/datastore/cache_adapter.py
@@ -40,7 +40,7 @@ class CacheDatastoreAdapter(DatastoreAdapter):
             )
 
         mapped_fields_per_fqid = {fqid: mapped_fields}
-        # fetch results from changed models
+        # fetch results from cached models
         results, missing_fields_per_fqid = self._get_many_from_cached_models(
             mapped_fields_per_fqid
         )

--- a/openslides_backend/services/datastore/commands.py
+++ b/openslides_backend/services/datastore/commands.py
@@ -38,6 +38,15 @@ class GetManyRequest:
             and self.mapped_fields == other.mapped_fields
         )
 
+    def __repr__(self) -> str:
+        return str(
+            {
+                "collection": self.collection,
+                "ids": self.ids,
+                "mapped_fields": list(self.mapped_fields),
+            }
+        )
+
 
 CommandData = Dict[str, Union[str, int, List[str]]]
 

--- a/openslides_backend/services/datastore/extended_adapter.py
+++ b/openslides_backend/services/datastore/extended_adapter.py
@@ -480,6 +480,6 @@ class ExtendedDatastoreAdapter(DatastoreAdapter):
             for fqid, fields in missing_fields_per_fqid.items()
         ]
         results = super().get_many(
-            get_many_requests, None, DeletedModelsBehaviour.ALL_MODELS, lock_result
+            get_many_requests, None, DeletedModelsBehaviour.NO_DELETED, lock_result
         )
         return results

--- a/openslides_backend/services/datastore/extended_adapter.py
+++ b/openslides_backend/services/datastore/extended_adapter.py
@@ -16,13 +16,10 @@ from ...shared.typing import DeletedModel, ModelMap
 from .cache_adapter import CacheDatastoreAdapter
 from .commands import GetManyRequest
 from .handle_datastore_errors import raise_datastore_error
-from .interface import Engine, LockResult, PartialModel
+from .interface import Engine, LockResult, MappedFieldsPerFqid, PartialModel
 
 MODEL_FIELD_SQL = "data->>%s"
 COMPARISON_VALUE_SQL = "%s::text"
-
-
-MappedFieldsPerFqid = Dict[FullQualifiedId, List[str]]
 
 
 class ExtendedDatastoreAdapter(CacheDatastoreAdapter):

--- a/openslides_backend/services/datastore/extended_adapter.py
+++ b/openslides_backend/services/datastore/extended_adapter.py
@@ -322,9 +322,10 @@ class ExtendedDatastoreAdapter(CacheDatastoreAdapter):
     def is_new(self, fqid: FullQualifiedId) -> bool:
         return self.changed_models.get(fqid, {}).get("meta_new") is True
 
-    def reset(self) -> None:
+    def reset(self, hard: bool = True) -> None:
         super().reset()
-        self.changed_models.clear()
+        if hard:
+            self.changed_models.clear()
 
     def _filter_changed_models(
         self,

--- a/openslides_backend/services/datastore/extended_adapter.py
+++ b/openslides_backend/services/datastore/extended_adapter.py
@@ -13,7 +13,7 @@ from ...shared.interfaces.env import Env
 from ...shared.interfaces.logging import LoggingModule
 from ...shared.patterns import Collection, FullQualifiedId
 from ...shared.typing import DeletedModel, ModelMap
-from .adapter import DatastoreAdapter
+from .cache_adapter import CacheDatastoreAdapter
 from .commands import GetManyRequest
 from .handle_datastore_errors import raise_datastore_error
 from .interface import Engine, LockResult, PartialModel
@@ -25,7 +25,7 @@ COMPARISON_VALUE_SQL = "%s::text"
 MappedFieldsPerFqid = Dict[FullQualifiedId, List[str]]
 
 
-class ExtendedDatastoreAdapter(DatastoreAdapter):
+class ExtendedDatastoreAdapter(CacheDatastoreAdapter):
     """
     Subclass of the datastore adapter to extend the functions with the usage of the changed_models.
 
@@ -479,7 +479,5 @@ class ExtendedDatastoreAdapter(DatastoreAdapter):
             GetManyRequest(fqid.collection, [fqid.id], fields)
             for fqid, fields in missing_fields_per_fqid.items()
         ]
-        results = super().get_many(
-            get_many_requests, None, DeletedModelsBehaviour.NO_DELETED, lock_result
-        )
+        results = super().get_many(get_many_requests, lock_result=lock_result)
         return results

--- a/openslides_backend/services/datastore/interface.py
+++ b/openslides_backend/services/datastore/interface.py
@@ -133,7 +133,7 @@ class BaseDatastoreService(Protocol):
     def is_deleted(self, fqid: FullQualifiedId) -> bool:
         ...
 
-    def reset(self) -> None:
+    def reset(self, hard: bool = True) -> None:
         ...
 
 

--- a/openslides_backend/services/datastore/interface.py
+++ b/openslides_backend/services/datastore/interface.py
@@ -26,6 +26,9 @@ PartialModel = Dict[str, Any]
 LockResult = Union[bool, List[str]]
 
 
+MappedFieldsPerFqid = Dict[FullQualifiedId, List[str]]
+
+
 class BaseDatastoreService(Protocol):
     """
     Datastore defines the interface to the datastore.

--- a/requirements/partial/requirements_development.txt
+++ b/requirements/partial/requirements_development.txt
@@ -4,6 +4,7 @@ flake8==4.0.1
 mypy==0.941
 pytest==7.1.1
 pytest-cov==3.0.0
+pytest-profiling==1.7.0
 pyyaml==6.0
 pip-check==2.7
 autoflake==1.4

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,5 @@
 from datastore.reader.app import register_services
+from datastore.writer.app import register_services as w_register_services
 
 register_services()
+w_register_services()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,3 @@
 from datastore.reader.app import register_services
-from datastore.writer.app import register_services as w_register_services
 
 register_services()
-w_register_services()

--- a/tests/system/action/poll/test_stop.py
+++ b/tests/system/action/poll/test_stop.py
@@ -5,6 +5,7 @@ from openslides_backend.models.models import Poll
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import DEFAULT_PASSWORD, BaseActionTestCase
 from tests.system.base import ADMIN_PASSWORD, ADMIN_USERNAME
+from tests.system.util import performance
 
 
 class PollStopActionTest(BaseActionTestCase):
@@ -195,7 +196,7 @@ class PollStopActionTest(BaseActionTestCase):
             Permissions.Poll.CAN_MANAGE,
         )
 
-    # @performance
+    @performance
     def test_stop_performance(self) -> None:
         USER_COUNT = 100
         user_ids = list(range(2, USER_COUNT + 2))

--- a/tests/system/action/poll/test_stop.py
+++ b/tests/system/action/poll/test_stop.py
@@ -1,11 +1,10 @@
-import cProfile
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from openslides_backend.models.models import Poll
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import DEFAULT_PASSWORD, BaseActionTestCase
 from tests.system.base import ADMIN_PASSWORD, ADMIN_USERNAME
-from tests.system.util import performance
+from tests.system.util import CountDatastoreCalls, Profiler, performance
 
 
 class PollStopActionTest(BaseActionTestCase):
@@ -196,10 +195,8 @@ class PollStopActionTest(BaseActionTestCase):
             Permissions.Poll.CAN_MANAGE,
         )
 
-    @performance
-    def test_stop_performance(self) -> None:
-        USER_COUNT = 100
-        user_ids = list(range(2, USER_COUNT + 2))
+    def prepare_users_and_poll(self, user_count: int) -> List[int]:
+        user_ids = list(range(2, user_count + 2))
         self.set_models(
             {
                 "poll/1": {
@@ -233,18 +230,27 @@ class PollStopActionTest(BaseActionTestCase):
             response = self.vote_service.vote({"id": 1, "value": {"1": "Y"}})
             self.assert_status_code(response, 200)
         self.client.login(ADMIN_USERNAME, ADMIN_PASSWORD)
+        return user_ids
 
-        def request_helper() -> Any:
-            return self.request("poll.stop", {"id": 1})
+    def test_stop_datastore_calls(self) -> None:
+        user_ids = self.prepare_users_and_poll(3)
 
-        cProfile.runctx(
-            "request_helper()",
-            globals(),
-            locals(),
-            filename="test_stop_performance.prof",
-        )
+        with CountDatastoreCalls() as counter:
+            response = self.request("poll.stop", {"id": 1})
 
-        # response = request_helper()
-        # self.assert_status_code(response, 200)
+        self.assert_status_code(response, 200)
+        poll = self.get_model("poll/1")
+        assert poll["voted_ids"] == user_ids
+        # always 4 calls, independent of user count
+        assert counter.calls == 4
+
+    @performance
+    def test_stop_performance(self) -> None:
+        user_ids = self.prepare_users_and_poll(100)
+
+        with Profiler("test_stop_performance.prof"):
+            response = self.request("poll.stop", {"id": 1})
+
+        self.assert_status_code(response, 200)
         poll = self.get_model("poll/1")
         assert poll["voted_ids"] == user_ids

--- a/tests/unit/extended_datastore_adapter/base.py
+++ b/tests/unit/extended_datastore_adapter/base.py
@@ -85,7 +85,7 @@ class BaseTestExtendedDatastoreAdapter(TestCase):
         return value.
         """
         patcher = patch(
-            f"openslides_backend.services.datastore.adapter.DatastoreAdapter.{method_name}",
+            f"openslides_backend.services.datastore.cache_adapter.CacheDatastoreAdapter.{method_name}",
         )
         mock = patcher.start()
         self.addCleanup(patcher.stop)


### PR DESCRIPTION
First test sees improvement of about 20%, which is slightly less then I expected. Probable cause for this is that as @ostcar noticed, although cache hits are faster than always accessing the database, the access to the cache should also be reduced by streamlining the code (e.g. checking permissions only once for all action data and not for every instance).

Only a raw draft for now, will continue work on this.