### PR TITLE
Use aiosmtpd as python10 hack from r-peschke's fork

### DIFF
--- a/requirements/partial/requirements_development.txt
+++ b/requirements/partial/requirements_development.txt
@@ -11,7 +11,8 @@ autoflake==1.4
 debugpy==1.5.1
 
 # fork of aiosmtpd for python 3.10
-git+https://github.com/foutrelis/aiosmtpd.git@e3321f474c0d8f63a17186a6e727f490d943f624
+git+https://github.com/r-peschke/aiosmtpd.git@aiosmtpd-customized
+#aiosmtpd==1.4.2 for better times
 
 # typing
 types-PyYAML==6.0.5


### PR DESCRIPTION
aiosmtpd itself (https://github.com/aio-libs/aiosmtpd) is still not python 3.10 compatible. 2 pull requests, that may solve our problems, are waiting (https://github.com/aio-libs/aiosmtpd/pull/292 since10.2021 without any comment)  or rejected and closed (https://github.com/aio-libs/aiosmtpd/pull/292, our used fork, now deleted).
I forked the aiosmtpd main branch and applied most of the https://github.com/aio-libs/aiosmtpd/pull/292-PR to have a working aiosmtpd-copy.
This is no solution for the future. The smtpd-package in Python is deprecated, the recommended aiosmtpd seems to renain static at python 3.9 version.