### PR TITLE
Catch all exceptions during migration

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: .github/docker-compose
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Create secrets for datastore
       run: mkdir secrets && echo -n "openslides" > secrets/postgres_password
@@ -46,7 +46,7 @@ jobs:
     name: Build and test development docker image with Docker Compose
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Run tests
       run: dev/run-tests.sh
@@ -55,7 +55,7 @@ jobs:
     name: Check coding style
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -88,7 +88,7 @@ jobs:
       PYTHONPATH: .
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/create-issue-for-file-updates.yml
+++ b/.github/workflows/create-issue-for-file-updates.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository_owner == 'OpenSlides'
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/create-issue-for-file-updates.yml
+++ b/.github/workflows/create-issue-for-file-updates.yml
@@ -43,13 +43,13 @@ jobs:
         with:
           filename: .github/workflows/announce-file-changes-template.md
 
-    steps:
       - name: Generate access token
         uses: tibdex/github-app-token@v1
         id: generate-token
         with:
           app_id: ${{ secrets.AUTOMATION_APP_ID }}
           private_key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
       - name: Send dispatch if models.yml or permission.yml was changed
         if: |
           contains(steps.changed-files.outputs.modified_files, 'global/meta/models.yml') ||

--- a/openslides_backend/migrations/migration_handler.py
+++ b/openslides_backend/migrations/migration_handler.py
@@ -34,7 +34,7 @@ class MigrationHandler(BaseHandler):
     migration_running = False
     migrate_thread_stream: Optional[StringIO] = None
     migrate_thread_stream_can_be_closed: bool = False
-    migrate_thread_exception: Optional[MigrationException] = None
+    migrate_thread_exception: Optional[Exception] = None
 
     def __init__(self, env: Env, services: Services, logging: LoggingModule) -> None:
         super().__init__(env, services, logging)
@@ -92,7 +92,7 @@ class MigrationHandler(BaseHandler):
         handler = MigrationWrapper(verbose, self.write_line)
         try:
             return handler.execute_command(command)
-        except MigrationException as e:
+        except Exception as e:
             MigrationHandler.migrate_thread_exception = e
             self.logger.exception(e)
         finally:

--- a/openslides_backend/migrations/migration_handler.py
+++ b/openslides_backend/migrations/migration_handler.py
@@ -3,7 +3,6 @@ from io import StringIO
 from threading import Lock, Thread
 from typing import Any, Dict, Optional
 
-from datastore.migrations import MigrationException
 from datastore.migrations import MigrationState as DatastoreMigrationState
 
 from ..shared.exceptions import View400Exception


### PR DESCRIPTION
If exceptions other than `MigrationException` happen during a migration, they are currently not logged anywhere. They should instead be logged.