### PR TITLE
Fix singular action mixin

### DIFF
--- a/openslides_backend/action/actions/user/save_saml_account.py
+++ b/openslides_backend/action/actions/user/save_saml_account.py
@@ -134,13 +134,7 @@ class UserSaveSamlAccount(
                 f"More than one existing user found in database with saml_id {instance['saml_id']}"
             )
 
-        instance = self.validate_fields(instance)
-        instance = self.update_instance(instance)
-        self.apply_instance(instance)
-        self.validate_relation_fields(instance)
-        # Return id of user anyway
-        self.results.append(self.create_action_result_element(instance))
-        return instance
+        return UpdateAction.base_update_instance(self, instance)
 
     def create_events(self, instance: Dict[str, Any]) -> Iterable[Event]:
         """

--- a/openslides_backend/action/mixins/singular_action_mixin.py
+++ b/openslides_backend/action/mixins/singular_action_mixin.py
@@ -2,7 +2,7 @@ import fastjsonschema
 
 from ...shared.exceptions import ActionException
 from ...shared.schema import schema_version
-from ..action import Action
+from ..action import Action, original_instances
 from ..util.typing import ActionData
 
 singular_schema = fastjsonschema.compile(
@@ -25,6 +25,7 @@ class SingularActionMixin(Action):
 
     is_singular = True
 
+    @original_instances
     def get_updated_instances(self, action_data: ActionData) -> ActionData:
         self.assert_singular_action_data(action_data)
         return super().get_updated_instances(action_data)


### PR DESCRIPTION
I thought about it again and actually, we can just set `@original_instances` in the `SingularActionMixin`: We do not have a situation where some base class is "inserted" in the inheritance order between `SingularActionMixin` and the base action. If an action overrides `get_updated_instances`, it is always done in the action itself. So this way works: Either the specific action does not override the method and the decorator is set correctly, or the action does override it and the decorator in the mixin does not matter.

I also added some more documentation, I hope the functionality is clearer now.