### PR TITLE
Change permission for forwarding meeting presenter

### DIFF
--- a/openslides_backend/presenter/get_forwarding_meetings.py
+++ b/openslides_backend/presenter/get_forwarding_meetings.py
@@ -36,7 +36,7 @@ class GetForwardingMeetings(BasePresenter):
         if not has_perm(
             self.datastore,
             self.user_id,
-            Permissions.Motion.CAN_MANAGE,
+            Permissions.Motion.CAN_FORWARD,
             self.data["meeting_id"],
         ):
             msg = "You are not allowed to perform presenter get_forwarding_meetings"


### PR DESCRIPTION
To forward a motion, `motion.can_forward` suffices. Therefore, the presenter needed to determine the receiving meetings should have the same permission.