### PR TITLE
use local datastore for writer including debug

### DIFF
--- a/dev/Dockerfile.dev
+++ b/dev/Dockerfile.dev
@@ -22,8 +22,6 @@ COPY setup.cfg .
 COPY dev/entrypoint.sh ./
 
 RUN chmod 777 -R .
-RUN chmod 777 /root
-RUN chmod 777 -R /usr/local/lib/
 
 EXPOSE 9002
 EXPOSE 9003

--- a/dev/dc.local-ds.yml
+++ b/dev/dc.local-ds.yml
@@ -10,3 +10,25 @@ services:
         environment:
             - PYTHONPATH=/app:/datastore-service
             - MYPYPATH=/app:/datastore-service
+    writer:
+        build:
+            context: ../../openslides-datastore-service/
+            dockerfile: Dockerfile.dev
+            args:
+                MODULE: "writer"
+                PORT: "9011"
+        image: openslides-datastore-writer-dev
+        ports:
+            - "9011:9011"
+            - "5679:5678"
+        environment:
+            - OPENSLIDES_DEVELOPMENT=1
+            - DATASTORE_ENABLE_DEV_ENVIRONMENT=1
+            - DATASTORE_DATABASE_NAME=openslides
+            - DATASTORE_DATABASE_USER=openslides
+            - DATASTORE_DATABASE_HOST=postgresql
+            - MESSAGE_BUS_HOST=redis
+        env_file: ../../docker/services.env
+        volumes:
+            - ../../openslides-datastore-service/datastore:/app/datastore
+            - ../../openslides-datastore-service/cli:/app/cli


### PR DESCRIPTION
Also removes some really time-consuming right settings to 777, that nobody seems to need.

Debugging needs also [PR](https://github.com/OpenSlides/openslides-datastore-service/pull/202) from datastore with modified entry.