### PR TITLE
Allow to set 'name' as updated value in meeting.clone

### DIFF
--- a/tests/system/action/meeting/test_clone.py
+++ b/tests/system/action/meeting/test_clone.py
@@ -159,6 +159,7 @@ class MeetingClone(BaseActionTestCase):
                 "end_time": 1641370959,
                 "location": "Testraum",
                 "organization_tag_ids": [1],
+                "name": "name_ORnVFSQJ",
             },
         )
         self.assert_status_code(response, 200)
@@ -171,6 +172,7 @@ class MeetingClone(BaseActionTestCase):
                 "organization_tag_ids": [1],
                 "start_time": 1641370959,
                 "end_time": 1641370959,
+                "name": "name_ORnVFSQJ",
             },
         )
 


### PR DESCRIPTION
And update the name suffix code to work with setting of name.
Update the tests.