### PR TITLE
Add vote decryptpublic main key as calculated field

### DIFF
--- a/global/meta/models.yml
+++ b/global/meta/models.yml
@@ -112,6 +112,12 @@ organization:
     default: 0
     minimum: 0
 
+  vote_decrypt_public_main_key:
+    type: string
+    description: Public key from vote decrypt to validate cryptographic votes.
+    calculated: true
+    restriction_mode: A
+
   committee_ids:
     type: relation-list
     restriction_mode: B

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -3,7 +3,7 @@
 from openslides_backend.models import fields
 from openslides_backend.models.base import Model
 
-MODELS_YML_CHECKSUM = "c225b5b775784fb39a8a867de8b6f177"
+MODELS_YML_CHECKSUM = "b314ac93c0250fd96d438686dea8c0eb"
 
 
 class Organization(Model):


### PR DESCRIPTION
Add a calculated field for the vote decrypt public main key.

Since this field is calculated, it is not in the datastore and not handled by the backend. It is only needed between the vote-service, the autoupdate-service and the client.

It would be nice, if you could merge this as soon as possible, so I can implement this feature until Thursday.