### PR TITLE
Replace short_string type with maxLength attribute

### DIFF
--- a/cli/generate_models.py
+++ b/cli/generate_models.py
@@ -26,7 +26,6 @@ DESTINATION = os.path.abspath(
 
 COMMON_FIELD_CLASSES = {
     "string": "CharField",
-    "short_string": "ShortCharField",
     "number": "IntegerField",
     "boolean": "BooleanField",
     "JSON": "JSONField",

--- a/cli/modelsvalidator/validate.py
+++ b/cli/modelsvalidator/validate.py
@@ -28,7 +28,6 @@ RELATION_TYPES = (
 
 DATA_TYPES = (
     "string",
-    "short_string",
     "number",
     "string[]",
     "number[]",
@@ -260,7 +259,6 @@ class Checker:
     ) -> None:
         basic_types = {
             "string": str,
-            "short_string": str,
             "number": int,
             "boolean": bool,
             "HTMLStrict": str,

--- a/cli/modelsvalidator/validate.py
+++ b/cli/modelsvalidator/validate.py
@@ -183,7 +183,7 @@ class Checker:
                 self.errors.append(f"'minimum' for {collectionfield} is not a number.")
         if type == "decimal(6)":
             valid_attributes.append("minimum")
-        if type == "string":
+        if type in ("string", "text"):
             valid_attributes.append("maxLength")
             if not isinstance(field.get("maxLength", 0), int):
                 self.errors.append(

--- a/global/meta/models.yml
+++ b/global/meta/models.yml
@@ -1,6 +1,6 @@
 ---
 # Types:
-#     - Nativ datatypes: string, text, number, boolean, JSON
+#     - Nativ datatypes: text, string (text with maxLength=256), number, boolean, JSON
 #     - HTMLStrict: A string with HTML content.
 #     - HTMLPermissive: A string with HTML content (with video tags).
 #     - float: Numbers that are expected to be non-integer. Formatted as in rfc7159.
@@ -215,7 +215,8 @@ user:
     type: string
     restriction_mode: A
   pronoun:
-    type: short_string
+    type: string
+    maxLength: 32
     restriction_mode: A
   title:
     type: string

--- a/global/meta/models.yml
+++ b/global/meta/models.yml
@@ -731,6 +731,7 @@ meeting:
     maxLength: 100
     default: OpenSlides
     restriction_mode: A
+    required: true
   is_active_in_organization_id:
     type: relation
     to: organization/active_meeting_ids

--- a/openslides_backend/action/actions/meeting/clone.py
+++ b/openslides_backend/action/actions/meeting/clone.py
@@ -103,15 +103,20 @@ class MeetingClone(MeetingImport):
             meeting["committee_id"] = committee_id
 
         # pre update the meeting
-        name_set = False
+        if "name" not in instance:
+            suffix = " - Copy"
+            max_length = Meeting().name.constraints.get("maxLength")
+            old_name = meeting["name"]
+            if max_length and len(old_name) + len(suffix) > max_length:
+                meeting["name"] = (
+                    old_name[: max_length - len(suffix) - 3] + "..." + suffix
+                )
+            else:
+                meeting["name"] = old_name + suffix
+
         for field in updatable_fields:
             if field in instance:
-                if field == "name":
-                    name_set = True
-                value = instance.pop(field)
-                meeting[field] = value
-        if not name_set:
-            meeting["name"] = meeting.get("name", "") + " - Copy"
+                meeting[field] = instance.pop(field)
 
         # reset mediafile/attachment_ids to [] if None.
         for mediafile_id in instance["meeting"].get("mediafile", []):

--- a/openslides_backend/models/fields.py
+++ b/openslides_backend/models/fields.py
@@ -146,11 +146,6 @@ class CharField(TextField):
         return self.extend_schema(super().get_schema(), maxLength=256)
 
 
-class ShortCharField(TextField):
-    def get_schema(self) -> Schema:
-        return self.extend_schema(super().get_schema(), maxLength=32)
-
-
 class JSONField(Field):
     def get_schema(self) -> Schema:
         types = ["object", "array"]

--- a/openslides_backend/models/fields.py
+++ b/openslides_backend/models/fields.py
@@ -143,7 +143,9 @@ class TextField(Field):
 
 class CharField(TextField):
     def get_schema(self) -> Schema:
-        return self.extend_schema(super().get_schema(), maxLength=256)
+        schema = super().get_schema()
+        schema.setdefault("maxLength", 256)
+        return schema
 
 
 class JSONField(Field):

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -3,7 +3,7 @@
 from openslides_backend.models import fields
 from openslides_backend.models.base import Model
 
-MODELS_YML_CHECKSUM = "b12d530c9385e56a4f4b6bf18965c633"
+MODELS_YML_CHECKSUM = "c2882d68f68affe0fc8b3ce77055e514"
 
 
 class Organization(Model):
@@ -73,7 +73,7 @@ class User(Model):
     id = fields.IntegerField()
     username = fields.CharField(required=True)
     saml_id = fields.CharField()
-    pronoun = fields.ShortCharField()
+    pronoun = fields.CharField(constraints={"maxLength": 32})
     title = fields.CharField()
     first_name = fields.CharField()
     last_name = fields.CharField()

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -3,7 +3,7 @@
 from openslides_backend.models import fields
 from openslides_backend.models.base import Model
 
-MODELS_YML_CHECKSUM = "c2882d68f68affe0fc8b3ce77055e514"
+MODELS_YML_CHECKSUM = "52fd248a0f0407e73542b9d416e4cc26"
 
 
 class Organization(Model):
@@ -335,7 +335,9 @@ class Meeting(Model):
     id = fields.IntegerField()
     welcome_title = fields.CharField(default="Welcome to OpenSlides")
     welcome_text = fields.HTMLPermissiveField(default="Space for your welcome text.")
-    name = fields.CharField(default="OpenSlides", constraints={"maxLength": 100})
+    name = fields.CharField(
+        required=True, default="OpenSlides", constraints={"maxLength": 100}
+    )
     is_active_in_organization_id = fields.RelationField(
         to={"organization": "active_meeting_ids"},
         constraints={"description": "Backrelation and boolean flag at once"},

--- a/tests/system/action/meeting/test_clone.py
+++ b/tests/system/action/meeting/test_clone.py
@@ -910,13 +910,21 @@ class MeetingClone(BaseActionTestCase):
         response = self.request("meeting.clone", {"meeting_id": 1})
         self.assert_status_code(response, 200)
 
-    def test_meeting_name_too_long(self) -> None:
-        long_name = "0123456789" * 10
+    def test_meeting_name_exact_fit(self) -> None:
+        long_name = "A" * 93
         self.test_models["meeting/1"]["name"] = long_name
         self.set_models(self.test_models)
         response = self.request("meeting.clone", {"meeting_id": 1})
         self.assert_status_code(response, 200)
         self.assert_model_exists("meeting/2", {"name": long_name + " - Copy"})
+
+    def test_meeting_name_too_long(self) -> None:
+        long_name = "A" * 100
+        self.test_models["meeting/1"]["name"] = long_name
+        self.set_models(self.test_models)
+        response = self.request("meeting.clone", {"meeting_id": 1})
+        self.assert_status_code(response, 200)
+        self.assert_model_exists("meeting/2", {"name": "A" * 90 + "... - Copy"})
 
     def test_permissions_both_okay(self) -> None:
         self.set_models(self.test_models)

--- a/tests/system/action/meeting/test_create.py
+++ b/tests/system/action/meeting/test_create.py
@@ -307,6 +307,12 @@ class MeetingCreateActionTest(BaseActionTestCase):
             set_400_str="Only one of start_time and end_time is not allowed.",
         )
 
+    def test_create_name_too_long(self) -> None:
+        self.basic_test(
+            {"name": "A" * 101},
+            set_400_str="data.name must be shorter than or equal to 100 characters",
+        )
+
     def test_create_no_permissions(self) -> None:
         self.set_models(
             {

--- a/tests/system/action/user/test_update.py
+++ b/tests/system/action/user/test_update.py
@@ -386,7 +386,7 @@ class UserUpdateActionTest(BaseActionTestCase):
         self.assert_status_code(response, 200)
         self.assert_model_exists("user/1", {"username": "admin"})
 
-    def test_update_check_short_string(self) -> None:
+    def test_update_check_pronoun_too_long(self) -> None:
         self.create_model(
             "user/111",
             {"username": "username_srtgb123"},


### PR DESCRIPTION
fixes #1726 

While wanting to document the feature, I realized that the functionality to replace the `short_string` field was already present, so I went ahead and replaced it already. Sorry for the unecessary overhead.