### PR TITLE
Fix schema usages

### DIFF
--- a/openslides_backend/action/actions/meeting/clone.py
+++ b/openslides_backend/action/actions/meeting/clone.py
@@ -14,7 +14,7 @@ from openslides_backend.shared.patterns import (
     FullQualifiedId,
     fqid_from_collection_and_id,
 )
-from openslides_backend.shared.schema import id_list_schema
+from openslides_backend.shared.schema import id_list_schema, required_id_schema
 
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
@@ -42,7 +42,7 @@ class MeetingClone(MeetingImport):
 
     schema = DefaultSchema(Meeting()).get_default_schema(
         optional_properties=updatable_fields,
-        additional_required_fields={"meeting_id": {"type": "integer"}},
+        additional_required_fields={"meeting_id": required_id_schema},
         additional_optional_fields={
             "user_ids": id_list_schema,
             "admin_ids": id_list_schema,

--- a/openslides_backend/action/actions/motion_workflow/import_.py
+++ b/openslides_backend/action/actions/motion_workflow/import_.py
@@ -1,9 +1,10 @@
 import copy
 from typing import Any, Dict, List
 
-from ....models.models import MotionWorkflow
+from ....models.models import MotionState, MotionWorkflow
 from ....permissions.permissions import Permissions
 from ....shared.exceptions import ActionException
+from ....shared.schema import str_list_schema
 from ...mixins.sequential_numbers_mixin import SequentialNumbersMixin
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
@@ -27,28 +28,22 @@ class MotionWorkflowImport(SequentialNumbersMixin):
                 "items": {
                     "type": "object",
                     "properties": {
-                        "name": {"type": "string"},
-                        "recommendation_label": {"type": "string"},
-                        "css_class": {"type": "string"},
-                        "restrictions": {"type": "array", "items": {"type": "string"}},
-                        "allow_support": {"type": ["boolean", "null"]},
-                        "allow_submitter_edit": {"type": ["boolean", "null"]},
-                        "allow_create_poll": {"type": ["boolean", "null"]},
-                        "set_number": {"type": ["boolean", "null"]},
-                        "show_state_extension_field": {"type": ["boolean", "null"]},
-                        "show_recommendation_extension_field": {
-                            "type": ["boolean", "null"]
-                        },
-                        "merge_amendment_into_final": {"type": ["string", "null"]},
-                        "next_state_names": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "previous_state_names": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "weight": {"type": "integer"},
+                        **MotionState().get_properties(
+                            "name",
+                            "weight",
+                            "recommendation_label",
+                            "css_class",
+                            "restrictions",
+                            "allow_support",
+                            "allow_create_poll",
+                            "allow_submitter_edit",
+                            "set_number",
+                            "show_state_extension_field",
+                            "show_recommendation_extension_field",
+                            "merge_amendment_into_final",
+                        ),
+                        "next_state_names": str_list_schema,
+                        "previous_state_names": str_list_schema,
                     },
                     "additionalProperties": False,
                 },

--- a/openslides_backend/action/actions/projector/add_to_preview.py
+++ b/openslides_backend/action/actions/projector/add_to_preview.py
@@ -1,7 +1,7 @@
 from ....models.models import Projection, Projector
 from ....permissions.permissions import Permissions
 from ....shared.filters import And, FilterOperator
-from ....shared.schema import required_id_schema
+from ....shared.schema import id_list_schema
 from ...generics.update import UpdateAction
 from ...mixins.weight_mixin import WeightMixin
 from ...util.default_schema import DefaultSchema
@@ -20,9 +20,7 @@ class ProjectorAddToPreview(WeightMixin, UpdateAction):
     schema = DefaultSchema(Projection()).get_default_schema(
         required_properties=["content_object_id", "meeting_id"],
         optional_properties=["options", "stable", "type"],
-        additional_required_fields={
-            "ids": {"type": "array", "items": required_id_schema, "uniqueItems": True}
-        },
+        additional_required_fields={"ids": id_list_schema},
         title="Projector add to preview schema",
     )
     permission = Permissions.Projector.CAN_MANAGE

--- a/openslides_backend/action/actions/projector/project.py
+++ b/openslides_backend/action/actions/projector/project.py
@@ -4,7 +4,7 @@ from ....models.models import Projection, Projector
 from ....permissions.permissions import Permissions
 from ....shared.filters import And, FilterOperator
 from ....shared.patterns import fqid_from_collection_and_id
-from ....shared.schema import required_id_schema
+from ....shared.schema import id_list_schema
 from ...generics.update import UpdateAction
 from ...mixins.singular_action_mixin import SingularActionMixin
 from ...mixins.weight_mixin import WeightMixin
@@ -28,7 +28,7 @@ class ProjectorProject(WeightMixin, SingularActionMixin, UpdateAction):
         required_properties=["content_object_id", "meeting_id"],
         optional_properties=["options", "stable", "type"],
         additional_required_fields={
-            "ids": {"type": "array", "items": required_id_schema, "uniqueItems": True}
+            "ids": id_list_schema,
         },
         title="Projector project schema",
     )

--- a/openslides_backend/action/actions/projector/sort_preview.py
+++ b/openslides_backend/action/actions/projector/sort_preview.py
@@ -4,7 +4,7 @@ from ....models.models import Projector
 from ....permissions.permissions import Permissions
 from ....shared.exceptions import ActionException
 from ....shared.patterns import fqid_from_collection_and_id
-from ....shared.schema import required_id_schema
+from ....shared.schema import id_list_schema
 from ...generics.update import UpdateAction
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
@@ -20,9 +20,7 @@ class ProjectorSortPreview(UpdateAction):
 
     model = Projector()
     schema = DefaultSchema(Projector()).get_update_schema(
-        additional_required_fields={
-            "projection_ids": {"type": "array", "items": required_id_schema}
-        },
+        additional_required_fields={"projection_ids": id_list_schema},
     )
     permission = Permissions.Projector.CAN_MANAGE
 

--- a/openslides_backend/action/actions/user/forget_password_confirm.py
+++ b/openslides_backend/action/actions/user/forget_password_confirm.py
@@ -5,6 +5,7 @@ from authlib.exceptions import InvalidCredentialsException
 
 from ....models.models import User
 from ....shared.exceptions import ActionException
+from ....shared.schema import required_id_schema
 from ...generics.update import UpdateAction
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
@@ -21,7 +22,7 @@ class UserForgetPasswordConfirm(UpdateAction):
         title="user forget password confirm schema",
         additional_required_fields={
             "new_password": {"type": "string"},
-            "user_id": {"type": "integer"},
+            "user_id": required_id_schema,
             "authorization_token": {"type": "string"},
         },
     )

--- a/openslides_backend/action/util/default_schema.py
+++ b/openslides_backend/action/util/default_schema.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Iterable, Optional
 
 from ...models.base import Model
-from ...shared.schema import schema_version
+from ...shared.schema import id_list_schema, required_id_schema, schema_version
 from ...shared.typing import Schema
 
 sort_node_schema = {
@@ -11,11 +11,7 @@ sort_node_schema = {
     "description": "A node inside a sort tree.",
     "type": "object",
     "properties": {
-        "id": {
-            "description": "The id of the instance.",
-            "type": "integer",
-            "minimum": 1,
-        },
+        "id": required_id_schema,
         "children": {
             "type": "array",
             "items": {"type": "object", "$ref": "tree_sort_node"},
@@ -146,11 +142,6 @@ class DefaultSchema:
             title=f"Sort {self.model} schema",
             required_properties=[id_field_main],
             additional_required_fields={
-                id_field_to_sort: {
-                    "type": "array",
-                    "items": {"type": "integer", "min": 1},
-                    "minItems": 1,
-                    "uniqueItems": True,
-                },
+                id_field_to_sort: id_list_schema,
             },
         )

--- a/openslides_backend/presenter/get_user_related_models.py
+++ b/openslides_backend/presenter/get_user_related_models.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, cast
 import fastjsonschema
 
 from openslides_backend.shared.mixins.user_scope_mixin import UserScopeMixin
+from openslides_backend.shared.schema import id_list_schema
 
 from ..models.models import Committee
 from ..services.datastore.commands import GetManyRequest
@@ -20,10 +21,7 @@ get_user_related_models_schema = fastjsonschema.compile(
         "title": "get_user_related_models",
         "description": "get user ids related models",
         "properties": {
-            "user_ids": {
-                "type": "array",
-                "item": {"type": "integer"},
-            },
+            "user_ids": id_list_schema,
         },
         "required": ["user_ids"],
         "additionalProperties": False,

--- a/openslides_backend/presenter/get_user_scope.py
+++ b/openslides_backend/presenter/get_user_scope.py
@@ -2,6 +2,8 @@ from typing import Any, Dict
 
 import fastjsonschema
 
+from openslides_backend.shared.schema import id_list_schema
+
 from ..shared.mixins.user_scope_mixin import UserScope, UserScopeMixin
 from ..shared.schema import schema_version
 from .base import BasePresenter
@@ -14,10 +16,7 @@ get_user_scope_schema = fastjsonschema.compile(
         "title": "get_user_related_models",
         "description": "get user ids related models",
         "properties": {
-            "user_ids": {
-                "type": "array",
-                "item": {"type": "integer"},
-            },
+            "user_ids": id_list_schema,
         },
         "required": ["user_ids"],
         "additionalProperties": False,

--- a/openslides_backend/presenter/get_users.py
+++ b/openslides_backend/presenter/get_users.py
@@ -11,30 +11,6 @@ from ..shared.schema import schema_version
 from .base import BasePresenter
 from .presenter import register_presenter
 
-get_users_schema = fastjsonschema.compile(
-    {
-        "$schema": schema_version,
-        "type": "object",
-        "title": "get_users",
-        "description": "get user ids data",
-        "properties": {
-            "start_index": {"type": "integer"},
-            "entries": {"type": "integer"},
-            "sort_criteria": {
-                "type": "array",
-                "item": {
-                    "type": "string",
-                    "enum": ["username", "first_name", "last_name"],
-                },
-            },
-            "reverse": {"type": "boolean"},
-            "filter": {"type": ["string", "null"]},
-        },
-        "required": [],
-        "additionalProperties": False,
-    }
-)
-
 # The values are the default values for None.
 ALLOWED = {
     "first_name": "",
@@ -50,6 +26,30 @@ ALLOWED = {
     "structure_level": "",
     "vote_weight": "",
 }
+
+get_users_schema = fastjsonschema.compile(
+    {
+        "$schema": schema_version,
+        "type": "object",
+        "title": "get_users",
+        "description": "get user ids data",
+        "properties": {
+            "start_index": {"type": "integer"},
+            "entries": {"type": "integer"},
+            "sort_criteria": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": list(ALLOWED.keys()),
+                },
+            },
+            "reverse": {"type": "boolean"},
+            "filter": {"type": ["string", "null"]},
+        },
+        "required": [],
+        "additionalProperties": False,
+    }
+)
 
 
 @register_presenter("get_users")

--- a/openslides_backend/shared/schema.py
+++ b/openslides_backend/shared/schema.py
@@ -18,6 +18,10 @@ optional_fqid_schema: Schema = {
     "pattern": FQID_REGEX,
     "minLength": 1,
 }
+required_str_schema: Schema = {
+    "type": ["string"],
+    "minLength": 1,
+}
 optional_str_schema: Schema = {
     "type": ["string", "null"],
     "minLength": 1,
@@ -30,5 +34,6 @@ base_list_schema: Schema = {
 id_list_schema: Schema = {**base_list_schema, "items": required_id_schema}
 fqid_list_schema: Schema = {**base_list_schema, "items": required_fqid_schema}
 optional_str_list_schema: Schema = {**base_list_schema, "items": optional_str_schema}
+str_list_schema: Schema = {**base_list_schema, "items": required_str_schema}
 
 decimal_schema: Schema = {"type": "string", "pattern": DECIMAL_REGEX}

--- a/tests/system/presenter/test_get_user_scope.py
+++ b/tests/system/presenter/test_get_user_scope.py
@@ -84,9 +84,7 @@ class TestGetUSerScope(BasePresenterTestCase):
     def test_without_user_None(self) -> None:
         status_code, data = self.request("get_user_scope", {"user_ids": [None]})
         self.assertEqual(status_code, 400)
-        self.assertIn(
-            "There is no user_id given to get the user_scope!", data["message"]
-        )
+        self.assertIn("data.user_ids[0] must be integer", data["message"])
 
     def test_without_user_empty_list(self) -> None:
         status_code, data = self.request("get_user_scope", {"user_ids": []})


### PR DESCRIPTION
follow-up to https://github.com/OpenSlides/openslides-backend/pull/1669: The error in the test for the `get_user_scope` presenter happened (partially) because we do not use our exsting schemas enough, so I replaced all places I could find with our predefined schemas. Also, I'm very confused that `fastjsonschema` does not throw an error in case of invalid keywords (like `item` instead of `items`) - if anyone knows if there exists a simple solution for that, I would love to fix this.