### PR TITLE
Fix output for migration stats command

### DIFF
--- a/openslides_backend/migrations/migration_wrapper.py
+++ b/openslides_backend/migrations/migration_wrapper.py
@@ -79,7 +79,7 @@ class MigrationWrapper:
         elif command == "clear-collectionfield-tables":
             self.handler.delete_collectionfield_aux_tables()
         elif command == "stats":
-            return self.handler.get_stats()
+            self.handler.print_stats()
         else:
             raise InvalidMigrationCommand(command)
 


### PR DESCRIPTION
Minor fix - when executing the migration script manually (which does not happen in production, since there the migration route is used via the manage tool), the `stats` command did not work as intended because `get_stats()` was called instead of `print_stats()` and therefore, no output was generated.