### PR TITLE
Generate readable default passwords

### DIFF
--- a/openslides_backend/action/actions/meeting/import_.py
+++ b/openslides_backend/action/actions/meeting/import_.py
@@ -42,7 +42,7 @@ from ....shared.interfaces.event import Event, ListFields
 from ....shared.util import ONE_ORGANIZATION_ID
 from ...action import RelationUpdates
 from ...mixins.singular_action_mixin import SingularActionMixin
-from ...util.crypto import get_random_string
+from ...util.crypto import get_random_password
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
 from ...util.typing import ActionData, ActionResultElement, ActionResults
@@ -330,7 +330,7 @@ class MeetingImport(SingularActionMixin, LimitOfUserMixin, UsernameMixin):
         # generate passwords
         for entry in json_data["user"].values():
             if entry["id"] not in self.merge_user_map:
-                entry["default_password"] = get_random_string(10)
+                entry["default_password"] = get_random_password()
                 entry["password"] = self.auth.hash(entry["default_password"])
 
         # set enable_anonymous

--- a/openslides_backend/action/actions/user/create.py
+++ b/openslides_backend/action/actions/user/create.py
@@ -9,10 +9,11 @@ from ....shared.exceptions import ActionException
 from ....shared.util import ONE_ORGANIZATION_ID
 from ...generics.create import CreateAction
 from ...mixins.send_email_mixin import EmailCheckMixin
+from ...util.crypto import get_random_password
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
 from .create_update_permissions_mixin import CreateUpdatePermissionsMixin
-from .password_mixin import PasswordCreateMixin
+from .password_mixin import PasswordMixin
 from .user_mixin import LimitOfUserMixin, UserMixin, UsernameMixin
 
 
@@ -22,7 +23,7 @@ class UserCreate(
     CreateAction,
     UserMixin,
     CreateUpdatePermissionsMixin,
-    PasswordCreateMixin,
+    PasswordMixin,
     LimitOfUserMixin,
     UsernameMixin,
 ):
@@ -78,9 +79,8 @@ class UserCreate(
         if not instance.get("username"):
             instance["username"] = self.generate_username(instance)
         if not instance.get("default_password"):
-            instance = self.generate_and_set_password(instance)
-        else:
-            instance = self.set_password(instance)
+            instance["default_password"] = get_random_password()
+        instance = self.set_password(instance)
         instance["organization_id"] = ONE_ORGANIZATION_ID
         return instance
 

--- a/openslides_backend/action/actions/user/generate_new_password.py
+++ b/openslides_backend/action/actions/user/generate_new_password.py
@@ -4,26 +4,16 @@ from ....action.mixins.archived_meeting_check_mixin import CheckForArchivedMeeti
 from ....models.models import User
 from ....permissions.management_levels import OrganizationManagementLevel
 from ....shared.mixins.user_scope_mixin import UserScopeMixin
+from ...util.crypto import get_random_password
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
-from .password_mixin import PasswordCreateMixin
 from .set_password import UserSetPasswordMixin
-
-
-class UserGenerateNewPasswordMixin(UserSetPasswordMixin, CheckForArchivedMeetingMixin):
-    def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Generates new password and call the super code.
-        """
-        new_password = PasswordCreateMixin.generate_password()
-        instance["password"] = new_password
-        instance["set_as_default"] = True
-        return super().update_instance(instance)
 
 
 @register_action("user.generate_new_password")
 class UserGenerateNewPassword(
-    UserGenerateNewPasswordMixin,
+    UserSetPasswordMixin,
+    CheckForArchivedMeetingMixin,
     UserScopeMixin,
 ):
     model = User()
@@ -32,3 +22,11 @@ class UserGenerateNewPassword(
 
     def check_permissions(self, instance: Dict[str, Any]) -> None:
         self.check_permissions_for_scope(instance["id"])
+
+    def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Generates new password and call the super code.
+        """
+        instance["password"] = get_random_password()
+        instance["set_as_default"] = True
+        return super().update_instance(instance)

--- a/openslides_backend/action/actions/user/password_mixin.py
+++ b/openslides_backend/action/actions/user/password_mixin.py
@@ -1,20 +1,11 @@
 from typing import Any, Dict
 
 from ...action import Action
-from ...util.crypto import get_random_string
 
 
-class PasswordCreateMixin(Action):
+class PasswordMixin(Action):
     def set_password(self, instance: Dict[str, Any]) -> Dict[str, Any]:
-        password = instance.get("default_password", "")
+        password = instance["default_password"]
         hashed_password = self.auth.hash(password)
         instance["password"] = hashed_password
         return instance
-
-    def generate_and_set_password(self, instance: Dict[str, Any]) -> Dict[str, Any]:
-        instance["default_password"] = self.generate_password()
-        return self.set_password(instance)
-
-    @staticmethod
-    def generate_password() -> str:
-        return get_random_string(10)

--- a/openslides_backend/action/util/crypto.py
+++ b/openslides_backend/action/util/crypto.py
@@ -1,6 +1,7 @@
 import secrets
 
 RANDOM_STRING_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+PASSWORD_CHARS = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPRSTUVWXYZ23456789"
 
 
 def get_random_string(length: int, allowed_chars: str = RANDOM_STRING_CHARS) -> str:
@@ -8,3 +9,10 @@ def get_random_string(length: int, allowed_chars: str = RANDOM_STRING_CHARS) -> 
     Return a securely generated random string.
     """
     return "".join(secrets.choice(allowed_chars) for i in range(length))
+
+
+def get_random_password(length: int = 10, allowed_chars: str = PASSWORD_CHARS) -> str:
+    """
+    Return a securely generated random password which uses only uses easily identifiable characters.
+    """
+    return get_random_string(length, allowed_chars)

--- a/openslides_backend/action/util/crypto.py
+++ b/openslides_backend/action/util/crypto.py
@@ -13,6 +13,6 @@ def get_random_string(length: int, allowed_chars: str = RANDOM_STRING_CHARS) -> 
 
 def get_random_password(length: int = 10, allowed_chars: str = PASSWORD_CHARS) -> str:
     """
-    Return a securely generated random password which uses only uses easily identifiable characters.
+    Return a securely generated random password which only uses easily identifiable characters.
     """
     return get_random_string(length, allowed_chars)

--- a/tests/system/action/user/test_create.py
+++ b/tests/system/action/user/test_create.py
@@ -1,3 +1,4 @@
+from openslides_backend.action.util.crypto import PASSWORD_CHARS
 from openslides_backend.permissions.management_levels import (
     CommitteeManagementLevel,
     OrganizationManagementLevel,
@@ -26,10 +27,9 @@ class UserCreateActionTest(BaseActionTestCase):
         self.assert_status_code(response, 200)
         model = self.get_model("user/2")
         assert model.get("username") == "test Xcdfgee"
-        assert model.get("default_password") is not None
-        assert self.auth.is_equals(
-            model.get("default_password", ""), model.get("password", "")
-        )
+        assert (password := model.get("default_password")) is not None
+        assert all(char in PASSWORD_CHARS for char in password)
+        assert self.auth.is_equals(password, model.get("password", ""))
 
     def test_create_first_and_last_name(self) -> None:
         response = self.request(

--- a/tests/system/action/user/test_generate_new_password.py
+++ b/tests/system/action/user/test_generate_new_password.py
@@ -1,3 +1,4 @@
+from openslides_backend.action.util.crypto import PASSWORD_CHARS
 from openslides_backend.permissions.management_levels import OrganizationManagementLevel
 from tests.system.action.base import BaseActionTestCase
 
@@ -10,10 +11,10 @@ class UserGenerateNewPasswordActionTest(ScopePermissionsTestMixin, BaseActionTes
         response = self.request("user.generate_new_password", {"id": 1})
         self.assert_status_code(response, 200)
         model = self.get_model("user/1")
-        assert model.get("password") is not None
-        assert self.auth.is_equals(
-            model.get("default_password", ""), model.get("password", "")
-        )
+        assert (hash := model.get("password")) is not None
+        assert (password := model.get("default_password")) is not None
+        assert all(char in PASSWORD_CHARS for char in password)
+        assert self.auth.is_equals(password, hash)
 
     def test_scope_meeting_no_permission(self) -> None:
         self.setup_admin_scope_permissions(None)


### PR DESCRIPTION
fixes #1734 

Removed the following chars from the list of possible password chars: `lIOQ01`

See also https://www.grc.com/ppp.htm