### PR TITLE
pin version of protobuf

### DIFF
--- a/requirements/partial/requirements_production.txt
+++ b/requirements/partial/requirements_production.txt
@@ -14,3 +14,4 @@ opentelemetry-api
 opentelemetry-sdk
 opentelemetry-instrumentation-requests
 opentelemetry-instrumentation-flask
+protobuf==3.20.1


### PR DESCRIPTION
since a new release of the protobuf package this leads to a traceback during intializing,
even if OTEL is not enabled.
see https://github.com/protocolbuffers/protobuf/issues/10051