### PR TITLE
Update set-project workflow to use automation app token

### DIFF
--- a/.github/workflows/set-project.yml
+++ b/.github/workflows/set-project.yml
@@ -11,8 +11,13 @@ jobs:
     name: 'Set project'
     runs-on: ubuntu-latest
     steps:
-      - name: Set project
-        uses: actions/add-to-project@v0.4.0
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
+      - uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/OpenSlides/projects/2
-          github-token: ${{ secrets.ISSUE_AND_PR_PAT }}
+          github-token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Previously, a personal token from my account was used to add issues and PRs to the project. Since the token is about to expire and we now have an openslides automation github app whose token we can use, I will go ahead and change all scripts to use that instead. This is the test repo to assert that it actually works as expected before rolling it out everywhere else.