### PR TITLE
Add HEALTHCHECK to productive Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,7 @@ LABEL org.opencontainers.image.description="Backend service for OpenSlides which
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.source="https://github.com/OpenSlides/openslides-backend"
 
+HEALTHCHECK CMD curl --fail http://localhost:9002/system/action/health/ || curl --fail http://localhost:9003/system/presenter/health/ || exit 1
+
 ENTRYPOINT ["./entrypoint.sh"]
 CMD exec python -m openslides_backend


### PR DESCRIPTION
fixes #1589

Analogous to the exposed ports above, I just try both possible targets. The (better and cleaner) alternative would be to only expose the actual port and test the actual health route (action or presenter), but this would require this data to be inserted in the Dockerfile via build args and would therefore require changes in all setups, so I figured it would not be worth the hassle.