### PR TITLE
Revert "Add an unique check for motion_category.prefix. (#1626)" (#1828)

### DIFF
--- a/openslides_backend/action/actions/motion_category/create_update_delete.py
+++ b/openslides_backend/action/actions/motion_category/create_update_delete.py
@@ -1,41 +1,12 @@
-from typing import Any, Dict
-
 from ....models.models import MotionCategory
 from ....permissions.permissions import Permissions
-from ....shared.exceptions import ActionException
-from ....shared.filters import And, FilterOperator
-from ...action import Action
 from ...action_set import ActionSet
-from ...generics.update import UpdateAction
 from ...mixins.sequential_numbers_mixin import SequentialNumbersMixin
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action_set
 
 
-class PrefixUniqueMixin(Action):
-    def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
-        instance = super().update_instance(instance)
-        if instance.get("prefix"):
-            meeting_id = self.get_meeting_id(instance)
-            if self.datastore.exists(
-                "motion_category",
-                And(
-                    FilterOperator("prefix", "=", instance["prefix"]),
-                    FilterOperator("id", "!=", instance["id"]),
-                    FilterOperator("meeting_id", "=", meeting_id),
-                ),
-            ):
-                raise ActionException(
-                    f"Prefix '{instance['prefix']}' is not unique in the meeting."
-                )
-        return instance
-
-
-class MotionCategoryCreate(PrefixUniqueMixin, SequentialNumbersMixin):
-    pass
-
-
-class MotionCategoryUpdate(PrefixUniqueMixin, UpdateAction):
+class MotionCategoryCreate(SequentialNumbersMixin):
     pass
 
 
@@ -56,4 +27,3 @@ class MotionCategoryActionSet(ActionSet):
     delete_schema = DefaultSchema(MotionCategory()).get_delete_schema()
     permission = Permissions.Motion.CAN_MANAGE
     CreateActionClass = MotionCategoryCreate
-    UpdateActionClass = MotionCategoryUpdate

--- a/tests/system/action/motion_category/test_create.py
+++ b/tests/system/action/motion_category/test_create.py
@@ -123,8 +123,15 @@ class MotionCategorySystemTest(BaseActionTestCase):
                 "prefix": "test",
             },
         )
-        self.assert_status_code(response, 400)
-        assert "Prefix 'test' is not unique in the meeting." in response.json["message"]
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "motion_category/2",
+            {
+                "name": "test_Xcdfgee",
+                "meeting_id": 222,
+                "prefix": "test",
+            },
+        )
 
     def test_create_no_permissions(self) -> None:
         self.base_permission_test(

--- a/tests/system/action/motion_category/test_update.py
+++ b/tests/system/action/motion_category/test_update.py
@@ -114,8 +114,15 @@ class MotionCategorySystemTest(BaseActionTestCase):
                 "prefix": "test",
             },
         )
-        self.assert_status_code(response, 400)
-        assert "Prefix 'test' is not unique in the meeting." in response.json["message"]
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "motion_category/111",
+            {
+                "name": "name_srtgb123",
+                "prefix": "test",
+                "meeting_id": 222,
+            },
+        )
 
     def test_update_no_permission(self) -> None:
         self.base_permission_test(


### PR DESCRIPTION
* Revert "Add an unique check for motion_category.prefix. (#1626)"

This reverts commit 787555a3fc37b741469ae2badf0d3ae63d41b66a.

* Add the non unique case tests