### PR TITLE
Fix language extraction from client header

### DIFF
--- a/openslides_backend/locale/translator.py
+++ b/openslides_backend/locale/translator.py
@@ -1,8 +1,8 @@
 import gettext
-from typing import Optional
+import pathlib
+from typing import List, Optional
 
 DEFAULT_LANGUAGE = "en_US"
-PATH_TO_LOCALE = "/app/openslides_backend/locale"
 DOMAIN = "messages"
 
 
@@ -13,12 +13,24 @@ class _Translator:
     def translate(self, msg: str) -> str:
         return self.translation.gettext(msg)
 
-    def set_translation_language(self, lang: Optional[str]) -> None:
-        if lang is None:
-            self.language = DEFAULT_LANGUAGE
+    def set_translation_language(self, lang_header: Optional[str]) -> None:
+        if lang_header is None:
+            langs = [DEFAULT_LANGUAGE]
         else:
-            self.language = lang
-        self.translation = gettext.translation(DOMAIN, PATH_TO_LOCALE, [self.language])
+            langs = self.parse_language_header(lang_header)
+            if DEFAULT_LANGUAGE not in langs:
+                langs.append(DEFAULT_LANGUAGE)
+        self.translation = gettext.translation(
+            DOMAIN, pathlib.Path(__file__).parent.resolve(), langs
+        )
+
+    def parse_language_header(self, lang_header: str) -> List[str]:
+        languages = lang_header.split(",")
+        result = []
+        for language in languages:
+            parts = language.split(";")
+            result.append(parts[0].strip())
+        return result
 
 
 Translator = _Translator()

--- a/tests/system/action/user/test_forget_password.py
+++ b/tests/system/action/user/test_forget_password.py
@@ -45,6 +45,30 @@ class UserForgetPassword(BaseActionTestCase):
         assert handler.emails[0]["from"] == EmailSettings.default_from_email
         assert "Ihres Openslides-Passworts" in handler.emails[0]["data"]
 
+    def test_forget_password_send_mail_correct_translated_not_normalized(self) -> None:
+        self.set_models(
+            {ONE_ORGANIZATION_FQID: {"url": None}, "user/1": {"email": "test@ntvtn.de"}}
+        )
+        handler = AIOHandler()
+        with AiosmtpdServerManager(handler):
+            response = self.request(
+                "user.forget_password", {"email": "test@ntvtn.de"}, lang="de"
+            )
+        self.assert_status_code(response, 200)
+        assert "Ihres Openslides-Passworts" in handler.emails[0]["data"]
+
+    def test_forget_password_send_mail_unknown_language(self) -> None:
+        self.set_models(
+            {ONE_ORGANIZATION_FQID: {"url": None}, "user/1": {"email": "test@ntvtn.de"}}
+        )
+        handler = AIOHandler()
+        with AiosmtpdServerManager(handler):
+            response = self.request(
+                "user.forget_password", {"email": "test@ntvtn.de"}, lang="xy"
+            )
+        self.assert_status_code(response, 200)
+        assert "Reset your OpenSlides password" in handler.emails[0]["data"]
+
     def test_forget_password_two_users_with_email(self) -> None:
         self.set_models(
             {


### PR DESCRIPTION
The new translation feature could not handle standard language headers with multiple languages and qualities given. Without this fix, OS4 cannot work atm.