### PR TITLE
Fix `check_database` presenter and add `check_database` CLI script

### DIFF
--- a/cli/check_database.py
+++ b/cli/check_database.py
@@ -1,0 +1,38 @@
+import logging
+import os
+import sys
+
+from datastore.reader.app import register_services
+
+from openslides_backend.presenter.check_database import check_meetings
+from openslides_backend.presenter.check_database_all import check_everything
+from openslides_backend.shared.env import Environment
+from openslides_backend.wsgi import OpenSlidesBackendServices
+
+
+def main() -> int:
+    register_services()
+    env = Environment(os.environ)
+    services = OpenSlidesBackendServices(
+        config=env.get_service_url(),
+        logging=logging,
+        env=env,
+    )
+    datastore = services.datastore()
+
+    arg = sys.argv[1] if len(sys.argv) > 1 else None
+    with datastore.get_database_context():
+        if arg == "all":
+            check_everything(datastore)
+        else:
+            meeting_id = int(arg) if arg else None
+            errors = check_meetings(datastore, meeting_id)
+            if errors:
+                for meeting_id, error in errors.items():
+                    print(f"Meeting {meeting_id}: {error}")
+                return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openslides_backend/action/actions/meeting/export_helper.py
+++ b/openslides_backend/action/actions/meeting/export_helper.py
@@ -26,6 +26,8 @@ from ....shared.patterns import (
     id_from_fqid,
 )
 
+FORBIDDEN_FIELDS = ["forwarded_motion_ids"]
+
 
 def export_meeting(datastore: DatastoreService, meeting_id: int) -> Dict[str, Any]:
     export: Dict[str, Any] = {}
@@ -37,6 +39,8 @@ def export_meeting(datastore: DatastoreService, meeting_id: int) -> Dict[str, An
         lock_result=False,
         use_changed_models=False,
     )
+    for forbidden_field in FORBIDDEN_FIELDS:
+        meeting.pop(forbidden_field, None)
     export["meeting"] = remove_meta_fields(transfer_keys({meeting_id: meeting}))
     export["_migration_index"] = get_backend_migration_index()
 

--- a/openslides_backend/http/application.py
+++ b/openslides_backend/http/application.py
@@ -65,7 +65,7 @@ class OpenSlidesBackendWSGIApplication:
             return exception
         if type(response_body) == dict:
             status_code = response_body.get("status_code", 200)
-        elif request.path == r"/system/presenter/handle_request":
+        elif request.path == "/system/presenter/handle_request":
             status_code = Response.default_status
         else:
             raise ViewException(f"Unknown type of response_body:{response_body}.")

--- a/openslides_backend/presenter/check_database_all.py
+++ b/openslides_backend/presenter/check_database_all.py
@@ -1,13 +1,14 @@
 from typing import Any, Dict
 
 import fastjsonschema
-from datastore.shared.util import strip_reserved_fields
+from datastore.shared.util import is_reserved_field
 
 from openslides_backend.migrations import get_backend_migration_index
 
 from ..models.checker import Checker, CheckException
 from ..permissions.management_levels import OrganizationManagementLevel
 from ..permissions.permission_helper import has_organization_management_level
+from ..services.datastore.interface import DatastoreService
 from ..shared.exceptions import PermissionDenied
 from ..shared.schema import schema_version
 from .base import BasePresenter
@@ -22,6 +23,27 @@ check_database_schema = fastjsonschema.compile(
         "properties": {},
     }
 )
+
+
+def check_everything(datastore: DatastoreService) -> None:
+    result = datastore.get_everything()
+    data: Dict[str, Any] = {
+        collection: {
+            str(id): {
+                field: value
+                for field, value in model.items()
+                if not is_reserved_field(field)
+            }
+            for id, model in models.items()
+        }
+        for collection, models in result.items()
+        if collection != "action_worker"
+    }
+    data["_migration_index"] = get_backend_migration_index()
+    Checker(
+        data=data,
+        mode="all",
+    ).run_check()
 
 
 @register_presenter("check_database_all")
@@ -40,30 +62,8 @@ class CheckDatabaseAll(BasePresenter):
             msg += f" Missing permission: {OrganizationManagementLevel.SUPERADMIN}"
             raise PermissionDenied(msg)
 
-        export = self.get_everything()
-        checker = Checker(
-            data=export,
-            mode="all",
-        )
         try:
-            checker.run_check()
+            check_everything(self.datastore)
             return {"ok": True}
         except CheckException as ce:
             return {"ok": False, "errors": str(ce)}
-
-    def get_everything(self) -> Dict[str, Any]:
-        everything = self.datastore.get_everything()
-        export: Dict[str, Any] = {
-            collection: self.remove_meta_fields(everything[collection])
-            for collection in everything
-            if collection != "action_worker"
-        }
-        export["_migration_index"] = get_backend_migration_index()
-        return export
-
-    def remove_meta_fields(self, res: Dict[int, Any]) -> Dict[str, Any]:
-        dict_without_meta_fields = {}
-        for key in res:
-            strip_reserved_fields(res[key])
-            dict_without_meta_fields[str(key)] = res[key]
-        return dict_without_meta_fields

--- a/openslides_backend/services/datastore/extended_adapter.py
+++ b/openslides_backend/services/datastore/extended_adapter.py
@@ -20,7 +20,13 @@ from ...shared.typing import DeletedModel, ModelMap
 from .cache_adapter import CacheDatastoreAdapter
 from .commands import GetManyRequest
 from .handle_datastore_errors import raise_datastore_error
-from .interface import Engine, LockResult, MappedFieldsPerFqid, PartialModel
+from .interface import (
+    DatastoreService,
+    Engine,
+    LockResult,
+    MappedFieldsPerFqid,
+    PartialModel,
+)
 
 MODEL_FIELD_SQL = "data->>%s"
 MODEL_FIELD_NUMERIC_SQL = r"\(data->%s\)::numeric"
@@ -29,7 +35,7 @@ COMPARISON_VALUE_TEXT_SQL = "%s::text"
 COMPARISON_VALUE_SQL = "%s"
 
 
-class ExtendedDatastoreAdapter(CacheDatastoreAdapter):
+class ExtendedDatastoreAdapter(CacheDatastoreAdapter, DatastoreService):
     """
     Subclass of the datastore adapter to extend the functions with the usage of the changed_models.
 

--- a/openslides_backend/services/datastore/interface.py
+++ b/openslides_backend/services/datastore/interface.py
@@ -176,7 +176,7 @@ class DatastoreService(BaseDatastoreService):
     def get(
         self,
         fqid: FullQualifiedId,
-        mapped_fields: Optional[List[str]] = None,
+        mapped_fields: List[str],
         position: Optional[int] = None,
         get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: LockResult = True,
@@ -201,7 +201,7 @@ class DatastoreService(BaseDatastoreService):
         self,
         collection: Collection,
         filter: Filter,
-        mapped_fields: List[str] = [],
+        mapped_fields: List[str],
         get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
         lock_result: bool = True,
         use_changed_models: bool = True,


### PR DESCRIPTION
The `check_database` presenter mistakenly reported errors for forwarded motions partially because the respective fields were not filtered out correctly and partially because the `export_meeting` method exported fields and models from other meetings through following the forwardings. I also added a `check_database.py` script to be able to execute the checks programmatically in a running instance.

I don't particularily like moving the presenter code into their own methods, but the presenter framework would need much rework for a better solution and I don't think that's worth it.