### PR TITLE
Remove all topic.tag_ids from database

### DIFF
--- a/global/data/example-data.json
+++ b/global/data/example-data.json
@@ -1,5 +1,5 @@
 {
-    "_migration_index": 46,
+    "_migration_index": 47,
     "organization": {
         "1": {
             "id": 1,

--- a/global/data/initial-data.json
+++ b/global/data/initial-data.json
@@ -1,5 +1,5 @@
 {
-    "_migration_index": 46,
+    "_migration_index": 47,
     "organization": {
         "1": {
             "id": 1,

--- a/openslides_backend/migrations/migrations/0046_fix_topic_tag_ids_error.py
+++ b/openslides_backend/migrations/migrations/0046_fix_topic_tag_ids_error.py
@@ -1,0 +1,29 @@
+from typing import Any, Dict, List, Optional
+
+from datastore.migrations import BaseModelMigration
+from datastore.writer.core import BaseRequestEvent, RequestUpdateEvent
+
+from openslides_backend.shared.patterns import fqid_from_collection_and_id
+
+
+class Migration(BaseModelMigration):
+    """
+    Remove all topic.tag_ids from database
+    """
+
+    target_migration_index = 47
+
+    field = "tag_ids"
+
+    def migrate_models(self) -> Optional[List[BaseRequestEvent]]:
+        events: List[BaseRequestEvent] = []
+        db_models = self.reader.get_all("topic")
+        for id, model in db_models.items():
+            if self.field in model:
+                update: Dict[str, Any] = {self.field: None}
+                events.append(
+                    RequestUpdateEvent(
+                        fqid_from_collection_and_id("topic", id), update
+                    )
+                )
+        return events

--- a/openslides_backend/migrations/migrations/0046_fix_topic_tag_ids_error.py
+++ b/openslides_backend/migrations/migrations/0046_fix_topic_tag_ids_error.py
@@ -22,8 +22,6 @@ class Migration(BaseModelMigration):
             if self.field in model:
                 update: Dict[str, Any] = {self.field: None}
                 events.append(
-                    RequestUpdateEvent(
-                        fqid_from_collection_and_id("topic", id), update
-                    )
+                    RequestUpdateEvent(fqid_from_collection_and_id("topic", id), update)
                 )
         return events

--- a/tests/system/migrations/test_0046_fix_topic_tag_ids_error.py
+++ b/tests/system/migrations/test_0046_fix_topic_tag_ids_error.py
@@ -1,0 +1,21 @@
+def test_migration(write, finalize, assert_model):
+    write(
+        {
+            "type": "create",
+            "fqid": "topic/61",
+            "fields": {
+                "id": 61,
+                "tag_ids": [],
+                "title": "topic61 with empty tag ids"
+            },
+        },
+    )
+    finalize("0046_fix_topic_tag_ids_error")
+
+    assert_model(
+        "topic/61",
+        {
+            "id": 61,
+            "title": "topic61 with empty tag ids",
+        },
+    )

--- a/tests/system/migrations/test_0046_fix_topic_tag_ids_error.py
+++ b/tests/system/migrations/test_0046_fix_topic_tag_ids_error.py
@@ -3,11 +3,7 @@ def test_migration(write, finalize, assert_model):
         {
             "type": "create",
             "fqid": "topic/61",
-            "fields": {
-                "id": 61,
-                "tag_ids": [],
-                "title": "topic61 with empty tag ids"
-            },
+            "fields": {"id": 61, "tag_ids": [], "title": "topic61 with empty tag ids"},
         },
     )
     finalize("0046_fix_topic_tag_ids_error")


### PR DESCRIPTION
This migrations enables meeting clone, because otherwise the existing topic.tag_ids are throwing validation exception