### PR TITLE
Ignore action_worker meeting-import/export and datastore checker.

### DIFF
--- a/openslides_backend/action/actions/meeting/import_.py
+++ b/openslides_backend/action/actions/meeting/import_.py
@@ -162,6 +162,7 @@ class MeetingImport(SingularActionMixin, LimitOfUserMixin, UsernameMixin):
             user.pop("committee_ids", None)
             remove_from_collection(user, regex_cml)
         self.get_meeting_from_json(json_data).pop("organization_tag_ids", None)
+        json_data.pop("action_worker", None)
 
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
         meeting_json = instance["meeting"]

--- a/openslides_backend/presenter/check_database_all.py
+++ b/openslides_backend/presenter/check_database_all.py
@@ -56,6 +56,7 @@ class CheckDatabaseAll(BasePresenter):
         export: Dict[str, Any] = {
             collection: self.remove_meta_fields(everything[collection])
             for collection in everything
+            if collection != "action_worker"
         }
         export["_migration_index"] = get_backend_migration_index()
         return export

--- a/tests/system/action/meeting/test_clone.py
+++ b/tests/system/action/meeting/test_clone.py
@@ -1,3 +1,4 @@
+from time import time
 from typing import Any, Dict, List, cast
 from unittest.mock import MagicMock
 
@@ -1234,6 +1235,21 @@ class MeetingClone(BaseActionTestCase):
                 "vote_delegated_vote_$3_ids": [3],
             },
         )
+
+    def test_with_action_worker(self) -> None:
+        """action_worker shouldn't be cloned"""
+        aw_name = "test action_worker"
+        self.test_models["action_worker/1"] = {
+            "name": aw_name,
+            "state": "end",
+            "created": round(time() - 3),
+            "timestamp": round(time()),
+        }
+        self.set_models(self.test_models)
+        response = self.request("meeting.clone", {"meeting_id": 1})
+        self.assert_status_code(response, 200)
+        self.assert_model_exists("action_worker/1", {"name": aw_name})
+        self.assert_model_not_exists("action_worker/2")
 
     def test_clone_with_2_existing_meetings(self) -> None:
         self.test_models[ONE_ORGANIZATION_FQID]["active_meeting_ids"] = [1, 2]

--- a/tests/system/action/meeting/test_import.py
+++ b/tests/system/action/meeting/test_import.py
@@ -1330,6 +1330,24 @@ class MeetingImport(BaseActionTestCase):
             in response.json["message"]
         )
 
+    def test_dont_import_action_worker(self) -> None:
+        request_data = self.create_request_data(
+            {
+                "action_worker": {
+                    "1": {
+                        "id": 1,
+                        "name": "testcase",
+                        "state": "end",
+                        "created": round(time.time() - 3),
+                        "timestamp": round(time.time()),
+                    }
+                }
+            }
+        )
+        response = self.request("meeting.import", request_data)
+        self.assert_status_code(response, 200)
+        self.assert_model_not_exists("action_worker/1")
+
     def test_bad_format_invalid_id_key(self) -> None:
         request_data = self.create_request_data({"tag": {"1": {"id": 2}}})
         response = self.request("meeting.import", request_data)

--- a/tests/system/presenter/test_check_database_all.py
+++ b/tests/system/presenter/test_check_database_all.py
@@ -1,3 +1,4 @@
+from time import time
 from typing import Any, Dict
 
 from openslides_backend.permissions.management_levels import OrganizationManagementLevel
@@ -244,6 +245,12 @@ class TestCheckDatabaseAll(BasePresenterTestCase):
                     "show_title": True,
                     "show_logo": True,
                     "show_clock": True,
+                },
+                "action_worker/1": {
+                    "name": "testcase",
+                    "state": "end",
+                    "created": round(time() - 3),
+                    "timestamp": round(time()),
                 },
             }
         )

--- a/tests/system/presenter/test_export_meeting.py
+++ b/tests/system/presenter/test_export_meeting.py
@@ -1,3 +1,5 @@
+from time import time
+
 from openslides_backend.permissions.management_levels import OrganizationManagementLevel
 
 from .base import BasePresenterTestCase
@@ -70,6 +72,23 @@ class TestExportMeeting(BasePresenterTestCase):
         assert status_code == 200
         assert "organization_tag" not in data
         assert data["meeting"]["1"].get("organization_tag_ids") is None
+
+    def test_action_worker_exclusion(self) -> None:
+        self.set_models(
+            {
+                "meeting/1": {"name": "name_foo"},
+                "action_worker/1": {
+                    "id": 1,
+                    "name": "testcase",
+                    "state": "end",
+                    "created": round(time() - 3),
+                    "timestamp": round(time()),
+                },
+            }
+        )
+        status_code, data = self.request("export_meeting", {"meeting_id": 1})
+        assert status_code == 200
+        assert "action_worker" not in data
 
     def test_add_users(self) -> None:
         self.set_models(


### PR DESCRIPTION
Fixed warning (```Collections in file do not match with models.py. Invalid collections: action_worker.```) from (extensive) datastore checker (button in client on legal notice page) by adding missiong collection `action_worker`.