### PR TITLE
LOS restrict point of order submission to open lists (#1830)

### DIFF
--- a/global/data/example-data.json
+++ b/global/data/example-data.json
@@ -411,6 +411,7 @@
             "list_of_speakers_show_first_contribution": false,
             "list_of_speakers_enable_point_of_order_speakers": true,
             "list_of_speakers_enable_point_of_order_categories": false,
+            "list_of_speakers_closing_disables_point_of_order": false,
             "list_of_speakers_enable_pro_contra_speech": false,
             "list_of_speakers_can_set_contribution_self": false,
             "list_of_speakers_speaker_note_for_everyone": true,

--- a/global/meta/models.yml
+++ b/global/meta/models.yml
@@ -1051,6 +1051,10 @@ meeting:
     type: boolean
     default: False
     restriction_mode: B
+  list_of_speakers_closing_disables_point_of_order:
+    type: boolean
+    default: False
+    restriction_mode: B
   list_of_speakers_enable_pro_contra_speech:
     type: boolean
     default: False

--- a/openslides_backend/action/actions/meeting/update.py
+++ b/openslides_backend/action/actions/meeting/update.py
@@ -76,6 +76,7 @@ meeting_settings_keys = [
     "list_of_speakers_show_first_contribution",
     "list_of_speakers_enable_point_of_order_speakers",
     "list_of_speakers_enable_point_of_order_categories",
+    "list_of_speakers_closing_disables_point_of_order",
     "list_of_speakers_enable_pro_contra_speech",
     "list_of_speakers_can_set_contribution_self",
     "list_of_speakers_speaker_note_for_everyone",

--- a/openslides_backend/action/actions/speaker/create.py
+++ b/openslides_backend/action/actions/speaker/create.py
@@ -215,6 +215,7 @@ class SpeakerCreateAction(
                 "list_of_speakers_enable_point_of_order_speakers",
                 "list_of_speakers_enable_point_of_order_categories",
                 "list_of_speakers_present_users_only",
+                "list_of_speakers_closing_disables_point_of_order",
             ],
         )
         if instance.get("point_of_order") and not meeting.get(
@@ -239,7 +240,10 @@ class SpeakerCreateAction(
             )
 
         if (
-            not instance.get("point_of_order")
+            (
+                not instance.get("point_of_order")
+                or meeting.get("list_of_speakers_closing_disables_point_of_order")
+            )
             and los.get("closed")
             and instance.get("user_id") == self.user_id
             and not has_perm(

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -3,7 +3,7 @@
 from openslides_backend.models import fields
 from openslides_backend.models.base import Model
 
-MODELS_YML_CHECKSUM = "8c8b134007bfc8c540f6074b00def99a"
+MODELS_YML_CHECKSUM = "dea25af9a336309f96f7ccb9eca61cb9"
 
 
 class Organization(Model):
@@ -455,6 +455,9 @@ class Meeting(Model):
     list_of_speakers_show_first_contribution = fields.BooleanField(default=False)
     list_of_speakers_enable_point_of_order_speakers = fields.BooleanField(default=True)
     list_of_speakers_enable_point_of_order_categories = fields.BooleanField(
+        default=False
+    )
+    list_of_speakers_closing_disables_point_of_order = fields.BooleanField(
         default=False
     )
     list_of_speakers_enable_pro_contra_speech = fields.BooleanField(default=False)

--- a/tests/system/action/meeting/test_update.py
+++ b/tests/system/action/meeting/test_update.py
@@ -547,6 +547,15 @@ class MeetingUpdateActionTest(BaseActionTestCase):
             "meeting/1", {"list_of_speakers_enable_point_of_order_speakers": True}
         )
 
+    def test_update_list_of_speakers_closing_disables_point_of_order(
+        self,
+    ) -> None:
+        self.basic_test({"list_of_speakers_closing_disables_point_of_order": True})
+        self.assert_model_exists(
+            "meeting/1",
+            {"list_of_speakers_closing_disables_point_of_order": True},
+        )
+
     def test_update_with_user(self) -> None:
         self.set_models(
             {

--- a/tests/system/action/speaker/test_create.py
+++ b/tests/system/action/speaker/test_create.py
@@ -99,6 +99,62 @@ class SpeakerCreateActionTest(BaseActionTestCase):
         )
         self.assert_status_code(response, 200)
 
+    def test_create_point_of_order_in_closed_los(self) -> None:
+        self.test_models["list_of_speakers/23"]["closed"] = True
+        self.test_models["meeting/1"][
+            "list_of_speakers_enable_point_of_order_speakers"
+        ] = True
+        self.test_models["meeting/1"]["group_ids"] = [3]
+        self.test_models["group/3"] = {"name": "permission group", "meeting_id": 1}
+        self.test_models["point_of_order_category/1"] = {"rank": 1, "meeting_id": 1}
+        self.set_models(self.test_models)
+        self.login(7)
+        self.set_user_groups(7, [3])
+        self.set_group_permissions(3, [Permissions.ListOfSpeakers.CAN_BE_SPEAKER])
+
+        response = self.request(
+            "speaker.create",
+            {"user_id": 7, "list_of_speakers_id": 23, "point_of_order": True},
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "speaker/1",
+            {
+                "user_id": 7,
+                "list_of_speakers_id": 23,
+                "weight": 1,
+                "point_of_order": True,
+            },
+        )
+        self.assert_model_exists("list_of_speakers/23", {"speaker_ids": [1]})
+        self.assert_model_exists(
+            "user/7", {"speaker_$1_ids": [1], "speaker_$_ids": ["1"]}
+        )
+
+    def test_create_point_of_order_in_closed_los_with_submission_restricted(
+        self,
+    ) -> None:
+        self.test_models["list_of_speakers/23"]["closed"] = True
+        self.test_models["meeting/1"][
+            "list_of_speakers_enable_point_of_order_speakers"
+        ] = True
+        self.test_models["meeting/1"][
+            "list_of_speakers_closing_disables_point_of_order"
+        ] = True
+        self.test_models["meeting/1"]["group_ids"] = [3]
+        self.test_models["group/3"] = {"name": "permission group", "meeting_id": 1}
+        self.test_models["point_of_order_category/1"] = {"rank": 1, "meeting_id": 1}
+        self.set_models(self.test_models)
+        self.login(7)
+        self.set_user_groups(7, [3])
+        self.set_group_permissions(3, [Permissions.ListOfSpeakers.CAN_BE_SPEAKER])
+        response = self.request(
+            "speaker.create",
+            {"user_id": 7, "list_of_speakers_id": 23, "point_of_order": True},
+        )
+        self.assert_status_code(response, 400)
+        self.assertIn("The list of speakers is closed.", response.json["message"])
+
     def test_create_empty_data(self) -> None:
         response = self.request("speaker.create", {})
         self.assert_status_code(response, 400)

--- a/tests/system/presenter/test_check_database_all.py
+++ b/tests/system/presenter/test_check_database_all.py
@@ -63,6 +63,7 @@ class TestCheckDatabaseAll(BasePresenterTestCase):
             "list_of_speakers_show_first_contribution": True,
             "list_of_speakers_enable_point_of_order_speakers": True,
             "list_of_speakers_enable_point_of_order_categories": False,
+            "list_of_speakers_closing_disables_point_of_order": False,
             "list_of_speakers_enable_pro_contra_speech": False,
             "list_of_speakers_can_set_contribution_self": False,
             "list_of_speakers_speaker_note_for_everyone": True,


### PR DESCRIPTION
* list of speaker point of order restrict
* Rename the restrict option to a short name

The long name for the option had problems with datastore get in the action. So I used a short name, here.