### PR TITLE
Assert that assignment poll history works

### DIFF
--- a/openslides_backend/services/datastore/adapter.py
+++ b/openslides_backend/services/datastore/adapter.py
@@ -338,7 +338,7 @@ class DatastoreAdapter(BaseDatastoreService):
         self.logger.debug(
             f"Start HISTORY_INFORMATION request to datastore with the following data: {request}"
         )
-        return self.reader.history_information(request)
+        return dict(self.reader.history_information(request))
 
     def lock_collection_fields_from_filter(
         self,

--- a/tests/system/action/base.py
+++ b/tests/system/action/base.py
@@ -364,7 +364,7 @@ class BaseActionTestCase(BaseSystemTestCase):
         """
         informations = self.datastore.history_information([fqid])[fqid]
         if information is None:
-            assert information is None
+            assert informations is None
         else:
             assert informations
             self.assertEqual(informations[-1]["information"], information)

--- a/tests/system/action/base.py
+++ b/tests/system/action/base.py
@@ -362,7 +362,7 @@ class BaseActionTestCase(BaseSystemTestCase):
         """
         Asserts that the last history information for the given model is the given information.
         """
-        informations = self.datastore.history_information([fqid])[fqid]
+        informations = self.datastore.history_information([fqid]).get(fqid)
         if information is None:
             assert informations is None
         else:

--- a/tests/system/action/motion/test_create_forwarded.py
+++ b/tests/system/action/motion/test_create_forwarded.py
@@ -364,9 +364,8 @@ class MotionCreateForwarded(BaseActionTestCase):
                 "all_derived_motion_ids": [11, 12, 13, 14],
             },
         )
-        # grandparent should not have a history entry
         self.assert_history_information("motion/11", ["Forwarding created"])
-        self.assert_history_information("motion/6", None)
+        self.assert_history_information("motion/6", ["Forwarding created"])
 
     def test_forward_with_deleted_motion_in_all_origin_ids(self) -> None:
         self.set_models(

--- a/tests/system/action/poll/test_update.py
+++ b/tests/system/action/poll/test_update.py
@@ -1,4 +1,3 @@
-import openslides_backend.action.actions  # noqa
 from openslides_backend.models.models import Poll
 from openslides_backend.permissions.permissions import Permissions
 from openslides_backend.shared.util import ONE_ORGANIZATION_FQID
@@ -83,6 +82,7 @@ class UpdatePollTestCase(BaseActionTestCase):
         assert poll.get("global_yes") is False
         assert poll.get("global_no") is True
         assert poll.get("global_abstain") is True
+        self.assert_history_information("assignment/1", ["Poll updated"])
 
     def test_not_allowed_for_analog(self) -> None:
         self.update_model("poll/1", {"type": "analog"})


### PR DESCRIPTION
There are already a few tests which test this functionality (that a history entry is created for the content object, in this case the assignment, when the poll is changed). This PR just verified that and adds another assertion.

Client side is still missing, I will create an issue for this.