### PR TITLE
Add import tests with present users

### DIFF
--- a/openslides_backend/action/actions/meeting/import_.py
+++ b/openslides_backend/action/actions/meeting/import_.py
@@ -507,7 +507,7 @@ class MeetingImport(SingularActionMixin, LimitOfUserMixin, UsernameMixin):
     def create_events(
         self, instance: Dict[str, Any], pure_create_events: bool = False
     ) -> Iterable[Event]:
-        """be carefull, this method is also used by meeting.clone action"""
+        """Be careful, this method is also used by meeting.clone!"""
         json_data = instance["meeting"]
         meeting = self.get_meeting_from_json(json_data)
         meeting_id = meeting["id"]

--- a/tests/system/action/meeting/test_import.py
+++ b/tests/system/action/meeting/test_import.py
@@ -1,6 +1,6 @@
 import base64
 import time
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Optional, cast
 
 from openslides_backend.migrations import get_backend_migration_index
 from openslides_backend.models.models import Meeting
@@ -40,7 +40,9 @@ class MeetingImport(BaseActionTestCase):
             }
         )
 
-    def create_request_data(self, datapart: Dict[str, Any] = {}) -> Dict[str, Any]:
+    def create_request_data(
+        self, datapart: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
         data: Dict[str, Any] = {
             "committee_id": 1,
             "meeting": {
@@ -326,11 +328,12 @@ class MeetingImport(BaseActionTestCase):
                 },
             },
         }
-        for collection, models in datapart.items():
-            if collection not in data["meeting"]:
-                data["meeting"][collection] = models
-            else:
-                data["meeting"][collection].update(models)
+        if datapart:
+            for collection, models in datapart.items():
+                if collection not in data["meeting"]:
+                    data["meeting"][collection] = models
+                else:
+                    data["meeting"][collection].update(models)
 
         return data
 


### PR DESCRIPTION
@rrenkert I tried to indentify/reproduce the "is_present_in_meeting_ids" error, but was not able to. I could, however, localize the error source: `meeting.import`. Since the meeting in question was imported a few days before the user merge feature was merged (in https://github.com/OpenSlides/openslides-backend/commit/ce6dfdb0eb12717b10c0a074ff10dae1a481a0b9), I can only assume that the error no longer exists. Broken instances can be fixed with a script written for that purpose.

@r-peschke These are just additional tests I created while trying to reproduce the problem, I thought it was better to keep them.