### PR TITLE
Send a dispatch message to autoupdate on changes

### DIFF
--- a/.github/workflows/create-issue-for-file-updates.yml
+++ b/.github/workflows/create-issue-for-file-updates.yml
@@ -43,16 +43,10 @@ jobs:
         with:
           filename: .github/workflows/announce-file-changes-template.md
       
-      - name: Send dispatch if models.yml was changed
-        if: contains(steps.changed-files.outputs.modified_files, 'global/meta/models.yml')
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          event-type: models-update
-          repository: OpenSlides/openslides-autoupdate-service
-          token: ${{ secrets.AUTOUPDATE_ACCESS_TOKEN }}
-
-      - name: Send dispatch if permission.yml was changed
-        if: contains(steps.changed-files.outputs.modified_files, 'global/meta/permission.yml')
+      - name: Send dispatch if models.yml or permission.yml was changed
+        if: |
+          contains(steps.changed-files.outputs.modified_files, 'global/meta/models.yml') ||
+          contains(steps.changed-files.outputs.modified_files, 'global/meta/permission.yml')
         uses: peter-evans/repository-dispatch@v2
         with:
           event-type: models-update

--- a/.github/workflows/create-issue-for-file-updates.yml
+++ b/.github/workflows/create-issue-for-file-updates.yml
@@ -42,3 +42,19 @@ jobs:
           OS_FILE_NAME: permission.yml
         with:
           filename: .github/workflows/announce-file-changes-template.md
+      
+      - name: Send dispatch if models.yml was changed
+        if: contains(steps.changed-files.outputs.modified_files, 'global/meta/models.yml')
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          event-type: models-update
+          repository: OpenSlides/openslides-autoupdate-service
+          token: ${{ secrets.AUTOUPDATE_ACCESS_TOKEN }}
+
+      - name: Send dispatch if permission.yml was changed
+        if: contains(steps.changed-files.outputs.modified_files, 'global/meta/permission.yml')
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          event-type: models-update
+          repository: OpenSlides/openslides-autoupdate-service
+          token: ${{ secrets.AUTOUPDATE_ACCESS_TOKEN }}


### PR DESCRIPTION
With this change to the github action, the backend should send a dispatch message to the autoupdate repo and trigger the following action, that should create a PR on the autoupdate service

https://github.com/OpenSlides/openslides-autoupdate-service/blob/main/.github/workflows/update-generated-files.yml

This should work, but I am not sure, since it is not possible to test it without making noise by changing the models.yml.

I could not find any documentation, if the [if-condition](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif) supports something like a `or`. If it does, only one stop would be necessary, since both use the same event-type.

