### PR TITLE
Add check for the tested fields

### DIFF
--- a/tests/system/action/meeting/test_import.py
+++ b/tests/system/action/meeting/test_import.py
@@ -1228,7 +1228,7 @@ class MeetingImport(BaseActionTestCase):
                 "meeting_id": 2,
                 "origin_id": None,
                 "derived_motion_ids": None,
-                "all_origin_id": None,
+                "all_origin_ids": None,
                 "all_derived_motion_ids": None,
             },
         )


### PR DESCRIPTION
Cleans up some test code and asserts that fields passed to the `assert_model_*` functions actually exist. While rebasing `feature/remove-template-fields` I came across this error a few times and thought it would be a good extension of our testing framework. Fortunately, it looks like we did not make any relevant errors there yet.