### PR TITLE
Validate all write request fields

### DIFF
--- a/openslides_backend/action/action_handler.py
+++ b/openslides_backend/action/action_handler.py
@@ -232,9 +232,7 @@ class ActionHandler(BaseHandler):
                         action_data, self.user_id, internal=self.internal
                     )
             if write_request:
-                action.validate_required_fields_and_check_for_extra_fields(
-                    write_request
-                )
+                action.validate_write_request(write_request)
 
                 # add locked_fields to request
                 write_request.locked_fields = self.datastore.locked_fields

--- a/openslides_backend/action/actions/meeting/import_.py
+++ b/openslides_backend/action/actions/meeting/import_.py
@@ -491,7 +491,8 @@ class MeetingImport(SingularActionMixin, LimitOfUserMixin, UsernameMixin):
                 "Imported meeting has no AdminGroup to assign to request user"
             )
         if group.get("user_ids"):
-            group["user_ids"].insert(0, self.user_id)
+            if self.user_id not in group["user_ids"]:
+                group["user_ids"].insert(0, self.user_id)
         else:
             group["user_ids"] = [self.user_id]
         self.new_group_for_request_user = admin_group_id

--- a/tests/system/action/projector/test_update.py
+++ b/tests/system/action/projector/test_update.py
@@ -167,10 +167,6 @@ class ProjectorUpdate(BaseActionTestCase):
         )
 
     def test_update_change_used_as_default__in_meeting_id(self) -> None:
-        """
-        To really change the value, it must be first set to None and in next
-        action/request can be set to a new value
-        """
         self.set_models(
             {
                 "meeting/222": {
@@ -189,26 +185,6 @@ class ProjectorUpdate(BaseActionTestCase):
                 "projector/2": {"name": "Projector2", "meeting_id": 222},
             }
         )
-        response = self.request(
-            "projector.update",
-            {
-                "id": 1,
-                "used_as_default_$_in_meeting_id": {"topics": None},
-            },
-        )
-        self.assert_status_code(response, 200)
-        self.assert_model_exists(
-            "projector/1",
-            {
-                "used_as_default_$_in_meeting_id": [],
-                "used_as_default_$topics_in_meeting_id": None,
-            },
-        )
-        self.assert_model_exists(
-            "meeting/222",
-            {"default_projector_$_id": [], "default_projector_$topics_id": None},
-        )
-
         response = self.request(
             "projector.update",
             {


### PR DESCRIPTION
closes #1365

I wanted to compare the speed of the tests before and after, but funnily enough, the pre-compiling of the validation schemas sped up the tests by about 16% because before, the schema had to be compiled for every written field in every test. So overall, a full win.