### PR TITLE
Fix payload of file generation trigger

### DIFF
--- a/.github/workflows/create-issue-for-file-updates.yml
+++ b/.github/workflows/create-issue-for-file-updates.yml
@@ -52,4 +52,4 @@ jobs:
           event-type: models-update
           repository: OpenSlides/openslides-autoupdate-service
           token: ${{ secrets.AUTOUPDATE_ACCESS_TOKEN }}
-          client-payload: '{"body": "Triggered by commit [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/{{ github.sha }})"}'
+          client-payload: '{"body": "Triggered by commit [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})"}'


### PR DESCRIPTION
Fixes broken PR message, see https://github.com/OpenSlides/openslides-autoupdate-service/pull/636 for a failed example