### PR TITLE
Make group.set_permission more robust.

### DIFF
--- a/openslides_backend/action/actions/group/set_permission.py
+++ b/openslides_backend/action/actions/group/set_permission.py
@@ -30,13 +30,14 @@ class GroupSetPermissionAction(UpdateAction):
         group = self.datastore.get(
             FullQualifiedId(self.model.collection, instance["id"]), ["permissions"]
         )
-        if set_ is True and permission not in group["permissions"]:
-            instance["permissions"] = group["permissions"]
+        group_permissions = group.get("permissions") or []
+        if set_ is True and permission not in group_permissions:
+            instance["permissions"] = group_permissions
             instance["permissions"].append(permission)
             instance["permissions"] = filter_surplus_permissions(
                 instance["permissions"]
             )
-        elif set_ is False and permission in group["permissions"]:
-            instance["permissions"] = group["permissions"]
+        elif set_ is False and permission in group_permissions:
+            instance["permissions"] = group_permissions
             instance["permissions"].remove(permission)
         return instance

--- a/tests/system/action/group/test_set_permission.py
+++ b/tests/system/action/group/test_set_permission.py
@@ -86,6 +86,24 @@ class GroupSetPermissionActionTest(BaseActionTestCase):
         model = self.get_model("group/11")
         assert model.get("permissions") == ["agenda_item.can_manage"]
 
+    def test_set_permissions_missing_permissions_in_group(self) -> None:
+        self.set_models(
+            {
+                "meeting/1": {"is_active_in_organization_id": 1},
+                "group/11": {
+                    "name": "group_11",
+                    "meeting_id": 1,
+                },
+            }
+        )
+        response = self.request(
+            "group.set_permission",
+            {"id": 11, "permission": "motion.can_create", "set": True},
+        )
+        self.assert_status_code(response, 200)
+        model = self.get_model("group/11")
+        assert model.get("permissions") == ["motion.can_create"]
+
     def test_set_permissions_no_permissions(self) -> None:
         self.base_permission_test(
             {


### PR DESCRIPTION
Add a test, which shows an KeyError and update the action to fix it.