### PR TITLE
[feature/remove-template-fields] Fix base permission test

### DIFF
--- a/tests/system/action/base.py
+++ b/tests/system/action/base.py
@@ -281,7 +281,7 @@ class BaseActionTestCase(BaseSystemTestCase):
                 GetManyRequest(
                     "group",
                     group_ids,
-                    ["id", "meeting_id", "user_ids", "meeting_user_ids"],
+                    ["id", "meeting_id", "meeting_user_ids"],
                 )
             ],
             lock_result=False,
@@ -395,6 +395,8 @@ class BaseActionTestCase(BaseSystemTestCase):
         self.create_meeting()
         self.user_id = self.create_user("user")
         self.login(self.user_id)
+        if models:
+            self.set_models(models)
         self.set_user_groups(self.user_id, [3])
         if permission:
             if type(permission) == OrganizationManagementLevel:
@@ -403,8 +405,6 @@ class BaseActionTestCase(BaseSystemTestCase):
                 )
             else:
                 self.set_group_permissions(3, [cast(Permission, permission)])
-        if models:
-            self.set_models(models)
         response = self.request(action, action_data)
         if permission:
             self.assert_status_code(response, 200)

--- a/tests/system/action/motion/test_update.py
+++ b/tests/system/action/motion/test_update.py
@@ -482,7 +482,7 @@ class MotionUpdateActionTest(BaseActionTestCase):
                 "title": "title_bDFsWtKL",
                 "text": "text_eNPkDVuq",
                 "reason": "reason_ukWqADfE",
-                # TODO "created": 1686735327,
+                "created": 1686735327,
             },
             Permissions.Motion.CAN_MANAGE,
         )


### PR DESCRIPTION
reason of the error: the set_models after the set_user_groups destroyed the meeting_user data