### PR TITLE
Fix deletion of motion in projector history

### DIFF
--- a/openslides_backend/action/actions/projection/delete.py
+++ b/openslides_backend/action/actions/projection/delete.py
@@ -22,12 +22,18 @@ class ProjectionDelete(DeleteAction):
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
         projection = self.datastore.get(
             fqid_from_collection_and_id(self.model.collection, instance["id"]),
-            ["current_projector_id", "preview_projector_id", "meeting_id"],
+            [
+                "current_projector_id",
+                "preview_projector_id",
+                "content_object_id",
+                "meeting_id",
+            ],
         )
         if not (
             projection.get("current_projector_id")
             or projection.get("preview_projector_id")
-            or self.is_meeting_deleted(projection.get("meeting_id", 0))
+            or self.is_meeting_deleted(projection["meeting_id"])
+            or self.is_deleted(projection["content_object_id"])
         ):
             raise ActionException(
                 f"Projection {instance['id']} must have a current_projector_id or a preview_projector_id."

--- a/tests/system/action/projection/test_delete.py
+++ b/tests/system/action/projection/test_delete.py
@@ -35,6 +35,17 @@ class ProjectionDelete(BaseActionTestCase):
         self.assert_model_deleted("projection/13")
 
     def test_delete_history_not_allowed(self) -> None:
+        self.set_models(
+            {
+                "projection/14": {
+                    "content_object_id": "motion/42",
+                },
+                "motion/42": {
+                    "meeting_id": 1,
+                    "projection_ids": [14],
+                },
+            }
+        )
         response = self.request("projection.delete", {"id": 14})
         self.assert_status_code(response, 400)
         assert (

--- a/tests/system/action/projection/test_delete.py
+++ b/tests/system/action/projection/test_delete.py
@@ -43,6 +43,21 @@ class ProjectionDelete(BaseActionTestCase):
         )
         self.assert_model_exists("projection/14")
 
+    def test_delete_motion_in_history(self) -> None:
+        self.set_models(
+            {
+                "projection/14": {
+                    "content_object_id": "motion/42",
+                },
+                "motion/42": {
+                    "meeting_id": 1,
+                    "projection_ids": [14],
+                },
+            }
+        )
+        response = self.request("motion.delete", {"id": 42})
+        self.assert_status_code(response, 200)
+
     def test_delete_no_permissions(self) -> None:
         self.base_permission_test({}, "projection.delete", {"id": 12})
 


### PR DESCRIPTION
If a motion was projected and then moved in to the projection history, it could no longer be deleted because of the projection blocking it.