### PR TITLE
Add uniqueness checks to `external_id` fields

### DIFF
--- a/global/meta/models.yml
+++ b/global/meta/models.yml
@@ -688,7 +688,7 @@ committee:
   external_id:
     type: string
     restriction_mode: A
-
+    description: unique
   meeting_ids:
     type: relation-list
     to: meeting/committee_id
@@ -745,6 +745,7 @@ meeting:
   external_id:
     type: string
     restriction_mode: A
+    description: unique in committee
   welcome_title:
     type: string
     default: Welcome to OpenSlides
@@ -1703,6 +1704,7 @@ group:
   external_id:
     type: string
     restriction_mode: A
+    description: unique in meeting
   name:
     type: string
     required: true

--- a/openslides_backend/action/actions/committee/committee_common_mixin.py
+++ b/openslides_backend/action/actions/committee/committee_common_mixin.py
@@ -1,10 +1,16 @@
 from typing import Any, Dict
 
+from openslides_backend.action.mixins.check_unique_name_mixin import (
+    CheckUniqueInContextMixin,
+)
+
 from ....action.mixins.archived_meeting_check_mixin import CheckForArchivedMeetingMixin
 from ....shared.exceptions import ActionException
 
 
-class CommitteeCommonCreateUpdateMixin(CheckForArchivedMeetingMixin):
+class CommitteeCommonCreateUpdateMixin(
+    CheckUniqueInContextMixin, CheckForArchivedMeetingMixin
+):
     def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
         """
         Check if own committee is forwarded or received explicitly,
@@ -24,3 +30,9 @@ class CommitteeCommonCreateUpdateMixin(CheckForArchivedMeetingMixin):
                 "Forwarding or receiving to/from own must be configured in both directions!"
             )
         return instance
+
+    def validate_instance(self, instance: Dict[str, Any]) -> None:
+        super().validate_instance(instance)
+        if "external_id" in instance:
+            text = "The external_id of the committee is not unique."
+            self.check_unique_in_context("external_id", instance["external_id"], text)

--- a/openslides_backend/action/actions/committee/committee_common_mixin.py
+++ b/openslides_backend/action/actions/committee/committee_common_mixin.py
@@ -34,5 +34,9 @@ class CommitteeCommonCreateUpdateMixin(
     def validate_instance(self, instance: Dict[str, Any]) -> None:
         super().validate_instance(instance)
         if "external_id" in instance:
-            text = "The external_id of the committee is not unique."
-            self.check_unique_in_context("external_id", instance["external_id"], text)
+            self.check_unique_in_context(
+                "external_id",
+                instance["external_id"],
+                "The external_id of the committee is not unique.",
+                instance.get("id"),
+            )

--- a/openslides_backend/action/actions/group/group_mixin.py
+++ b/openslides_backend/action/actions/group/group_mixin.py
@@ -1,12 +1,30 @@
 from typing import Any, Dict
 
+from openslides_backend.action.mixins.check_unique_name_mixin import (
+    CheckUniqueInContextMixin,
+)
 from openslides_backend.shared.exceptions import PermissionDenied
 
 from ....permissions.permission_helper import is_admin
 from ...action import Action
 
 
-class GroupMixin(Action):
+class GroupMixin(CheckUniqueInContextMixin, Action):
+    check_unique_error_text = (
+        "The external_id of the group is not unique in the meeting scope."
+    )
+
+    def validate_instance(self, instance: Dict[str, Any]) -> None:
+        super().validate_instance(instance)
+        if "external_id" in instance:
+            self.check_unique_in_context(
+                "external_id",
+                instance["external_id"],
+                self.__class__.check_unique_error_text,
+                "meeting_id",
+                self.get_meeting_id(instance),
+            )
+
     def check_permissions(self, instance: Dict[str, Any]) -> None:
         super().check_permissions(instance)
         # external id is only allowed for admins

--- a/openslides_backend/action/actions/group/group_mixin.py
+++ b/openslides_backend/action/actions/group/group_mixin.py
@@ -10,17 +10,14 @@ from ...action import Action
 
 
 class GroupMixin(CheckUniqueInContextMixin, Action):
-    check_unique_error_text = (
-        "The external_id of the group is not unique in the meeting scope."
-    )
-
     def validate_instance(self, instance: Dict[str, Any]) -> None:
         super().validate_instance(instance)
         if "external_id" in instance:
             self.check_unique_in_context(
                 "external_id",
                 instance["external_id"],
-                self.__class__.check_unique_error_text,
+                "The external_id of the group is not unique in the meeting scope.",
+                instance.get("id"),
                 "meeting_id",
                 self.get_meeting_id(instance),
             )

--- a/openslides_backend/action/actions/meeting/create.py
+++ b/openslides_backend/action/actions/meeting/create.py
@@ -73,9 +73,6 @@ class MeetingCreate(
         "users_email_subject",
         "users_email_body",
     ]
-    check_unique_error_text = (
-        "The external_id of the meeting is not unique in the committee scope."
-    )
 
     def validate_instance(self, instance: Dict[str, Any]) -> None:
         super().validate_instance(instance)
@@ -83,7 +80,8 @@ class MeetingCreate(
             self.check_unique_in_context(
                 "external_id",
                 instance["external_id"],
-                self.__class__.check_unique_error_text,
+                "The external_id of the meeting is not unique in the committee scope.",
+                None,
                 "committee_id",
                 instance["committee_id"],
             )

--- a/openslides_backend/action/actions/meeting/update.py
+++ b/openslides_backend/action/actions/meeting/update.py
@@ -309,10 +309,10 @@ class MeetingUpdate(
                 raise MissingPermission(OrganizationManagementLevel.SUPERADMIN)
 
     def get_committee_id(self, meeting_id: int) -> int:
-        if not hasattr(self, "__committee_id"):
-            self.__committee_id = self.datastore.get(
+        if not hasattr(self, "_committee_id"):
+            self._committee_id = self.datastore.get(
                 fqid_from_collection_and_id(self.model.collection, meeting_id),
                 ["committee_id"],
                 lock_result=False,
             )["committee_id"]
-        return self.__committee_id
+        return self._committee_id

--- a/openslides_backend/action/actions/meeting/update.py
+++ b/openslides_backend/action/actions/meeting/update.py
@@ -177,9 +177,6 @@ class MeetingUpdate(
         },
     )
     check_email_field = "users_email_replyto"
-    check_unique_error_text = (
-        "The external_id of the meeting is not unique in the committee scope."
-    )
 
     def validate_instance(self, instance: Dict[str, Any]) -> None:
         super().validate_instance(instance)
@@ -187,7 +184,8 @@ class MeetingUpdate(
             self.check_unique_in_context(
                 "external_id",
                 instance["external_id"],
-                self.__class__.check_unique_error_text,
+                "The external_id of the meeting is not unique in the committee scope.",
+                instance["id"],
                 "committee_id",
                 self.get_committee_id(instance["id"]),
             )
@@ -316,5 +314,5 @@ class MeetingUpdate(
                 fqid_from_collection_and_id(self.model.collection, meeting_id),
                 ["committee_id"],
                 lock_result=False,
-            ).get("committee_id", 0)
+            )["committee_id"]
         return self.__committee_id

--- a/openslides_backend/action/mixins/check_unique_name_mixin.py
+++ b/openslides_backend/action/mixins/check_unique_name_mixin.py
@@ -1,0 +1,34 @@
+from openslides_backend.action.action import Action
+from openslides_backend.shared.exceptions import ActionException
+from openslides_backend.shared.filters import And, FilterOperator
+
+
+class CheckUniqueInContextMixin(Action):
+    def check_unique_in_context(
+        self,
+        unique_name: str,
+        unique_value: str,
+        exception_message: str,
+        context_name: str = "",
+        context_id: int = 0,
+    ) -> None:
+        """
+        checks uniqueness of a string_value in context, i.e. in meeting, committee or organisation
+        Leave context_name empty to look without context
+        """
+        if context_name:
+            name_exists = self.datastore.exists(
+                self.model.collection,
+                And(
+                    FilterOperator(unique_name, "=", unique_value),
+                    FilterOperator(context_name, "=", context_id),
+                ),
+            )
+        else:
+            name_exists = self.datastore.exists(
+                self.model.collection,
+                FilterOperator(unique_name, "=", unique_value),
+            )
+
+        if name_exists:
+            raise ActionException(exception_message)

--- a/openslides_backend/action/mixins/check_unique_name_mixin.py
+++ b/openslides_backend/action/mixins/check_unique_name_mixin.py
@@ -1,6 +1,8 @@
+from typing import Optional
+
 from openslides_backend.action.action import Action
 from openslides_backend.shared.exceptions import ActionException
-from openslides_backend.shared.filters import And, FilterOperator
+from openslides_backend.shared.filters import And, Filter, FilterOperator, Not
 
 
 class CheckUniqueInContextMixin(Action):
@@ -9,6 +11,7 @@ class CheckUniqueInContextMixin(Action):
         unique_name: str,
         unique_value: str,
         exception_message: str,
+        self_id: Optional[int] = None,
         context_name: str = "",
         context_id: int = 0,
     ) -> None:
@@ -16,19 +19,19 @@ class CheckUniqueInContextMixin(Action):
         checks uniqueness of a string_value in context, i.e. in meeting, committee or organisation
         Leave context_name empty to look without context
         """
+        filter: Filter = FilterOperator(unique_name, "=", unique_value)
         if context_name:
-            name_exists = self.datastore.exists(
-                self.model.collection,
-                And(
-                    FilterOperator(unique_name, "=", unique_value),
-                    FilterOperator(context_name, "=", context_id),
-                ),
+            filter = And(
+                filter,
+                FilterOperator(context_name, "=", context_id),
             )
-        else:
-            name_exists = self.datastore.exists(
-                self.model.collection,
-                FilterOperator(unique_name, "=", unique_value),
-            )
+        if self_id:
+            filter = And(filter, Not(FilterOperator("id", "=", self_id)))
+
+        name_exists = self.datastore.exists(
+            self.model.collection,
+            filter,
+        )
 
         if name_exists:
             raise ActionException(exception_message)

--- a/openslides_backend/action/mixins/check_unique_name_mixin.py
+++ b/openslides_backend/action/mixins/check_unique_name_mixin.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from openslides_backend.action.action import Action
 from openslides_backend.shared.exceptions import ActionException
-from openslides_backend.shared.filters import And, Filter, FilterOperator, Not
+from openslides_backend.shared.filters import And, Filter, FilterOperator
 
 
 class CheckUniqueInContextMixin(Action):
@@ -18,7 +18,7 @@ class CheckUniqueInContextMixin(Action):
         """
         checks uniqueness of a string_value in context, i.e. in meeting, committee or organisation
         Leave context_name empty to look without context. On case of update put the id of your object
-        to self_id to excude the object itself from search.
+        to self_id to exclude the object itself from search.
         """
         filter: Filter = FilterOperator(unique_name, "=", unique_value)
         if context_name:

--- a/openslides_backend/action/mixins/check_unique_name_mixin.py
+++ b/openslides_backend/action/mixins/check_unique_name_mixin.py
@@ -17,7 +17,8 @@ class CheckUniqueInContextMixin(Action):
     ) -> None:
         """
         checks uniqueness of a string_value in context, i.e. in meeting, committee or organisation
-        Leave context_name empty to look without context
+        Leave context_name empty to look without context. On case of update put the id of your object
+        to self_id to excude the object itself from search.
         """
         filter: Filter = FilterOperator(unique_name, "=", unique_value)
         if context_name:
@@ -26,7 +27,7 @@ class CheckUniqueInContextMixin(Action):
                 FilterOperator(context_name, "=", context_id),
             )
         if self_id:
-            filter = And(filter, Not(FilterOperator("id", "=", self_id)))
+            filter = And(filter, FilterOperator("id", "!=", self_id))
 
         name_exists = self.datastore.exists(
             self.model.collection,

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -3,7 +3,7 @@
 from openslides_backend.models import fields
 from openslides_backend.models.base import Model
 
-MODELS_YML_CHECKSUM = "c7b0deee8f8e4f5841dcb490c90c8781"
+MODELS_YML_CHECKSUM = "4926667fbf41432ca0957342eb309f5a"
 
 
 class Organization(Model):
@@ -308,7 +308,7 @@ class Committee(Model):
     id = fields.IntegerField()
     name = fields.CharField(required=True)
     description = fields.HTMLStrictField()
-    external_id = fields.CharField()
+    external_id = fields.CharField(constraints={"description": "unique"})
     meeting_ids = fields.RelationListField(
         to={"meeting": "committee_id"}, on_delete=fields.OnDelete.PROTECT
     )
@@ -345,7 +345,7 @@ class Meeting(Model):
     verbose_name = "meeting"
 
     id = fields.IntegerField()
-    external_id = fields.CharField()
+    external_id = fields.CharField(constraints={"description": "unique in committee"})
     welcome_title = fields.CharField(default="Welcome to OpenSlides")
     welcome_text = fields.HTMLPermissiveField(default="Space for your welcome text.")
     name = fields.CharField(
@@ -785,7 +785,7 @@ class Group(Model):
     verbose_name = "group"
 
     id = fields.IntegerField()
-    external_id = fields.CharField()
+    external_id = fields.CharField(constraints={"description": "unique in meeting"})
     name = fields.CharField(required=True)
     permissions = fields.CharArrayField(
         in_array_constraints={

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -3,7 +3,7 @@
 from openslides_backend.models import fields
 from openslides_backend.models.base import Model
 
-MODELS_YML_CHECKSUM = "c7b0deee8f8e4f5841dcb490c90c8781"
+MODELS_YML_CHECKSUM = "291a6452dcb76d06930a5b8bf5d728ed"
 
 
 class Organization(Model):
@@ -11,6 +11,7 @@ class Organization(Model):
     verbose_name = "organization"
 
     id = fields.IntegerField()
+    external_id = fields.CharField()
     name = fields.CharField()
     description = fields.HTMLStrictField()
     legal_notice = fields.TextField()

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -3,7 +3,7 @@
 from openslides_backend.models import fields
 from openslides_backend.models.base import Model
 
-MODELS_YML_CHECKSUM = "291a6452dcb76d06930a5b8bf5d728ed"
+MODELS_YML_CHECKSUM = "c7b0deee8f8e4f5841dcb490c90c8781"
 
 
 class Organization(Model):
@@ -11,7 +11,6 @@ class Organization(Model):
     verbose_name = "organization"
 
     id = fields.IntegerField()
-    external_id = fields.CharField()
     name = fields.CharField()
     description = fields.HTMLStrictField()
     legal_notice = fields.TextField()

--- a/tests/system/action/committee/test_create.py
+++ b/tests/system/action/committee/test_create.py
@@ -366,3 +366,29 @@ class CommitteeCreateActionTest(BaseActionTestCase):
             "user/1",
             {"committee_$can_manage_management_level": [2], "committee_ids": [2]},
         )
+
+    def test_create_external_id_not_unique(self) -> None:
+        external_id = "external"
+        self.set_models(
+            {
+                ONE_ORGANIZATION_FQID: {"name": "test_organization1"},
+                "committee/1": {
+                    "organization_id": 1,
+                    "name": "c1",
+                    "external_id": external_id,
+                },
+            }
+        )
+
+        response = self.request(
+            "committee.create",
+            {
+                "name": "committee_name",
+                "organization_id": 1,
+                "external_id": external_id,
+            },
+        )
+        self.assert_status_code(response, 400)
+        self.assertIn(
+            "The external_id of the committee is not unique.", response.json["message"]
+        )

--- a/tests/system/action/committee/test_update.py
+++ b/tests/system/action/committee/test_update.py
@@ -71,11 +71,13 @@ class CommitteeUpdateActionTest(BaseActionTestCase):
         self.assertEqual(model.get("name"), new_name)
 
     def test_update_everything_correct(self) -> None:
-        self.create_data()
-        self.create_meetings_with_users()
         new_name = "committee_testname_updated"
         new_description = "<p>New Test description</p>"
         external_id = "external"
+
+        self.create_data()
+        self.update_model(self.COMMITTEE_FQID, {"external_id": external_id})
+        self.create_meetings_with_users()
 
         response = self.request(
             "committee.update",

--- a/tests/system/action/committee/test_update.py
+++ b/tests/system/action/committee/test_update.py
@@ -860,3 +860,32 @@ class CommitteeUpdateActionTest(BaseActionTestCase):
                 "committee_$can_manage_management_level": [2],
             },
         )
+
+    def test_update_external_id_not_unique(self) -> None:
+        external_id = "external"
+        self.set_models(
+            {
+                ONE_ORGANIZATION_FQID: {"name": "test_organization1"},
+                "committee/1": {
+                    "organization_id": 1,
+                    "name": "c1",
+                    "external_id": external_id,
+                },
+                "committee/2": {
+                    "organization_id": 1,
+                    "name": "c2",
+                },
+            }
+        )
+
+        response = self.request(
+            "committee.update",
+            {
+                "id": 2,
+                "external_id": external_id,
+            },
+        )
+        self.assert_status_code(response, 400)
+        self.assertIn(
+            "The external_id of the committee is not unique.", response.json["message"]
+        )

--- a/tests/system/action/group/test_create.py
+++ b/tests/system/action/group/test_create.py
@@ -227,3 +227,30 @@ class GroupCreateActionTest(BaseActionTestCase):
         self.assert_model_exists(
             "group/4", {"external_id": "test", "name": "test_name", "meeting_id": 22}
         )
+
+    def test_create_external_id_not_unique(self) -> None:
+        external_id = "external_id"
+        self.set_models(
+            {
+                "meeting/22": {
+                    "name": "name_vJxebUwo",
+                    "admin_group_id": 3,
+                    "is_active_in_organization_id": 1,
+                },
+                "group/3": {
+                    "name": "test",
+                    "admin_group_for_meeting_id": 22,
+                    "meeting_id": 22,
+                    "external_id": external_id,
+                },
+            }
+        )
+        response = self.request(
+            "group.create",
+            {"name": "test_name", "external_id": external_id, "meeting_id": 22},
+        )
+        self.assert_status_code(response, 400)
+        self.assertIn(
+            "The external_id of the group is not unique in the meeting scope.",
+            response.json["message"],
+        )

--- a/tests/system/action/group/test_update.py
+++ b/tests/system/action/group/test_update.py
@@ -77,6 +77,17 @@ class GroupUpdateActionTest(BaseActionTestCase):
             response.json["message"],
         )
 
+    def test_update_external_id_self(self) -> None:
+        external_id = "external_id"
+        self.update_model("group/2", {"external_id": external_id, "name": "group2"})
+        response = self.request(
+            "group.update", {"id": 2, "external_id": external_id, "name": "grp2"}
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "group/2", {"external_id": external_id, "name": "grp2"}
+        )
+
     def test_update_forbidden(self) -> None:
         self.base_permission_test(
             {},

--- a/tests/system/action/group/test_update.py
+++ b/tests/system/action/group/test_update.py
@@ -67,6 +67,16 @@ class GroupUpdateActionTest(BaseActionTestCase):
         response = self.request("group.update", {"id": 3, "external_id": "test"})
         self.assert_status_code(response, 200)
 
+    def test_update_external_id_not_unique(self) -> None:
+        external_id = "external_id"
+        self.update_model("group/2", {"external_id": external_id})
+        response = self.request("group.update", {"id": 3, "external_id": external_id})
+        self.assert_status_code(response, 400)
+        self.assertIn(
+            "The external_id of the group is not unique in the meeting scope.",
+            response.json["message"],
+        )
+
     def test_update_forbidden(self) -> None:
         self.base_permission_test(
             {},

--- a/tests/system/action/meeting/test_create.py
+++ b/tests/system/action/meeting/test_create.py
@@ -444,3 +444,25 @@ class MeetingCreateActionTest(BaseActionTestCase):
         self.assert_status_code(response, 200)
         Translator.set_translation_language("de")
         self.assert_model_exists("group/2", {"name": _("Default")})
+
+    def test_create_external_id_not_unique(self) -> None:
+        external_id = "external"
+        self.set_models(
+            {
+                "meeting/1": {"committee_id": 1, "external_id": external_id},
+            }
+        )
+        response = self.request(
+            "meeting.create",
+            {
+                "name": "meeting2",
+                "committee_id": 1,
+                "language": "pt",
+                "external_id": external_id,
+            },
+        )
+        self.assert_status_code(response, 400)
+        self.assertIn(
+            "The external_id of the meeting is not unique in the committee scope.",
+            response.json["message"],
+        )

--- a/tests/system/action/meeting/test_update.py
+++ b/tests/system/action/meeting/test_update.py
@@ -646,7 +646,7 @@ class MeetingUpdateActionTest(BaseActionTestCase):
             "meeting.update",
             {
                 "id": 1,
-                "external_id": external_id,
+                "external_id": external_id, "organization_tag_ids": []
             },
         )
         self.assert_status_code(response, 200)

--- a/tests/system/action/meeting/test_update.py
+++ b/tests/system/action/meeting/test_update.py
@@ -630,3 +630,23 @@ class MeetingUpdateActionTest(BaseActionTestCase):
             "The external_id of the meeting is not unique in the committee scope.",
             response.json["message"],
         )
+
+    def test_update_external_id_self(self) -> None:
+        external_id = "external"
+        self.set_models(
+            {
+                "meeting/1": {
+                    "committee_id": 1,
+                    "external_id": external_id,
+                    "is_active_in_organization_id": 1,
+                },
+            }
+        )
+        response = self.request(
+            "meeting.update",
+            {
+                "id": 1,
+                "external_id": external_id,
+            },
+        )
+        self.assert_status_code(response, 200)

--- a/tests/system/action/meeting/test_update.py
+++ b/tests/system/action/meeting/test_update.py
@@ -642,11 +642,5 @@ class MeetingUpdateActionTest(BaseActionTestCase):
                 },
             }
         )
-        response = self.request(
-            "meeting.update",
-            {
-                "id": 1,
-                "external_id": external_id, "organization_tag_ids": []
-            },
-        )
+        response = self.request("meeting.update", {"id": 1, "external_id": external_id})
         self.assert_status_code(response, 200)

--- a/tests/system/action/meeting/test_update.py
+++ b/tests/system/action/meeting/test_update.py
@@ -609,3 +609,24 @@ class MeetingUpdateActionTest(BaseActionTestCase):
             "It is not allowed to end jitsi_domain with '/'."
             in response.json["message"]
         )
+
+    def test_update_external_id_not_unique(self) -> None:
+        external_id = "external"
+        self.set_models(
+            {
+                "meeting/1": {"committee_id": 1, "external_id": external_id},
+                "meeting/2": {"committee_id": 1},
+            }
+        )
+        response = self.request(
+            "meeting.update",
+            {
+                "id": 2,
+                "external_id": external_id,
+            },
+        )
+        self.assert_status_code(response, 400)
+        self.assertIn(
+            "The external_id of the meeting is not unique in the committee scope.",
+            response.json["message"],
+        )


### PR DESCRIPTION
Original PR was merged, but there should be made some checks for uniqueness of external_id in scope of meeting for group, committee for meeting and organization for committee.external_id