### PR TITLE
Add search_deleted_models presenter

### DIFF
--- a/openslides_backend/presenter/__init__.py
+++ b/openslides_backend/presenter/__init__.py
@@ -10,6 +10,7 @@ from . import (  # noqa
     get_user_scope,
     get_users,
     number_of_users,
+    search_deleted_models,
     search_users_by_name_or_email,
     server_time,
 )

--- a/openslides_backend/presenter/search_deleted_models.py
+++ b/openslides_backend/presenter/search_deleted_models.py
@@ -1,0 +1,89 @@
+from typing import Any, List
+
+import fastjsonschema
+from datastore.shared.util import DeletedModelsBehaviour
+
+from ..permissions.management_levels import OrganizationManagementLevel
+from ..permissions.permission_helper import has_organization_management_level
+from ..shared.exceptions import PermissionDenied
+from ..shared.filters import And, Filter, FilterOperator, Or
+from ..shared.schema import schema_version
+from .base import BasePresenter
+from .presenter import register_presenter
+
+schema = fastjsonschema.compile(
+    {
+        "$schema": schema_version,
+        "type": "object",
+        "properties": {
+            "collection": {"type": "string"},
+            "filter_string": {"type": "string"},
+            "meeting_id": {"type": "integer", "minimum": 1},
+        },
+        "required": ["collection", "filter_string"],
+        "additionalProperties": False,
+    }
+)
+
+
+search_fields = {
+    "assignment": ["title"],
+    "motion": ["number", "title"],
+    "user": [
+        "username",
+        "first_name",
+        "last_name",
+        "title",
+        "pronoun",
+        "structure_level",
+        "number",
+        "email",
+    ],
+}
+
+
+@register_presenter("search_deleted_models")
+class SearchDeletedModels(BasePresenter):
+    """
+    Searches all deleted models of the given collection for a given filter string.
+    """
+
+    schema = schema
+
+    def get_result(self) -> Any:
+        if not has_organization_management_level(
+            self.datastore, self.user_id, OrganizationManagementLevel.SUPERADMIN
+        ):
+            raise PermissionDenied("You are not a superadmin")
+
+        collection = self.data["collection"]
+        meeting_id = self.data["meeting_id"]
+        filters: List[Filter] = []
+        for search_field in search_fields[collection]:
+            filters.append(
+                FilterOperator(search_field, "%=", self.data["filter_string"])
+            )
+            filter: Filter
+        if len(filters) > 1:
+            filter = Or(*filters)
+        else:
+            filter = filters[0]
+
+        if collection == "user":
+            filter = And(
+                filter,
+                FilterOperator(f"group_${meeting_id}_ids", "!=", None),
+                FilterOperator(f"group_${meeting_id}_ids", "!=", []),
+            )
+        else:
+            filter = And(filter, FilterOperator("meeting_id", "=", meeting_id))
+        result = self.datastore.filter(
+            collection,
+            filter,
+            ["id"] + search_fields[collection],
+            DeletedModelsBehaviour.ONLY_DELETED,
+            lock_result=False,
+            use_changed_models=False,
+        )
+
+        return result

--- a/openslides_backend/services/datastore/extended_adapter.py
+++ b/openslides_backend/services/datastore/extended_adapter.py
@@ -356,7 +356,7 @@ class ExtendedDatastoreAdapter(CacheDatastoreAdapter):
         # transform query into valid python code
         filter_code = sql_query.lower().replace("null", "None").replace(" = ", " == ")
         # regex for all FilterOperators which were translated by the SqlQueryHelper
-        regex = rf"(?:{MODEL_FIELD_SQL}|lower\({MODEL_FIELD_SQL}\)|{MODEL_FIELD_NUMERIC_SQL}|lower\({MODEL_FIELD_NUMERIC_SQL}\)) (<|<=|>=|>|==|!=|is|is not) ({COMPARISON_VALUE_SQL}|lower\({COMPARISON_VALUE_SQL}\)|{COMPARISON_VALUE_TEXT_SQL}|lower\({COMPARISON_VALUE_TEXT_SQL}\)|None)"
+        regex = rf"(?:{MODEL_FIELD_SQL}|lower\({MODEL_FIELD_SQL}\)|{MODEL_FIELD_NUMERIC_SQL}|lower\({MODEL_FIELD_NUMERIC_SQL}\)) (<|<=|>=|>|==|!=|is|is not|ilike) ({COMPARISON_VALUE_SQL}|lower\({COMPARISON_VALUE_SQL}\)|{COMPARISON_VALUE_TEXT_SQL}|lower\({COMPARISON_VALUE_TEXT_SQL}\)|None)"
         matches = re.findall(regex, filter_code)
         # this will hold all items from arguments, but correctly formatted for python and enhanced with validity checks
         formatted_args = []
@@ -372,6 +372,8 @@ class ExtendedDatastoreAdapter(CacheDatastoreAdapter):
                 formatted_args.append(
                     f'self._comparable(model.get("{arguments[i]}"), {val_str}) and model.get("{arguments[i]}")'
                 )
+            elif match[0] == "ilike":
+                raise NotImplementedError("%= is not implemented for changed models")
             else:
                 formatted_args.append(f'model.get("{arguments[i]}")')
             i += 1

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -192,7 +192,9 @@ class BaseSystemTestCase(TestCase):
     def get_write_request(self, events: List[Event]) -> WriteRequest:
         return WriteRequest(events, user_id=0)
 
-    def set_models(self, models: Dict[str, Dict[str, Any]]) -> None:
+    def set_models(
+        self, models: Dict[str, Dict[str, Any]], deleted: bool = False
+    ) -> None:
         """
         Can be used to set multiple models at once, independent of create or update.
         Uses self.created_fqids to determine which models are already created. If you want to update
@@ -204,7 +206,7 @@ class BaseSystemTestCase(TestCase):
             if fqid in self.created_fqids:
                 events.extend(self.get_update_events(fqid, model))
             else:
-                events.extend(self.get_create_events(fqid, model))
+                events.extend(self.get_create_events(fqid, model, deleted))
         write_request = self.get_write_request(events)
         self.datastore.write(write_request)
 

--- a/tests/system/presenter/test_search_deleted_models.py
+++ b/tests/system/presenter/test_search_deleted_models.py
@@ -1,0 +1,140 @@
+from typing import Any
+
+from .base import BasePresenterTestCase
+
+
+class TestSearchDeletedModels(BasePresenterTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.users = {
+            i: {
+                "id": i,
+                "first_name": f"first{i}",
+                "last_name": f"last{i}",
+                "username": f"user{i}",
+            }
+            for i in range(2, 6)
+        }
+        self.motions = {
+            i: {
+                "id": i,
+                "title": f"title{i}",
+            }
+            for i in range(1, 5)
+        }
+        self.motions[1]["number"] = "42"
+        self.assignments = {
+            i: {
+                "id": i,
+                "title": f"title{i}",
+            }
+            for i in range(1, 5)
+        }
+        user_group = {
+            "group_$1_ids": [1],
+        }
+        meeting_id = {
+            "meeting_id": 1,
+        }
+        # add not deleted models
+        self.set_models(
+            {
+                "meeting/1": {
+                    "user_ids": [5],
+                    "motion_ids": [4],
+                    "assignment_ids": [4],
+                    "group_ids": [1],
+                },
+                "group/1": {
+                    "meeting_id": 1,
+                },
+                "user/5": self.users[5] | user_group,
+                "motion/4": self.motions[4] | meeting_id,
+                "assignment/4": self.assignments[4] | meeting_id,
+            }
+        )
+        # add deleted models
+        self.set_models(
+            {
+                "user/2": self.users[2] | user_group,
+                "user/3": self.users[3] | user_group,
+                "user/4": self.users[4],
+                "motion/1": self.motions[1] | meeting_id,
+                "motion/2": self.motions[2] | meeting_id,
+                "motion/3": self.motions[3],
+                "assignment/1": self.assignments[1] | meeting_id,
+                "assignment/2": self.assignments[2] | meeting_id,
+                "assignment/3": self.assignments[3],
+            },
+            True,
+        )
+
+    def search_deleted_models(
+        self,
+        collection: str,
+        filter_string: str,
+        meeting_id: int = 1,
+        status_code: int = 200,
+    ) -> Any:
+        actual_status_code, data = self.request(
+            "search_deleted_models",
+            {
+                "collection": collection,
+                "filter_string": filter_string,
+                "meeting_id": meeting_id,
+            },
+        )
+        self.assertEqual(actual_status_code, status_code)
+        return data
+
+    def test_search_users_first_name(self) -> None:
+        data = self.search_deleted_models("user", "%first2%")
+        self.assertCountEqual(data.keys(), ["2"])
+        self.assertEqual(data.get("2") | self.users[2], data.get("2"))
+
+    def test_search_users_last_name_multiple_results(self) -> None:
+        data = self.search_deleted_models("user", "%user%")
+        self.assertCountEqual(data.keys(), ["2", "3"])
+        self.assertEqual(data.get("2") | self.users[2], data.get("2"))
+        self.assertEqual(data.get("3") | self.users[3], data.get("3"))
+
+    def test_search_users_not_in_meeting(self) -> None:
+        data = self.search_deleted_models("user", "%last4%")
+        self.assertEqual(data, {})
+
+    def test_search_users_start_of_string_not_found(self) -> None:
+        data = self.search_deleted_models("user", "ser%")
+        self.assertEqual(data, {})
+
+    def test_search_users_start_of_string_found(self) -> None:
+        data = self.search_deleted_models("user", "%ser%")
+        self.assertCountEqual(data.keys(), ["2", "3"])
+        self.assertEqual(data.get("2") | self.users[2], data.get("2"))
+        self.assertEqual(data.get("3") | self.users[3], data.get("3"))
+
+    def test_search_motions_one_result(self) -> None:
+        data = self.search_deleted_models("motion", "title1")
+        self.assertCountEqual(data.keys(), ["1"])
+        self.assertEqual(data.get("1") | self.motions[1], data.get("1"))
+
+    def test_search_motions_multiple_results(self) -> None:
+        data = self.search_deleted_models("motion", "title%")
+        self.assertCountEqual(data.keys(), ["1", "2"])
+        self.assertEqual(data.get("1") | self.motions[1], data.get("1"))
+        self.assertEqual(data.get("2") | self.motions[2], data.get("2"))
+
+    def test_search_motions_number(self) -> None:
+        data = self.search_deleted_models("motion", "42")
+        self.assertCountEqual(data.keys(), ["1"])
+        self.assertEqual(data.get("1") | self.motions[1], data.get("1"))
+
+    def test_search_assignments_one_result(self) -> None:
+        data = self.search_deleted_models("assignment", "title1")
+        self.assertCountEqual(data.keys(), ["1"])
+        self.assertEqual(data.get("1") | self.assignments[1], data.get("1"))
+
+    def test_search_assignments_multiple_results(self) -> None:
+        data = self.search_deleted_models("assignment", "title%")
+        self.assertCountEqual(data.keys(), ["1", "2"])
+        self.assertEqual(data.get("1") | self.assignments[1], data.get("1"))
+        self.assertEqual(data.get("2") | self.assignments[2], data.get("2"))

--- a/tests/system/presenter/test_search_users_by_name_or_email.py
+++ b/tests/system/presenter/test_search_users_by_name_or_email.py
@@ -37,15 +37,9 @@ class TestSearchUsersByNameEmail(BasePresenterTestCase):
         }
         self.set_models(
             {
-                "user/2": {
-                    **self.user2,
-                },
-                "user/3": {
-                    **self.user3,
-                },
-                "user/4": {
-                    **self.user4,
-                },
+                "user/2": self.user2,
+                "user/3": self.user3,
+                "user/4": self.user4,
             }
         )
 


### PR DESCRIPTION
We need a presenter for the client to have access to deleted models. Use case: A user gets deleted by accident and should be (manually, partially) recovered from the history. If the operating user does not remember the id (which will most likely be the case), he has no easy way of accessing the history of the deleted user. This presenter will enable the client to query for deleted models and present them to the operating user in a meaningful way. 