### PR TITLE
Allow to set agenda item tags with agenda_tag_ids

### DIFF
--- a/global/meta/models.yml
+++ b/global/meta/models.yml
@@ -1894,7 +1894,6 @@ tag:
         - agenda_item
         - assignment
         - motion
-        - topic
       field: tag_ids
     equal_fields: meeting_id
     restriction_mode: A
@@ -2148,11 +2147,6 @@ topic:
     to: list_of_speakers/content_object_id
     required: true
     on_delete: CASCADE
-    equal_fields: meeting_id
-    restriction_mode: A
-  tag_ids:
-    type: relation-list
-    to: tag/tagged_ids
     equal_fields: meeting_id
     restriction_mode: A
   poll_ids:

--- a/openslides_backend/action/actions/agenda_item/agenda_creation.py
+++ b/openslides_backend/action/actions/agenda_item/agenda_creation.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Type
 
 from ....models.models import AgendaItem
 from ....shared.patterns import fqid_from_collection_and_id
-from ....shared.schema import optional_id_schema
+from ....shared.schema import id_list_schema, optional_id_schema
 from ...action import Action
 
 AGENDA_PREFIX = "agenda_"
@@ -37,6 +37,10 @@ agenda_creation_properties = {
     f"{AGENDA_PREFIX}weight": {
         "description": "The weight of the agenda item.",
         "type": "integer",
+    },
+    f"{AGENDA_PREFIX}tag_ids": {
+        "description": "The ids of tags to be set.",
+        **id_list_schema,
     },
 }
 

--- a/openslides_backend/action/actions/agenda_item/create.py
+++ b/openslides_backend/action/actions/agenda_item/create.py
@@ -27,6 +27,7 @@ class AgendaItemCreate(CreateActionWithInferredMeeting):
             "parent_id",
             "duration",
             "weight",
+            "tag_ids",
         ],
     )
     permission = Permissions.AgendaItem.CAN_MANAGE

--- a/openslides_backend/action/actions/topic/create.py
+++ b/openslides_backend/action/actions/topic/create.py
@@ -32,7 +32,7 @@ class TopicCreate(
     model = Topic()
     schema = DefaultSchema(Topic()).get_create_schema(
         required_properties=["meeting_id", "title"],
-        optional_properties=["text", "attachment_ids", "tag_ids"],
+        optional_properties=["text", "attachment_ids"],
         additional_optional_fields=agenda_creation_properties,
     )
     dependencies = [AgendaItemCreate, ListOfSpeakersCreate]

--- a/openslides_backend/action/actions/topic/update.py
+++ b/openslides_backend/action/actions/topic/update.py
@@ -13,6 +13,6 @@ class TopicUpdate(UpdateAction):
 
     model = Topic()
     schema = DefaultSchema(Topic()).get_update_schema(
-        optional_properties=["title", "text", "attachment_ids", "tag_ids"]
+        optional_properties=["title", "text", "attachment_ids"]
     )
     permission = Permissions.AgendaItem.CAN_MANAGE

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -3,7 +3,7 @@
 from openslides_backend.models import fields
 from openslides_backend.models.base import Model
 
-MODELS_YML_CHECKSUM = "dea25af9a336309f96f7ccb9eca61cb9"
+MODELS_YML_CHECKSUM = "4ee1bccdf2ec2a8d19562e1e4d4b18b2"
 
 
 class Organization(Model):
@@ -905,12 +905,7 @@ class Tag(Model):
     id = fields.IntegerField()
     name = fields.CharField(required=True)
     tagged_ids = fields.GenericRelationListField(
-        to={
-            "agenda_item": "tag_ids",
-            "assignment": "tag_ids",
-            "motion": "tag_ids",
-            "topic": "tag_ids",
-        },
+        to={"agenda_item": "tag_ids", "assignment": "tag_ids", "motion": "tag_ids"},
         equal_fields="meeting_id",
     )
     meeting_id = fields.RelationField(to={"meeting": "tag_ids"}, required=True)
@@ -1078,9 +1073,6 @@ class Topic(Model):
         on_delete=fields.OnDelete.CASCADE,
         required=True,
         equal_fields="meeting_id",
-    )
-    tag_ids = fields.RelationListField(
-        to={"tag": "tagged_ids"}, equal_fields="meeting_id"
     )
     poll_ids = fields.RelationListField(
         to={"poll": "content_object_id"},

--- a/tests/system/action/agenda_item/test_create.py
+++ b/tests/system/action/agenda_item/test_create.py
@@ -33,6 +33,7 @@ class AgendaItemSystemTest(BaseActionTestCase):
                 "meeting/1": {"is_active_in_organization_id": 1},
                 "topic/1": {"meeting_id": 1},
                 "agenda_item/42": {"comment": "test", "meeting_id": 1},
+                "tag/561": {"meeting_id": 1},
             }
         )
         response = self.request(
@@ -43,6 +44,7 @@ class AgendaItemSystemTest(BaseActionTestCase):
                 "type": AgendaItem.INTERNAL_ITEM,
                 "parent_id": 42,
                 "duration": 360,
+                "tag_ids": [561],
             },
         )
         self.assert_status_code(response, 200)
@@ -54,6 +56,10 @@ class AgendaItemSystemTest(BaseActionTestCase):
         self.assertEqual(agenda_item["weight"], 1)
         self.assertFalse(agenda_item.get("closed"))
         assert agenda_item.get("level") == 1
+        assert agenda_item.get("tag_ids") == [561]
+        self.assert_model_exists(
+            "tag/561", {"meeting_id": 1, "tagged_ids": ["agenda_item/43"]}
+        )
 
     def test_create_twice_without_parent(self) -> None:
         self.set_models(

--- a/tests/system/action/agenda_item/test_update.py
+++ b/tests/system/action/agenda_item/test_update.py
@@ -84,6 +84,50 @@ class AgendaItemActionTest(BaseActionTestCase):
         assert child_model.get("is_hidden") is True
         assert child_model.get("is_internal") is False
 
+    def test_update_tag_ids_add(self) -> None:
+        self.set_models(
+            {
+                "meeting/1": {"name": "test", "is_active_in_organization_id": 1},
+                "agenda_item/1": {"comment": "test", "meeting_id": 1},
+                "tag/1": {"name": "tag", "meeting_id": 1},
+            }
+        )
+        response = self.request("agenda_item.update", {"id": 1, "tag_ids": [1]})
+        self.assert_status_code(response, 200)
+        agenda_item = self.get_model("agenda_item/1")
+        self.assertEqual(agenda_item.get("tag_ids"), [1])
+
+    def test_update_tag_ids_remove(self) -> None:
+        self.test_update_tag_ids_add()
+        response = self.request("agenda_item.update", {"id": 1, "tag_ids": []})
+        self.assert_status_code(response, 200)
+        agenda_item = self.get_model("agenda_item/1")
+        self.assertEqual(agenda_item.get("tag_ids"), [])
+
+    def test_update_multiple_with_tag(self) -> None:
+        self.set_models(
+            {
+                "meeting/1": {"name": "test", "is_active_in_organization_id": 1},
+                "tag/1": {
+                    "name": "tag",
+                    "meeting_id": 1,
+                    "tagged_ids": ["agenda_item/1", "agenda_item/2"],
+                },
+                "agenda_item/1": {"comment": "test", "meeting_id": 1, "tag_ids": [1]},
+                "agenda_item/2": {"comment": "test", "meeting_id": 1, "tag_ids": [1]},
+            }
+        )
+        response = self.request_multi(
+            "agenda_item.update", [{"id": 1, "tag_ids": []}, {"id": 2, "tag_ids": []}]
+        )
+        self.assert_status_code(response, 200)
+        agenda_item = self.get_model("agenda_item/1")
+        self.assertEqual(agenda_item.get("tag_ids"), [])
+        agenda_item = self.get_model("agenda_item/2")
+        self.assertEqual(agenda_item.get("tag_ids"), [])
+        tag = self.get_model("tag/1")
+        self.assertEqual(tag.get("tagged_ids"), [])
+
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
             {

--- a/tests/system/action/tag/test_delete.py
+++ b/tests/system/action/tag/test_delete.py
@@ -31,20 +31,24 @@ class TagDeleteTest(BaseActionTestCase):
                 "tag/111": {
                     "name": "name_srtgb123",
                     "meeting_id": 1,
-                    "tagged_ids": ["topic/222"],
+                    "tagged_ids": ["agenda_item/222"],
                 },
-                "topic/222": {"title": "test_title_ertgd590854398", "tag_ids": [111]},
+                "agenda_item/222": {
+                    "comment": "test_comment_ertgd590854398",
+                    "tag_ids": [111],
+                    "meeting_id": 1,
+                },
             }
         )
         response = self.request("tag.delete", {"id": 111})
         self.assert_status_code(response, 200)
         self.assert_model_not_exists("tag/112")
         self.assert_model_exists(
-            "topic/222",
+            "agenda_item/222",
             {
                 "id": 222,
                 "meta_deleted": False,
-                "title": "test_title_ertgd590854398",
+                "comment": "test_comment_ertgd590854398",
                 "tag_ids": [],
             },
         )

--- a/tests/system/action/topic/test_create.py
+++ b/tests/system/action/topic/test_create.py
@@ -67,8 +67,11 @@ class TopicCreateSystemTest(BaseActionTestCase):
         self.assert_model_not_exists("topic/4")
 
     def test_create_more_fields(self) -> None:
-        self.create_model(
-            "meeting/1", {"name": "test", "is_active_in_organization_id": 1}
+        self.set_models(
+            {
+                "meeting/1": {"name": "test", "is_active_in_organization_id": 1},
+                "tag/37": {"meeting_id": 1},
+            }
         )
         response = self.request(
             "topic.create",
@@ -77,6 +80,7 @@ class TopicCreateSystemTest(BaseActionTestCase):
                 "title": "test",
                 "agenda_type": AgendaItem.INTERNAL_ITEM,
                 "agenda_duration": 60,
+                "agenda_tag_ids": [37],
             },
         )
         self.assert_status_code(response, 200)
@@ -91,6 +95,10 @@ class TopicCreateSystemTest(BaseActionTestCase):
         self.assertEqual(agenda_item["type"], AgendaItem.INTERNAL_ITEM)
         self.assertEqual(agenda_item["duration"], 60)
         self.assertEqual(agenda_item["weight"], 1)
+        self.assertEqual(agenda_item["tag_ids"], [37])
+        self.assert_model_exists(
+            "tag/37", {"meeting_id": 1, "tagged_ids": ["agenda_item/1"]}
+        )
 
     def test_create_multiple_in_one_request(self) -> None:
         self.create_model("meeting/1", {"is_active_in_organization_id": 1})
@@ -158,47 +166,6 @@ class TopicCreateSystemTest(BaseActionTestCase):
         self.assertEqual(topic.get("sequential_number"), 43)
         topic = self.get_model("topic/3")
         self.assertEqual(topic.get("sequential_number"), 44)
-
-    def test_create_meeting_id_tag_ids_mismatch(self) -> None:
-        """Tag 8 is from meeting 8 and a topic for meeting 1 should be created.
-        This should lead to an error."""
-        self.set_models(
-            {
-                "meeting/1": {"is_active_in_organization_id": 1},
-                "meeting/8": {
-                    "is_active_in_organization_id": 1,
-                    "tag_ids": [8],
-                },
-                "tag/8": {"name": "tag8", "meeting_id": 8},
-            }
-        )
-        response = self.request(
-            "topic.create", {"meeting_id": 1, "title": "A", "tag_ids": [8]}
-        )
-        self.assert_status_code(response, 400)
-        assert (
-            "The following models do not belong to meeting 1: ['tag/8']"
-            in response.json["message"]
-        )
-
-    def test_create_with_tag_ids(self) -> None:
-        """Tag 1 is from meeting 1 and a topic for meeting 1 should be created."""
-        self.set_models(
-            {
-                "meeting/1": {"is_active_in_organization_id": 1, "tag_ids": [1]},
-                "tag/1": {"name": "test tag", "meeting_id": 1},
-            }
-        )
-        response = self.request(
-            "topic.create", {"meeting_id": 1, "title": "A", "tag_ids": [1]}
-        )
-        self.assert_status_code(response, 200)
-        self.assert_model_exists(
-            "topic/1", {"meeting_id": 1, "title": "A", "tag_ids": [1]}
-        )
-        self.assert_model_exists(
-            "tag/1", {"meeting_id": 1, "name": "test tag", "tagged_ids": ["topic/1"]}
-        )
 
     def test_create_no_permission(self) -> None:
         self.base_permission_test(

--- a/tests/system/action/topic/test_create.py
+++ b/tests/system/action/topic/test_create.py
@@ -167,6 +167,71 @@ class TopicCreateSystemTest(BaseActionTestCase):
         topic = self.get_model("topic/3")
         self.assertEqual(topic.get("sequential_number"), 44)
 
+    def test_create_meeting_id_agenda_tag_ids_mismatch(self) -> None:
+        """Tag 8 is from meeting 8 and a topic for meeting 1 should be created.
+        This should lead to an error."""
+        self.set_models(
+            {
+                "meeting/1": {"is_active_in_organization_id": 1},
+                "meeting/8": {
+                    "is_active_in_organization_id": 1,
+                    "tag_ids": [8],
+                },
+                "tag/8": {"name": "tag8", "meeting_id": 8},
+            }
+        )
+        response = self.request(
+            "topic.create",
+            {
+                "meeting_id": 1,
+                "title": "A",
+                "agenda_type": AgendaItem.INTERNAL_ITEM,
+                "agenda_duration": 60,
+                "agenda_tag_ids": [8],
+            },
+        )
+        self.assert_status_code(response, 400)
+        assert (
+            "The following models do not belong to meeting 1: ['tag/8']"
+            in response.json["message"]
+        )
+
+    def test_create_with_agenda_tag_ids(self) -> None:
+        """Tag 1 is from meeting 1 and a topic for meeting 1 should be created."""
+        self.set_models(
+            {
+                "meeting/1": {"is_active_in_organization_id": 1, "tag_ids": [1]},
+                "tag/1": {"name": "test tag", "meeting_id": 1},
+            }
+        )
+        response = self.request(
+            "topic.create",
+            {
+                "meeting_id": 1,
+                "title": "A",
+                "agenda_type": AgendaItem.INTERNAL_ITEM,
+                "agenda_duration": 60,
+                "agenda_tag_ids": [1],
+            },
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "topic/1", {"meeting_id": 1, "title": "A", "agenda_item_id": 1}
+        )
+        self.assert_model_exists(
+            "agenda_item/1",
+            {
+                "meeting_id": 1,
+                "type": AgendaItem.INTERNAL_ITEM,
+                "duration": 60,
+                "tag_ids": [1],
+            },
+        )
+        self.assert_model_exists(
+            "tag/1",
+            {"meeting_id": 1, "name": "test tag", "tagged_ids": ["agenda_item/1"]},
+        )
+
     def test_create_no_permission(self) -> None:
         self.base_permission_test(
             {}, "topic.create", {"meeting_id": 1, "title": "test"}

--- a/tests/system/action/topic/test_update.py
+++ b/tests/system/action/topic/test_update.py
@@ -45,50 +45,6 @@ class TopicUpdateTest(BaseActionTestCase):
             },
         )
 
-    def test_update_tag_ids_add(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {"name": "test", "is_active_in_organization_id": 1},
-                "topic/1": {"title": "test", "meeting_id": 1},
-                "tag/1": {"name": "tag", "meeting_id": 1},
-            }
-        )
-        response = self.request("topic.update", {"id": 1, "tag_ids": [1]})
-        self.assert_status_code(response, 200)
-        topic = self.get_model("topic/1")
-        self.assertEqual(topic.get("tag_ids"), [1])
-
-    def test_update_tag_ids_remove(self) -> None:
-        self.test_update_tag_ids_add()
-        response = self.request("topic.update", {"id": 1, "tag_ids": []})
-        self.assert_status_code(response, 200)
-        topic = self.get_model("topic/1")
-        self.assertEqual(topic.get("tag_ids"), [])
-
-    def test_update_multiple_with_tag(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {"name": "test", "is_active_in_organization_id": 1},
-                "tag/1": {
-                    "name": "tag",
-                    "meeting_id": 1,
-                    "tagged_ids": ["topic/1", "topic/2"],
-                },
-                "topic/1": {"title": "test", "meeting_id": 1, "tag_ids": [1]},
-                "topic/2": {"title": "test", "meeting_id": 1, "tag_ids": [1]},
-            }
-        )
-        response = self.request_multi(
-            "topic.update", [{"id": 1, "tag_ids": []}, {"id": 2, "tag_ids": []}]
-        )
-        self.assert_status_code(response, 200)
-        topic = self.get_model("topic/1")
-        self.assertEqual(topic.get("tag_ids"), [])
-        topic = self.get_model("topic/2")
-        self.assertEqual(topic.get("tag_ids"), [])
-        tag = self.get_model("tag/1")
-        self.assertEqual(tag.get("tagged_ids"), [])
-
     def test_update_no_permission(self) -> None:
         self.base_permission_test(
             self.permission_test_models,


### PR DESCRIPTION
Remove topic/tag_ids because it is not used in the client.
Update topic.create.