### PR TITLE
Add optional pip dependency to support pdf crypto

### DIFF
--- a/requirements/partial/requirements_production.txt
+++ b/requirements/partial/requirements_production.txt
@@ -4,7 +4,7 @@ dependency_injector==4.41.0
 fastjsonschema==2.16.2
 gunicorn==20.1.0
 lxml==4.9.2
-pypdf==3.4.0
+pypdf[crypto]==3.4.0
 requests==2.28.2
 roman==3.3
 simplejson==3.18.3


### PR DESCRIPTION
Previously uploading an encrypted / password secured pdf file would result in a traceback.