### PR TITLE
Set new env vars for auth service

### DIFF
--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -77,6 +77,8 @@ services:
         ports:
             - "9004:9004"
         environment:
+            - ACTION_HOST=backend
+            - ACTION_PORT=9002
             - MESSAGE_BUS_HOST=redis
             - CACHE_HOST=redis
             - DATASTORE_READER_HOST=datastore-reader


### PR DESCRIPTION
Missing ACTION_HOST and ACTION_PORT the auth sevice in backend development doesn't come up.