### PR TITLE
Issue1341 minimize locked_fields for motion.set_state action

### DIFF
--- a/openslides_backend/action/action.py
+++ b/openslides_backend/action/action.py
@@ -228,6 +228,7 @@ class Action(BaseAction, metaclass=SchemaProvider):
         meeting = self.datastore.get(
             fqid,
             ["is_active_in_organization_id", "name"],
+            lock_result=False,
         )
         if not meeting.get("is_active_in_organization_id"):
             raise ActionException(
@@ -258,6 +259,7 @@ class Action(BaseAction, metaclass=SchemaProvider):
             db_instance = self.datastore.get(
                 FullQualifiedId(model.collection, instance[identifier]),
                 ["meeting_id"],
+                lock_result=False,
             )
             return db_instance["meeting_id"]
 

--- a/openslides_backend/action/actions/motion/set_number_mixin.py
+++ b/openslides_backend/action/actions/motion/set_number_mixin.py
@@ -32,11 +32,14 @@ class SetNumberMixin(BaseAction):
         meeting = self.datastore.get(
             FullQualifiedId(Collection("meeting"), meeting_id),
             ["motions_number_type", "motions_number_min_digits"],
+            lock_result=False,
         )
         if meeting.get("motions_number_type") == "manually":
             return
         state = self.datastore.get(
-            FullQualifiedId(Collection("motion_state"), state_id), ["set_number"]
+            FullQualifiedId(Collection("motion_state"), state_id),
+            ["set_number"],
+            lock_result=False,
         )
         if not state.get("set_number"):
             return

--- a/openslides_backend/action/actions/motion/set_state.py
+++ b/openslides_backend/action/actions/motion/set_state.py
@@ -22,47 +22,6 @@ class MotionSetStateAction(UpdateAction, SetNumberMixin, PermissionHelperMixin):
     model = Motion()
     schema = DefaultSchema(Motion()).get_update_schema(["state_id"])
 
-    """
-        Documentation from Issue1341 locked_fields
-        All reading database calls made duringrequest with fqid, origin lock_result
-        and changed value, mapped fields and finally calling method name
-        00: motion/22, lock=True=>False, mapped:[meeting_id] from get_meeting_id
-        01: meeting/222, lock=True=>False, mapped:['is_active_in_organization_id', 'name'] from check_for_archived_meeting
-        02: motion/22, lock=True=>False, mapped:['state_id', 'submitter_ids'] from set_state.check permissions
-        03: user/1, lock=False, ['group_$222_ids', 'organization_management_level'] => from check_permissions
-        04: motion/22, lock=[state_id], mapped_fields:['lead_motion_id', 'category_id', 'number', 'number_value', 'created'] from update_instance
-        05: motion_state/77, lock=True=>False, ['next_state_ids', 'previous_state_ids'] from update_instance
-        06: meeting/222: lock=True=>False, ['motions_number_type', 'motions_number_min_digits'] from set_number_mixin.set_number
-        07: motion_state/76, lock=True=>False, [set_number] from set_number_mixin,set_number
-        08: motion_state/76, lock=True=>False, ['set_created_timestamp'] from update_instance
-        09: motion_state/76, lock=True=False, [meeting_id] from assert_belongs_to_meeting
-        10: motion_state/77, lock=True, [motion_ids] from relation handling
-        11: motion_state/76, lock=True, [motion_ids] from relation handling
-
-        All initially locked_fields (and position_number)with my decision whether they have to be locked or not:
-        {
-            'motion/22/meeting_id': 2, no
-            'meeting/222/is_active_in_organization_id': 2, no
-            'meeting/222/name': 2, no
-            'motion/22/state_id': 2, yes
-            'motion/22/submitter_ids': 2, no
-            'motion_state/77/next_state_ids': 2, no
-            'motion_state/77/previous_state_ids': 2, no
-            'meeting/222/motions_number_min_digits': 2, no
-            'meeting/222/motions_number_type': 2, no
-            'motion_state/76/set_number': 2, no
-            'motion_state/76/set_created_timestamp': 2, no
-            'motion_state/76/meeting_id': 2, no
-            'motion_state/77/motion_ids': 2, yes
-            'motion_state/76/motion_ids': 2  yes
-        }
-
-        All remaining locked_fields (and position_number) after changes:
-            'motion/22/state_id': 2
-            'motion_state/77/motion_ids': 2
-            'motion_state/76/motion_ids': 2
-    """
-
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
         """
         Check if the state_id is from a previous or next state.

--- a/openslides_backend/action/util/assert_belongs_to_meeting.py
+++ b/openslides_backend/action/util/assert_belongs_to_meeting.py
@@ -22,12 +22,13 @@ def assert_belongs_to_meeting(
             instance = datastore.get(
                 fqid,
                 ["meeting_ids"],
+                lock_result=False,
                 raise_exception=False,
             )
             if meeting_id not in instance.get("meeting_ids", []):
                 errors.add(str(fqid))
         elif fqid.collection.collection == "mediafile":
-            mediafile = datastore.get(fqid, ["owner_id"])
+            mediafile = datastore.get(fqid, ["owner_id"], lock_result=False)
             collection, id_ = mediafile["owner_id"].split(KEYSEPARATOR)
             if collection == "meeting":
                 if int(id_) != meeting_id:
@@ -38,6 +39,7 @@ def assert_belongs_to_meeting(
             instance = datastore.get(
                 fqid,
                 ["meeting_id"],
+                lock_result=False,
                 raise_exception=False,
             )
             if instance.get("meeting_id") != meeting_id:

--- a/tests/system/action/motion/test_set_state.py
+++ b/tests/system/action/motion/test_set_state.py
@@ -177,7 +177,7 @@ class MotionSetStateActionTest(BaseActionTestCase):
         self.assert_status_code(response, 200)
 
     def test_set_state_parallel(self) -> None:
-        count:int = 500
+        count:int = 5
         self.sync_event = threading.Event()
         self.sync_event.clear()
 

--- a/tests/system/action/motion/test_set_state.py
+++ b/tests/system/action/motion/test_set_state.py
@@ -228,7 +228,7 @@ class MotionSetStateActionTest(BaseActionTestCase):
         duration = round(time.time() - check_time, 2)
         print(duration)
 
-    def thread_method(self, i) -> None:
+    def thread_method(self, i: int) -> None:
         self.sync_event.wait()
         response = self.request("motion.set_state", {"id": 22 + i, "state_id": 76})
         self.assert_status_code(response, 200)

--- a/tests/system/action/motion/test_set_state.py
+++ b/tests/system/action/motion/test_set_state.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from typing import Any, Dict
 
@@ -174,3 +175,60 @@ class MotionSetStateActionTest(BaseActionTestCase):
         self.set_user_groups(self.user_id, [3])
         response = self.request("motion.set_state", {"id": 22, "state_id": 76})
         self.assert_status_code(response, 200)
+
+    def test_set_state_parallel(self) -> None:
+        count:int = 500
+        self.sync_event = threading.Event()
+        self.sync_event.clear()
+
+        self.set_models(
+            {
+                "meeting/222": {
+                    "name": "name_SNLGsvIV",
+                    "is_active_in_organization_id": 1,
+                },
+                "motion_state/76": {
+                    "meeting_id": 222,
+                    "name": "test0",
+                    "motion_ids": [],
+                    "next_state_ids": [77],
+                    "previous_state_ids": [],
+                    "set_created_timestamp": True,
+                },
+                "motion_state/77": {
+                    "meeting_id": 222,
+                    "name": "test1",
+                    "motion_ids": [22+i for i in range(count)],
+                    "first_state_of_workflow_id": 76,
+                    "next_state_ids": [],
+                    "previous_state_ids": [76],
+                },
+                **{
+                    f"motion/{22+i}": {
+                        "meeting_id": 222,
+                        "title": "test1",
+                        "state_id": 77,
+                        "number_value": 23+i,
+                    } for i in range(count)
+                },
+            }
+        )
+
+        threads= []
+        for i in range(count):
+            thread = threading.Thread(target=self.thread_method, kwargs={"i":i})
+            thread.start()
+            threads.append(thread)
+
+        check_time = time.time()
+        self.sync_event.set()
+        for thread in threads:
+            thread.join()
+        duration = round(time.time() - check_time, 2)
+        print(duration)
+
+    def thread_method(self, i) -> None:
+        self.sync_event.wait()
+        response = self.request("motion.set_state", {"id": 22+i, "state_id": 76})
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(f"motion/{22+i}", {"state_id": 76})

--- a/tests/system/action/motion/test_set_state.py
+++ b/tests/system/action/motion/test_set_state.py
@@ -177,7 +177,7 @@ class MotionSetStateActionTest(BaseActionTestCase):
         self.assert_status_code(response, 200)
 
     def test_set_state_parallel(self) -> None:
-        count:int = 5
+        count: int = 5
         self.sync_event = threading.Event()
         self.sync_event.clear()
 
@@ -198,7 +198,7 @@ class MotionSetStateActionTest(BaseActionTestCase):
                 "motion_state/77": {
                     "meeting_id": 222,
                     "name": "test1",
-                    "motion_ids": [22+i for i in range(count)],
+                    "motion_ids": [22 + i for i in range(count)],
                     "first_state_of_workflow_id": 76,
                     "next_state_ids": [],
                     "previous_state_ids": [76],
@@ -208,15 +208,16 @@ class MotionSetStateActionTest(BaseActionTestCase):
                         "meeting_id": 222,
                         "title": "test1",
                         "state_id": 77,
-                        "number_value": 23+i,
-                    } for i in range(count)
+                        "number_value": 23 + i,
+                    }
+                    for i in range(count)
                 },
             }
         )
 
-        threads= []
+        threads = []
         for i in range(count):
-            thread = threading.Thread(target=self.thread_method, kwargs={"i":i})
+            thread = threading.Thread(target=self.thread_method, kwargs={"i": i})
             thread.start()
             threads.append(thread)
 
@@ -229,6 +230,6 @@ class MotionSetStateActionTest(BaseActionTestCase):
 
     def thread_method(self, i) -> None:
         self.sync_event.wait()
-        response = self.request("motion.set_state", {"id": 22+i, "state_id": 76})
+        response = self.request("motion.set_state", {"id": 22 + i, "state_id": 76})
         self.assert_status_code(response, 200)
         self.assert_model_exists(f"motion/{22+i}", {"state_id": 76})

--- a/tests/system/action/test_action_command_format.py
+++ b/tests/system/action/test_action_command_format.py
@@ -55,8 +55,6 @@ class GeneralActionCommandFormat(BaseActionTestCase):
                 "group/meeting_id",
                 "group/weight",
                 "meeting/1/group_ids",
-                "meeting/1/is_active_in_organization_id",
-                "meeting/1/name",
             ],
         )
         self.assertEqual(write_requests[0].events[0]["type"], "create")
@@ -69,8 +67,6 @@ class GeneralActionCommandFormat(BaseActionTestCase):
             [
                 "group/meeting_id",
                 "group/weight",
-                "meeting/1/is_active_in_organization_id",
-                "meeting/1/name",
             ],
         )
 
@@ -104,8 +100,6 @@ class GeneralActionCommandFormat(BaseActionTestCase):
                 "group/meeting_id",
                 "group/weight",
                 "meeting/1/group_ids",
-                "meeting/1/is_active_in_organization_id",
-                "meeting/1/name",
             ],
         )
         self.assertEqual(write_requests[0].events[0]["type"], "create")


### PR DESCRIPTION
**Documentation from Issue1341 locked_fields**
All reading database calls made during request with fqid, origin lock_result and changed value, mapped fields and finally calling method name:

        00: motion/22, lock=True=>False, mapped:[meeting_id] from get_meeting_id
        01: meeting/222, lock=True=>False, mapped:['is_active_in_organization_id', 'name'] from check_for_archived_meeting
        02: motion/22, lock=True=>False, mapped:['state_id', 'submitter_ids'] from set_state.check permissions
        03: user/1, lock=False, ['group_$222_ids', 'organization_management_level'] => from check_permissions
        04: motion/22, lock=[state_id], mapped_fields:['lead_motion_id', 'category_id', 'number', 'number_value', 'created'] from update_instance
        05: motion_state/77, lock=True=>False, ['next_state_ids', 'previous_state_ids'] from update_instance
        06: meeting/222: lock=True=>False, ['motions_number_type', 'motions_number_min_digits'] from set_number_mixin.set_number
        07: motion_state/76, lock=True=>False, [set_number] from set_number_mixin,set_number
        08: motion_state/76, lock=True=>False, ['set_created_timestamp'] from update_instance
        09: motion_state/76, lock=True=False, [meeting_id] from assert_belongs_to_meeting
        10: motion_state/77, lock=True, [motion_ids] from relation handling
        11: motion_state/76, lock=True, [motion_ids] from relation handling

**All initially locked_fields (and position_number) with my decision whether they have to be locked or not:**
        
            'motion/22/meeting_id': 2, no
            'meeting/222/is_active_in_organization_id': 2, no
            'meeting/222/name': 2, no
            'motion/22/state_id': 2, yes
            'motion/22/submitter_ids': 2, no
            'motion_state/77/next_state_ids': 2, no
            'motion_state/77/previous_state_ids': 2, no
            'meeting/222/motions_number_min_digits': 2, no
            'meeting/222/motions_number_type': 2, no
            'motion_state/76/set_number': 2, no
            'motion_state/76/set_created_timestamp': 2, no
            'motion_state/76/meeting_id': 2, no
            'motion_state/77/motion_ids': 2, yes
            'motion_state/76/motion_ids': 2  yes
      
**Remaining locked_fields (and position_number) after changes:**

            'motion/22/state_id': 2
            'motion_state/77/motion_ids': 2
            'motion_state/76/motion_ids': 2
