### PR TITLE
Add checks to migration tests

### DIFF
--- a/openslides_backend/models/checker.py
+++ b/openslides_backend/models/checker.py
@@ -617,7 +617,7 @@ class Checker:
                     )
             elif self.mode == "external":
                 self.errors.append(
-                    f"{basemsg} points to {foreign_collection}/foreign_id, which is not allowed in an external import."
+                    f"{basemsg} points to {foreign_collection}/{foreign_id}, which is not allowed in an external import."
                 )
 
         elif isinstance(field_type, GenericRelationField) and model[field] is not None:

--- a/tests/system/migrations/conftest.py
+++ b/tests/system/migrations/conftest.py
@@ -23,7 +23,8 @@ from openslides_backend.models.checker import Checker
 
 
 class MigrationChecker(Checker):
-    """ Adjusted Checker for migrations which is capable of handling dummy fields & collections. """
+    """Adjusted Checker for migrations which is capable of handling dummy fields & collections."""
+
     def check_collections(self) -> None:
         pass
 

--- a/tests/system/migrations/test_0010_add_sequential_numbers.py
+++ b/tests/system/migrations/test_0010_add_sequential_numbers.py
@@ -20,16 +20,26 @@ def test_migration_all(clear_datastore, write, finalize, assert_model):
         write(
             {
                 "type": "create",
+                "fqid": "meeting/1",
+                "fields": {"id": 1, collection + "_ids": [1]},
+            },
+            {
+                "type": "create",
                 "fqid": collection + KEYSEPARATOR + "1",
                 "fields": {"id": 1, "meeting_id": 1},
-            }
+            },
         )
         write(
+            {
+                "type": "update",
+                "fqid": "meeting/1",
+                "fields": {collection + "_ids": [1, 2]},
+            },
             {
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "2",
                 "fields": {"id": 2, "meeting_id": 1},
-            }
+            },
         )
 
         finalize("0010_add_sequential_numbers")
@@ -64,30 +74,50 @@ def test_migration_motion_block_more_objects(
         write(
             {
                 "type": "create",
+                "fqid": "meeting/1",
+                "fields": {"id": 1, collection + "_ids": [1]},
+            },
+            {
+                "type": "create",
                 "fqid": collection + KEYSEPARATOR + "1",
                 "fields": {"id": 1, "meeting_id": 1},
-            }
+            },
         )
         write(
+            {
+                "type": "update",
+                "fqid": "meeting/1",
+                "fields": {collection + "_ids": [1, 2]},
+            },
             {
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "2",
                 "fields": {"id": 2, "meeting_id": 1},
-            }
+            },
         )
         write(
+            {
+                "type": "create",
+                "fqid": "meeting/2",
+                "fields": {"id": 2, collection + "_ids": [3]},
+            },
             {
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "3",
                 "fields": {"id": 3, "meeting_id": 2},
-            }
+            },
         )
         write(
+            {
+                "type": "update",
+                "fqid": "meeting/2",
+                "fields": {collection + "_ids": [3, 4]},
+            },
             {
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "4",
                 "fields": {"id": 4, "meeting_id": 2},
-            }
+            },
         )
 
         finalize("0010_add_sequential_numbers")
@@ -141,32 +171,52 @@ def test_assignment_two_stages(migrate, write, finalize, assert_model):
     write({"type": "create", "fqid": "meeting/2", "fields": {"id": 2}})
     write(
         {
+            "type": "update",
+            "fqid": "meeting/1",
+            "fields": {"id": 1, "assignment_ids": [1]},
+        },
+        {
             "type": "create",
             "fqid": "assignment" + KEYSEPARATOR + "1",
             "fields": {"id": 1, "meeting_id": 1},
-        }
+        },
     )
     write(
+        {
+            "type": "update",
+            "fqid": "meeting/1",
+            "fields": {"assignment_ids": [1, 2]},
+        },
         {
             "type": "create",
             "fqid": "assignment" + KEYSEPARATOR + "2",
             "fields": {"id": 2, "meeting_id": 1},
-        }
+        },
     )
     migrate("0010_add_sequential_numbers")
     write(
         {
+            "type": "update",
+            "fqid": "meeting/1",
+            "fields": {"assignment_ids": [1, 2, 3]},
+        },
+        {
             "type": "create",
             "fqid": "assignment" + KEYSEPARATOR + "3",
             "fields": {"id": 3, "meeting_id": 1},
-        }
+        },
     )
     write(
+        {
+            "type": "update",
+            "fqid": "meeting/1",
+            "fields": {"assignment_ids": [1, 2, 3, 4]},
+        },
         {
             "type": "create",
             "fqid": "assignment" + KEYSEPARATOR + "4",
             "fields": {"id": 4, "meeting_id": 1},
-        }
+        },
     )
 
     finalize("0010_add_sequential_numbers")
@@ -218,6 +268,16 @@ def test_assignment_only_2_position(migrate, write, finalize, assert_model):
     write(
         {
             "type": "create",
+            "fqid": "meeting/1",
+            "fields": {"id": 1, "assignment_ids": [1]},
+        },
+        {
+            "type": "create",
+            "fqid": "meeting/2",
+            "fields": {"id": 2, "assignment_ids": [2, 3]},
+        },
+        {
+            "type": "create",
             "fqid": "assignment" + KEYSEPARATOR + "1",
             "fields": {"id": 1, "meeting_id": 1},
         },
@@ -233,6 +293,11 @@ def test_assignment_only_2_position(migrate, write, finalize, assert_model):
         },
     )
     write(
+        {
+            "type": "update",
+            "fqid": "meeting/1",
+            "fields": {"assignment_ids": [1, 4, 5]},
+        },
         {
             "type": "create",
             "fqid": "assignment" + KEYSEPARATOR + "4",

--- a/tests/system/migrations/test_0011_rename_used_as_list_of_speaker_countdown_meeting_id.py
+++ b/tests/system/migrations/test_0011_rename_used_as_list_of_speaker_countdown_meeting_id.py
@@ -1,11 +1,15 @@
 def test_migration(write, finalize, assert_model):
-    write({"type": "create", "fqid": "meeting/1", "fields": {"id": 1}})
     write(
+        {
+            "type": "create",
+            "fqid": "meeting/1",
+            "fields": {"id": 1, "list_of_speakers_countdown_id": 1},
+        },
         {
             "type": "create",
             "fqid": "projector_countdown/1",
             "fields": {"id": 1, "used_as_list_of_speaker_countdown_meeting_id": 1},
-        }
+        },
     )
 
     finalize("0011_rename_used_as_list_of_speaker_countdown_meeting_id")
@@ -16,7 +20,7 @@ def test_migration(write, finalize, assert_model):
             "id": 1,
             "used_as_list_of_speakers_countdown_meeting_id": 1,
             "meta_deleted": False,
-            "meta_position": 2,
+            "meta_position": 1,
         },
         position=2,
     )

--- a/tests/system/migrations/test_0012_committee_user_relation.py
+++ b/tests/system/migrations/test_0012_committee_user_relation.py
@@ -30,7 +30,12 @@ def test_user_group_create_delete_restore_update_one_position(
             "type": "create",
             "fqid": "user/1000",
             "fields": {"group_$10_ids": [100], "group_$_ids": ["10"]},
-        }
+        },
+        {
+            "type": "update",
+            "fqid": "group/100",
+            "fields": {"user_ids": [1000]},
+        },
     )
     write({"type": "delete", "fqid": "user/1000"})
     write({"type": "restore", "fqid": "user/1000"})
@@ -43,7 +48,17 @@ def test_user_group_create_delete_restore_update_one_position(
                 "group_$20_ids": [200],
                 "group_$_ids": ["20"],
             },
-        }
+        },
+        {
+            "type": "update",
+            "fqid": "group/100",
+            "fields": {"user_ids": []},
+        },
+        {
+            "type": "update",
+            "fqid": "group/200",
+            "fields": {"user_ids": [1000]},
+        },
     )
 
     finalize("0012_committee_user_relation")
@@ -324,7 +339,7 @@ def test_user_committee_management_level_create_delete_restore_update_one_positi
     )
 
 
-def test_user_mixed_cml_and_group(read_model, write, finalize, assert_model):
+def test_user_mixed_cml_and_group(write, finalize, assert_model):
     write(
         {
             "type": "create",
@@ -375,6 +390,20 @@ def test_user_mixed_cml_and_group(read_model, write, finalize, assert_model):
                 "committee_$2_management_level": "can_manage",
             },
         },
+        {
+            "type": "update",
+            "fqid": "group/100",
+            "fields": {
+                "user_ids": [1000, 1001],
+            },
+        },
+        {
+            "type": "update",
+            "fqid": "group/200",
+            "fields": {
+                "user_ids": [1000],
+            },
+        },
     )
 
     # user/1000 remove group 100
@@ -386,6 +415,13 @@ def test_user_mixed_cml_and_group(read_model, write, finalize, assert_model):
             "fields": {
                 "group_$10_ids": None,
                 "group_$_ids": ["20"],
+            },
+        },
+        {
+            "type": "update",
+            "fqid": "group/100",
+            "fields": {
+                "user_ids": [1001],
             },
         },
         {
@@ -538,6 +574,11 @@ def test_user_add_remove_add(write, finalize, assert_model):
             "fqid": "user/1000",
             "fields": {"group_$10_ids": [100], "group_$_ids": ["10"]},
         },
+        {
+            "type": "update",
+            "fqid": "group/100",
+            "fields": {"user_ids": [1000]},
+        },
     )
 
     finalize("0012_committee_user_relation")
@@ -589,7 +630,11 @@ def test_user_remove_add(write, finalize, assert_model):
             "fqid": "meeting/10",
             "fields": {"committee_id": 1, "group_ids": [100]},
         },
-        {"type": "create", "fqid": "group/100", "fields": {"meeting_id": 10}},
+        {
+            "type": "create",
+            "fqid": "group/100",
+            "fields": {"meeting_id": 10, "user_ids": [1000]},
+        },
         {
             "type": "create",
             "fqid": "user/1000",
@@ -669,7 +714,11 @@ def test_user_remove_add_2_stages(migrate, write, finalize, assert_model):
             "fqid": "meeting/10",
             "fields": {"committee_id": 1, "group_ids": [100]},
         },
-        {"type": "create", "fqid": "group/100", "fields": {"meeting_id": 10}},
+        {
+            "type": "create",
+            "fqid": "group/100",
+            "fields": {"meeting_id": 10, "user_ids": [1000]},
+        },
         {
             "type": "create",
             "fqid": "user/1000",
@@ -746,7 +795,11 @@ def test_events_in_wrong_sequence(write, finalize, assert_model):
             "fqid": "user/1000",
             "fields": {"group_$10_ids": [100], "group_$_ids": ["10"]},
         },
-        {"type": "create", "fqid": "group/100", "fields": {"meeting_id": 10}},
+        {
+            "type": "create",
+            "fqid": "group/100",
+            "fields": {"meeting_id": 10, "user_ids": [1000]},
+        },
         {
             "type": "create",
             "fqid": "meeting/10",
@@ -834,7 +887,6 @@ def test_with_shortened_example_data(write, finalize, assert_model):
                 "user_ids": [1, 2, 3],
                 "default_group_id": 1,
                 "admin_group_id": 2,
-                "is_active_in_organization_id": 1,
             },
         },
         {
@@ -843,6 +895,7 @@ def test_with_shortened_example_data(write, finalize, assert_model):
             "fields": {
                 "meeting_id": 1,
                 "user_ids": [],
+                "default_group_for_meeting_id": 1,
             },
         },
         {
@@ -851,6 +904,7 @@ def test_with_shortened_example_data(write, finalize, assert_model):
             "fields": {
                 "meeting_id": 1,
                 "user_ids": [1],
+                "admin_group_for_meeting_id": 1,
             },
         },
         {

--- a/tests/system/migrations/test_0019_calc_mediafile_is_public.py
+++ b/tests/system/migrations/test_0019_calc_mediafile_is_public.py
@@ -178,6 +178,14 @@ def test_migration_varying(write, finalize, assert_model):
     write(
         {
             "type": "update",
+            "fqid": "group/1",
+            "fields": {
+                "mediafile_access_group_ids": [],
+                "mediafile_inherited_access_group_ids": [],
+            },
+        },
+        {
+            "type": "update",
             "fqid": "mediafile/11",
             "list_fields": {
                 "add": {"access_group_ids": []},

--- a/tests/system/migrations/test_0020_2nd_migration_seq_numbers.py
+++ b/tests/system/migrations/test_0020_2nd_migration_seq_numbers.py
@@ -19,8 +19,11 @@ def test_migration_all(clear_datastore, write, finalize, assert_model):
 
     for collection in COLLECTIONS:
         write(
-            {"type": "create", "fqid": "meeting/1", "fields": {"id": 1}},
-            {"type": "create", "fqid": "meeting/2", "fields": {"id": 2}},
+            {
+                "type": "create",
+                "fqid": "meeting/1",
+                "fields": {"id": 1, collection + "_ids": [1, 2]},
+            },
             {
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "1",
@@ -63,6 +66,16 @@ def test_migration_motion_block_more_objects(
 ):
     for collection in COLLECTIONS:
         write(
+            {
+                "type": "create",
+                "fqid": "meeting/1",
+                "fields": {"id": 1, collection + "_ids": [1, 2]},
+            },
+            {
+                "type": "create",
+                "fqid": "meeting/2",
+                "fields": {"id": 2, collection + "_ids": [3, 4]},
+            },
             {
                 "type": "create",
                 "fqid": collection + KEYSEPARATOR + "1",
@@ -135,6 +148,11 @@ def test_assignment_two_stages(migrate, write, finalize, assert_model):
     write(
         {
             "type": "create",
+            "fqid": "meeting/1",
+            "fields": {"id": 1, "assignment_ids": [1, 2]},
+        },
+        {
+            "type": "create",
             "fqid": "assignment" + KEYSEPARATOR + "1",
             "fields": {"id": 1, "meeting_id": 1, "sequential_number": 11},
         },
@@ -146,6 +164,11 @@ def test_assignment_two_stages(migrate, write, finalize, assert_model):
     )
     migrate("0020_2nd_migration_seq_numbers")
     write(
+        {
+            "type": "update",
+            "fqid": "meeting/1",
+            "fields": {"assignment_ids": [1, 2, 3, 4]},
+        },
         {
             "type": "create",
             "fqid": "assignment" + KEYSEPARATOR + "3",

--- a/tests/system/migrations/test_0028_rename_motion_sort_children_ids.py
+++ b/tests/system/migrations/test_0028_rename_motion_sort_children_ids.py
@@ -4,7 +4,7 @@ def test_migration(write, finalize, assert_model):
         {
             "type": "create",
             "fqid": "motion/1",
-            "fields": {"id": 1, "sort_children_ids": [1]},
+            "fields": {"id": 1, "sort_children_ids": [1], "sort_parent_id": 1},
         }
     )
 
@@ -15,6 +15,7 @@ def test_migration(write, finalize, assert_model):
         {
             "id": 1,
             "sort_child_ids": [1],
+            "sort_parent_id": 1,
             "meta_deleted": False,
             "meta_position": 2,
         },


### PR DESCRIPTION
closes #974

Use the current models definition to check the relations of all migrations. A potential problem is that the migrations were written for an older models state. This should however almost never impact the tests. The only thing being checked are the relations, with unknown collections and fields being skipped. So, the following cases can occur:
- A previous "normal" field is refunctioned to become a relation field: This will not happen, since we are very strict in naming relation fields with an `_id[s]` suffix and not doing this for normal fields.
- A previous relation field is refunctioned to no longer be a relation field: Will not happen for the same reason, but even if it would, this is no problem, because we check with the new definition where the field is no longer a relation field, so it is just ignored.
- A relation is redirected to another field/collection: This is the only case where problems might occur. If this ever happens, we can then talk about a specific solution for the individual cases, but for now I don't think the risk is very high.

This was the best solution I came up with. The most important part for me was that the error described in https://github.com/OpenSlides/openslides-backend/pull/956#pullrequestreview-776245444 would be caught by the automatic tests, which is the case.