### PR TITLE
Add two options to workflow import

### DIFF
--- a/openslides_backend/action/actions/motion_workflow/import_.py
+++ b/openslides_backend/action/actions/motion_workflow/import_.py
@@ -41,6 +41,8 @@ class MotionWorkflowImport(SequentialNumbersMixin):
                             "show_state_extension_field",
                             "show_recommendation_extension_field",
                             "merge_amendment_into_final",
+                            "set_workflow_timestamp",
+                            "allow_motion_forwarding",
                         ),
                         "next_state_names": str_list_schema,
                         "previous_state_names": str_list_schema,

--- a/tests/system/action/motion_workflow/test_import.py
+++ b/tests/system/action/motion_workflow/test_import.py
@@ -39,7 +39,13 @@ class MotionWorkflowImport(BaseActionTestCase):
                 "name": "test_Xcdfgee",
                 "meeting_id": 42,
                 "first_state_name": "begin",
-                "states": [self.get_state("begin", [], [])],
+                "states": [
+                    {
+                        **self.get_state("begin", [], []),
+                        "set_workflow_timestamp": True,
+                        "allow_motion_forwarding": True,
+                    }
+                ],
             },
         )
         self.assert_status_code(response, 200)
@@ -58,6 +64,8 @@ class MotionWorkflowImport(BaseActionTestCase):
                 "name": "begin",
                 "first_state_of_workflow_id": 1,
                 "weight": 1,
+                "set_workflow_timestamp": True,
+                "allow_motion_forwarding": True,
             },
         )
 

--- a/tests/system/action/motion_workflow/test_import.py
+++ b/tests/system/action/motion_workflow/test_import.py
@@ -26,6 +26,8 @@ class MotionWorkflowImport(BaseActionTestCase):
             "next_state_names": next_state_names,
             "previous_state_names": previous_state_names,
             "weight": weight,
+            "set_workflow_timestamp": True,
+            "allow_motion_forwarding": True,
         }
 
     def test_import_simple_case(self) -> None:
@@ -40,11 +42,7 @@ class MotionWorkflowImport(BaseActionTestCase):
                 "meeting_id": 42,
                 "first_state_name": "begin",
                 "states": [
-                    {
-                        **self.get_state("begin", [], []),
-                        "set_workflow_timestamp": True,
-                        "allow_motion_forwarding": True,
-                    }
+                    self.get_state("begin", [], []),
                 ],
             },
         )


### PR DESCRIPTION
Add the options `set_workflow_timestamp` and `allow_motion_forwarding` to the motion_workflow.import.