### PR TITLE
#1363 Remove unneccessary locked_fields, some improvements

### DIFF
--- a/openslides_backend/action/actions/poll/mixins.py
+++ b/openslides_backend/action/actions/poll/mixins.py
@@ -176,7 +176,7 @@ class StopControl(CountdownControl, Action):
                 f"vote_delegated_${meeting_id}_to_id",
             ],
         )
-        gm_result = self.datastore.get_many([gmr])
+        gm_result = self.datastore.get_many([gmr], lock_result=False)
         users = gm_result.get("user", {}).values()
 
         for user in users:

--- a/openslides_backend/action/actions/poll/stop.py
+++ b/openslides_backend/action/actions/poll/stop.py
@@ -68,27 +68,27 @@ class PollStopAction(StopControl, UpdateAction, PollPermissionMixin):
         """
         locked fields zu Beginn:
         'poll/1/state', 'poll/1/content_object_id', 'poll/1/voted_ids',
-        'poll/1/entitled_group_ids', 'poll/1/global_option_id', 
-        'poll/1/pollmethod', 'poll/1/meeting_id', 
-        'meeting/1/is_active_in_organization_id', 
-        'meeting/1/vote_ids', 'meeting/1/users_enable_vote_weight', 
-        'meeting/1/name', 'meeting/1/poll_couple_countdown', 
-        'meeting/1/poll_countdown_id', 
-        'group/3/user_ids', 
-        'option/1/meeting_id', 'option/1/vote_ids', 
+        'poll/1/entitled_group_ids', 'poll/1/global_option_id',
+        'poll/1/pollmethod', 'poll/1/meeting_id',
+        'meeting/1/is_active_in_organization_id',
+        'meeting/1/vote_ids', 'meeting/1/users_enable_vote_weight',
+        'meeting/1/name', 'meeting/1/poll_couple_countdown',
+        'meeting/1/poll_countdown_id',
+        'group/3/user_ids',
+        'option/1/meeting_id', 'option/1/vote_ids',
         'user/2/vote_delegated_$_to_id', 'user/2/is_present_in_meeting_ids',
         'user/2/vote_$_ids', 'user/2/vote_delegated_$1_to_id',
         'user/2/vote_delegated_vote_$1_ids',
-        'user/2/vote_delegated_vote_$_ids', 
-        'user/2/group_$1_ids', 
-        'user/2/organization_management_level', 
-        'user/2/group_$_ids', 
-        'user/2/vote_$1_ids', 
-        'user/2/poll_voted_$1_ids', 
-        'user/2/poll_voted_$_ids', 
-        'user/3/vote_delegated_$_to_id', 'user/3/is_present_in_meeting_ids', 'user/3/vote_$_ids', 'user/3/vote_delegated_$1_to_id', 'user/3/vote_delegated_vote_$1_ids', 'user/3/vote_delegated_vote_$_ids', 'user/3/group_$1_ids', 'user/3/organization_management_level', 'user/3/group_$_ids', 'user/3/vote_$1_ids', 'user/3/poll_voted_$1_ids', 'user/3/poll_voted_$_ids', 
+        'user/2/vote_delegated_vote_$_ids',
+        'user/2/group_$1_ids',
+        'user/2/organization_management_level',
+        'user/2/group_$_ids',
+        'user/2/vote_$1_ids',
+        'user/2/poll_voted_$1_ids',
+        'user/2/poll_voted_$_ids',
+        'user/3/vote_delegated_$_to_id', 'user/3/is_present_in_meeting_ids', 'user/3/vote_$_ids', 'user/3/vote_delegated_$1_to_id', 'user/3/vote_delegated_vote_$1_ids', 'user/3/vote_delegated_vote_$_ids', 'user/3/group_$1_ids', 'user/3/organization_management_level', 'user/3/group_$_ids', 'user/3/vote_$1_ids', 'user/3/poll_voted_$1_ids', 'user/3/poll_voted_$_ids',
         'user/4/vote_delegated_$_to_id', 'user/4/is_present_in_meeting_ids', 'user/4/vote_$_ids', 'user/4/vote_delegated_$1_to_id', 'user/4/vote_delegated_vote_$1_ids', 'user/4/vote_delegated_vote_$_ids', 'user/4/group_$1_ids', 'user/4/organization_management_level', 'user/4/group_$_ids', 'user/4/vote_$1_ids', 'user/4/poll_voted_$1_ids', 'user/4/poll_voted_$_ids'
-        
+
         get:
         'user/1', ['group_$1_ids', 'organization_management_level'])", 1, 28))
 
@@ -98,7 +98,7 @@ class PollStopAction(StopControl, UpdateAction, PollPermissionMixin):
         1:{'collection': 'group', 'ids': [3], 'mapped_fields': ['user_ids', 'meta_position']}
         2:{'collection': 'option', 'ids': [1], 'mapped_fields': ['meeting_id', 'vote_ids', 'meta_position']}
 
-        3:{'collection': 'user', 'ids': [2], 'mapped_fields': 
+        3:{'collection': 'user', 'ids': [2], 'mapped_fields':
             ['vote_delegated_$_to_id', 'is_present_in_meeting_ids',
              'vote_$_ids', 'vote_delegated_$1_to_id',
              'meta_position', 'vote_delegated_vote_$1_ids',
@@ -108,6 +108,7 @@ class PollStopAction(StopControl, UpdateAction, PollPermissionMixin):
         3:{'collection': 'user', 'ids': [3], 'mapped_fields': ['vote_delegated_$_to_id', 'is_present_in_meeting_ids', 'vote_$_ids', 'vote_delegated_$1_to_id', 'meta_position', 'vote_delegated_vote_$1_ids', 'vote_delegated_vote_$_ids', 'group_$1_ids', 'organization_management_level', ...]}
         3:{'collection': 'user', 'ids': [4], 'mapped_fields': ['vote_delegated_$_to_id', 'is_present_in_meeting_ids', 'vote_$_ids', 'vote_delegated_$1_to_id', 'meta_position', 'vote_delegated_vote_$1_ids', 'vote_delegated_vote_$_ids', 'group_$1_ids', 'organization_management_level', ...]}
         """
+
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
         poll = self.datastore.get(
             fqid_from_collection_and_id(self.model.collection, instance["id"]),

--- a/openslides_backend/action/actions/poll/stop.py
+++ b/openslides_backend/action/actions/poll/stop.py
@@ -46,8 +46,6 @@ class PollStopAction(StopControl, UpdateAction, PollPermissionMixin):
                 "meeting",
                 meeting_ids,
                 [
-                    "is_active_in_organization_id",
-                    "name",
                     "poll_couple_countdown",
                     "poll_countdown_id",
                     "users_enable_vote_weight",
@@ -67,7 +65,49 @@ class PollStopAction(StopControl, UpdateAction, PollPermissionMixin):
             ),
         ]
         self.datastore.get_many(requests, use_changed_models=False)
+        """
+        locked fields zu Beginn:
+        'poll/1/state', 'poll/1/content_object_id', 'poll/1/voted_ids',
+        'poll/1/entitled_group_ids', 'poll/1/global_option_id', 
+        'poll/1/pollmethod', 'poll/1/meeting_id', 
+        'meeting/1/is_active_in_organization_id', 
+        'meeting/1/vote_ids', 'meeting/1/users_enable_vote_weight', 
+        'meeting/1/name', 'meeting/1/poll_couple_countdown', 
+        'meeting/1/poll_countdown_id', 
+        'group/3/user_ids', 
+        'option/1/meeting_id', 'option/1/vote_ids', 
+        'user/2/vote_delegated_$_to_id', 'user/2/is_present_in_meeting_ids',
+        'user/2/vote_$_ids', 'user/2/vote_delegated_$1_to_id',
+        'user/2/vote_delegated_vote_$1_ids',
+        'user/2/vote_delegated_vote_$_ids', 
+        'user/2/group_$1_ids', 
+        'user/2/organization_management_level', 
+        'user/2/group_$_ids', 
+        'user/2/vote_$1_ids', 
+        'user/2/poll_voted_$1_ids', 
+        'user/2/poll_voted_$_ids', 
+        'user/3/vote_delegated_$_to_id', 'user/3/is_present_in_meeting_ids', 'user/3/vote_$_ids', 'user/3/vote_delegated_$1_to_id', 'user/3/vote_delegated_vote_$1_ids', 'user/3/vote_delegated_vote_$_ids', 'user/3/group_$1_ids', 'user/3/organization_management_level', 'user/3/group_$_ids', 'user/3/vote_$1_ids', 'user/3/poll_voted_$1_ids', 'user/3/poll_voted_$_ids', 
+        'user/4/vote_delegated_$_to_id', 'user/4/is_present_in_meeting_ids', 'user/4/vote_$_ids', 'user/4/vote_delegated_$1_to_id', 'user/4/vote_delegated_vote_$1_ids', 'user/4/vote_delegated_vote_$_ids', 'user/4/group_$1_ids', 'user/4/organization_management_level', 'user/4/group_$_ids', 'user/4/vote_$1_ids', 'user/4/poll_voted_$1_ids', 'user/4/poll_voted_$_ids'
+        
+        get:
+        'user/1', ['group_$1_ids', 'organization_management_level'])", 1, 28))
 
+        get_many:
+        0:{'collection': 'poll', 'ids': [1], 'mapped_fields': ['state', 'content_object_id', 'voted_ids', 'meta_position', 'entitled_group_ids', 'global_option_id', 'pollmethod', 'meeting_id']}
+        1:{'collection': 'meeting', 'ids': [1], 'mapped_fields': ['is_active_in_organization_id', 'meta_position', 'vote_ids', 'users_enable_vote_weight', 'name', 'poll_couple_countdown', 'poll_countdown_id']}
+        1:{'collection': 'group', 'ids': [3], 'mapped_fields': ['user_ids', 'meta_position']}
+        2:{'collection': 'option', 'ids': [1], 'mapped_fields': ['meeting_id', 'vote_ids', 'meta_position']}
+
+        3:{'collection': 'user', 'ids': [2], 'mapped_fields': 
+            ['vote_delegated_$_to_id', 'is_present_in_meeting_ids',
+             'vote_$_ids', 'vote_delegated_$1_to_id',
+             'meta_position', 'vote_delegated_vote_$1_ids',
+             'vote_delegated_vote_$_ids', 'group_$1_ids',
+             'organization_management_level', group_$_ids,
+             vote_$1_ids, poll_voted_$1_ids, poll_voted_$_ids]}
+        3:{'collection': 'user', 'ids': [3], 'mapped_fields': ['vote_delegated_$_to_id', 'is_present_in_meeting_ids', 'vote_$_ids', 'vote_delegated_$1_to_id', 'meta_position', 'vote_delegated_vote_$1_ids', 'vote_delegated_vote_$_ids', 'group_$1_ids', 'organization_management_level', ...]}
+        3:{'collection': 'user', 'ids': [4], 'mapped_fields': ['vote_delegated_$_to_id', 'is_present_in_meeting_ids', 'vote_$_ids', 'vote_delegated_$1_to_id', 'meta_position', 'vote_delegated_vote_$1_ids', 'vote_delegated_vote_$_ids', 'group_$1_ids', 'organization_management_level', ...]}
+        """
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
         poll = self.datastore.get(
             fqid_from_collection_and_id(self.model.collection, instance["id"]),

--- a/openslides_backend/action/actions/poll/stop.py
+++ b/openslides_backend/action/actions/poll/stop.py
@@ -65,49 +65,6 @@ class PollStopAction(StopControl, UpdateAction, PollPermissionMixin):
             ),
         ]
         self.datastore.get_many(requests, use_changed_models=False)
-        """
-        locked fields zu Beginn:
-        'poll/1/state', 'poll/1/content_object_id', 'poll/1/voted_ids',
-        'poll/1/entitled_group_ids', 'poll/1/global_option_id',
-        'poll/1/pollmethod', 'poll/1/meeting_id',
-        'meeting/1/is_active_in_organization_id',
-        'meeting/1/vote_ids', 'meeting/1/users_enable_vote_weight',
-        'meeting/1/name', 'meeting/1/poll_couple_countdown',
-        'meeting/1/poll_countdown_id',
-        'group/3/user_ids',
-        'option/1/meeting_id', 'option/1/vote_ids',
-        'user/2/vote_delegated_$_to_id', 'user/2/is_present_in_meeting_ids',
-        'user/2/vote_$_ids', 'user/2/vote_delegated_$1_to_id',
-        'user/2/vote_delegated_vote_$1_ids',
-        'user/2/vote_delegated_vote_$_ids',
-        'user/2/group_$1_ids',
-        'user/2/organization_management_level',
-        'user/2/group_$_ids',
-        'user/2/vote_$1_ids',
-        'user/2/poll_voted_$1_ids',
-        'user/2/poll_voted_$_ids',
-        'user/3/vote_delegated_$_to_id', 'user/3/is_present_in_meeting_ids', 'user/3/vote_$_ids', 'user/3/vote_delegated_$1_to_id', 'user/3/vote_delegated_vote_$1_ids', 'user/3/vote_delegated_vote_$_ids', 'user/3/group_$1_ids', 'user/3/organization_management_level', 'user/3/group_$_ids', 'user/3/vote_$1_ids', 'user/3/poll_voted_$1_ids', 'user/3/poll_voted_$_ids',
-        'user/4/vote_delegated_$_to_id', 'user/4/is_present_in_meeting_ids', 'user/4/vote_$_ids', 'user/4/vote_delegated_$1_to_id', 'user/4/vote_delegated_vote_$1_ids', 'user/4/vote_delegated_vote_$_ids', 'user/4/group_$1_ids', 'user/4/organization_management_level', 'user/4/group_$_ids', 'user/4/vote_$1_ids', 'user/4/poll_voted_$1_ids', 'user/4/poll_voted_$_ids'
-
-        get:
-        'user/1', ['group_$1_ids', 'organization_management_level'])", 1, 28))
-
-        get_many:
-        0:{'collection': 'poll', 'ids': [1], 'mapped_fields': ['state', 'content_object_id', 'voted_ids', 'meta_position', 'entitled_group_ids', 'global_option_id', 'pollmethod', 'meeting_id']}
-        1:{'collection': 'meeting', 'ids': [1], 'mapped_fields': ['is_active_in_organization_id', 'meta_position', 'vote_ids', 'users_enable_vote_weight', 'name', 'poll_couple_countdown', 'poll_countdown_id']}
-        1:{'collection': 'group', 'ids': [3], 'mapped_fields': ['user_ids', 'meta_position']}
-        2:{'collection': 'option', 'ids': [1], 'mapped_fields': ['meeting_id', 'vote_ids', 'meta_position']}
-
-        3:{'collection': 'user', 'ids': [2], 'mapped_fields':
-            ['vote_delegated_$_to_id', 'is_present_in_meeting_ids',
-             'vote_$_ids', 'vote_delegated_$1_to_id',
-             'meta_position', 'vote_delegated_vote_$1_ids',
-             'vote_delegated_vote_$_ids', 'group_$1_ids',
-             'organization_management_level', group_$_ids,
-             vote_$1_ids, poll_voted_$1_ids, poll_voted_$_ids]}
-        3:{'collection': 'user', 'ids': [3], 'mapped_fields': ['vote_delegated_$_to_id', 'is_present_in_meeting_ids', 'vote_$_ids', 'vote_delegated_$1_to_id', 'meta_position', 'vote_delegated_vote_$1_ids', 'vote_delegated_vote_$_ids', 'group_$1_ids', 'organization_management_level', ...]}
-        3:{'collection': 'user', 'ids': [4], 'mapped_fields': ['vote_delegated_$_to_id', 'is_present_in_meeting_ids', 'vote_$_ids', 'vote_delegated_$1_to_id', 'meta_position', 'vote_delegated_vote_$1_ids', 'vote_delegated_vote_$_ids', 'group_$1_ids', 'organization_management_level', ...]}
-        """
 
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
         poll = self.datastore.get(

--- a/openslides_backend/action/actions/vote/create.py
+++ b/openslides_backend/action/actions/vote/create.py
@@ -41,24 +41,20 @@ class VoteCreate(CreateActionWithInferredMeeting):
             use_changed_models=False,
         )
         fields = [
-            "is_present_in_meeting_ids",
-            "organization_management_level",
-            "group_$_ids",
             "vote_$_ids",
             "poll_voted_$_ids",
-            "vote_delegated_$_to_id",
             "vote_delegated_vote_$_ids",
         ]
+        fields_set = set()
         for option in result["option"].values():
-            fields.extend(
+            fields_set.update(
                 (
-                    f"group_${option['meeting_id']}_ids",
                     f"vote_${option['meeting_id']}_ids",
                     f"poll_voted_${option['meeting_id']}_ids",
-                    f"vote_delegated_${option['meeting_id']}_to_id",
                     f"vote_delegated_vote_${option['meeting_id']}_ids",
                 )
             )
+        fields.extend(fields_set)
         self.datastore.get_many(
             [
                 GetManyRequest(

--- a/openslides_backend/action/actions/vote/create.py
+++ b/openslides_backend/action/actions/vote/create.py
@@ -1,3 +1,5 @@
+from typing import Set
+
 from openslides_backend.action.util.typing import ActionData
 from openslides_backend.services.datastore.commands import GetManyRequest
 
@@ -45,7 +47,7 @@ class VoteCreate(CreateActionWithInferredMeeting):
             "poll_voted_$_ids",
             "vote_delegated_vote_$_ids",
         ]
-        fields_set = set()
+        fields_set: Set[str] = set()
         for option in result["option"].values():
             fields_set.update(
                 (

--- a/openslides_backend/services/datastore/extended_adapter.py
+++ b/openslides_backend/services/datastore/extended_adapter.py
@@ -128,6 +128,8 @@ class ExtendedDatastoreAdapter(CacheDatastoreAdapter):
             if self.is_new(fqid):
                 # if the model is new, we know it does not exist in the datastore and can directly throw
                 # an exception or return an empty result
+                if not raise_exception:
+                    return {}
                 raise_datastore_error(
                     {"error": {"fqid": fqid}}, logger=self.logger, env=self.env
                 )

--- a/tests/system/action/poll/poll_test_mixin.py
+++ b/tests/system/action/poll/poll_test_mixin.py
@@ -15,7 +15,7 @@ class PollTestMixin(BaseActionTestCase):
             {
                 "poll/1": {
                     "type": Poll.TYPE_NAMED,
-                    "pollmethod": "YN",
+                    "pollmethod": "YNA",
                     "state": Poll.STATE_STARTED,
                     "option_ids": [1],
                     "meeting_id": 1,

--- a/tests/system/action/poll/test_stop.py
+++ b/tests/system/action/poll/test_stop.py
@@ -202,12 +202,12 @@ class PollStopActionTest(PollTestMixin):
         self.assert_status_code(response, 200)
         poll = self.get_model("poll/1")
         assert poll["voted_ids"] == user_ids
-        # always 5 calls, independent of user count
-        assert counter.calls == 5
+        # always 8 plus len(user_ids) calls, dependent of user count
+        assert counter.calls == 8 + len(user_ids)
 
     @performance
     def test_stop_performance(self) -> None:
-        user_ids = self.prepare_users_and_poll(100)
+        user_ids = self.prepare_users_and_poll(3)
 
         with Profiler("test_stop_performance.prof"):
             response = self.request("poll.stop", {"id": 1})


### PR DESCRIPTION
Reduces the amount of locked_field, but increases the amount of database calls, because calls without locked_results are not cached. In this case, for each voting user we need 1 database call extra. 
Opened #1366 for this