### PR TITLE
fix changed_models filter creation for datastore issue 197

### DIFF
--- a/openslides_backend/services/datastore/extended_adapter.py
+++ b/openslides_backend/services/datastore/extended_adapter.py
@@ -19,7 +19,10 @@ from .handle_datastore_errors import raise_datastore_error
 from .interface import Engine, LockResult, MappedFieldsPerFqid, PartialModel
 
 MODEL_FIELD_SQL = "data->>%s"
-COMPARISON_VALUE_SQL = "%s::text"
+MODEL_FIELD_NUMERIC_SQL = r"\(data->%s\)::numeric"
+MODEL_FIELD_NUMERIC_REPLACE = "(data->%s)::numeric"
+COMPARISON_VALUE_TEXT_SQL = "%s::text"
+COMPARISON_VALUE_SQL = "%s"
 
 
 class ExtendedDatastoreAdapter(CacheDatastoreAdapter):
@@ -343,7 +346,7 @@ class ExtendedDatastoreAdapter(CacheDatastoreAdapter):
         # transform query into valid python code
         filter_code = sql_query.lower().replace("null", "None").replace(" = ", " == ")
         # regex for all FilterOperators which were translated by the SqlQueryHelper
-        regex = rf"(?:{MODEL_FIELD_SQL}|lower\({MODEL_FIELD_SQL}\)) (<|<=|>=|>|==|!=|is|is not) ({COMPARISON_VALUE_SQL}|lower\({COMPARISON_VALUE_SQL}\)|None)"
+        regex = rf"(?:{MODEL_FIELD_SQL}|lower\({MODEL_FIELD_SQL}\)|{MODEL_FIELD_NUMERIC_SQL}|lower\({MODEL_FIELD_NUMERIC_SQL}\)) (<|<=|>=|>|==|!=|is|is not) ({COMPARISON_VALUE_SQL}|lower\({COMPARISON_VALUE_SQL}\)|{COMPARISON_VALUE_TEXT_SQL}|lower\({COMPARISON_VALUE_TEXT_SQL}\)|None)"
         matches = re.findall(regex, filter_code)
         # this will hold all items from arguments, but correctly formatted for python and enhanced with validity checks
         formatted_args = []
@@ -363,16 +366,12 @@ class ExtendedDatastoreAdapter(CacheDatastoreAdapter):
                 formatted_args.append(f'model.get("{arguments[i]}")')
             i += 1
             # if comparison happens with a value, append it as well
-            if (
-                match[1] == COMPARISON_VALUE_SQL
-                or match[1] == f"lower({COMPARISON_VALUE_SQL})"
-            ):
+            if match[1] in (COMPARISON_VALUE_SQL, f"lower({COMPARISON_VALUE_SQL})", COMPARISON_VALUE_TEXT_SQL, f"lower({COMPARISON_VALUE_TEXT_SQL})"):
                 formatted_args.append(repr(arguments[i]))
                 i += 1
         # replace SQL placeholders and SQL specific code with the formatted python snippets
-        filter_code = filter_code.replace(MODEL_FIELD_SQL, "{}").replace(
-            COMPARISON_VALUE_SQL, "{}"
-        )
+        filter_code = filter_code.replace(MODEL_FIELD_NUMERIC_REPLACE, "{}").replace(
+            COMPARISON_VALUE_TEXT_SQL, "{}").replace(MODEL_FIELD_SQL, "{}").replace(COMPARISON_VALUE_SQL, "{}")
         filter_code = filter_code.format(*formatted_args)
 
         # needed for generated code since postgres uses it

--- a/openslides_backend/services/datastore/extended_adapter.py
+++ b/openslides_backend/services/datastore/extended_adapter.py
@@ -366,12 +366,21 @@ class ExtendedDatastoreAdapter(CacheDatastoreAdapter):
                 formatted_args.append(f'model.get("{arguments[i]}")')
             i += 1
             # if comparison happens with a value, append it as well
-            if match[1] in (COMPARISON_VALUE_SQL, f"lower({COMPARISON_VALUE_SQL})", COMPARISON_VALUE_TEXT_SQL, f"lower({COMPARISON_VALUE_TEXT_SQL})"):
+            if match[1] in (
+                COMPARISON_VALUE_SQL,
+                f"lower({COMPARISON_VALUE_SQL})",
+                COMPARISON_VALUE_TEXT_SQL,
+                f"lower({COMPARISON_VALUE_TEXT_SQL})",
+            ):
                 formatted_args.append(repr(arguments[i]))
                 i += 1
         # replace SQL placeholders and SQL specific code with the formatted python snippets
-        filter_code = filter_code.replace(MODEL_FIELD_NUMERIC_REPLACE, "{}").replace(
-            COMPARISON_VALUE_TEXT_SQL, "{}").replace(MODEL_FIELD_SQL, "{}").replace(COMPARISON_VALUE_SQL, "{}")
+        filter_code = (
+            filter_code.replace(MODEL_FIELD_NUMERIC_REPLACE, "{}")
+            .replace(COMPARISON_VALUE_TEXT_SQL, "{}")
+            .replace(MODEL_FIELD_SQL, "{}")
+            .replace(COMPARISON_VALUE_SQL, "{}")
+        )
         filter_code = filter_code.format(*formatted_args)
 
         # needed for generated code since postgres uses it


### PR DESCRIPTION
A change made in datastore with [Issue197](https://github.com/OpenSlides/openslides-datastore-service/issues/197l) create a different sql for database filter, which leads to about 30 tests-errors in generation of memory filter for changed_models. This PR fixes these 