### PR TITLE
Use get_all instead of filter for migration 46

### DIFF
--- a/openslides_backend/migrations/migrations/0045_fix_amendment_paragraph.py
+++ b/openslides_backend/migrations/migrations/0045_fix_amendment_paragraph.py
@@ -24,8 +24,8 @@ class Migration(BaseModelMigration):
             collection="motion",
             filter=And(
                 FilterOperator(self.old_field, "!=", None),
-                FilterOperator("meta_deleted", "!=", True)
-            )
+                FilterOperator("meta_deleted", "!=", True),
+            ),
         )
 
         for id, model in db_models.items():

--- a/openslides_backend/migrations/migrations/0045_fix_amendment_paragraph.py
+++ b/openslides_backend/migrations/migrations/0045_fix_amendment_paragraph.py
@@ -5,7 +5,7 @@ from datastore.writer.core import BaseRequestEvent, RequestUpdateEvent
 
 from openslides_backend.shared.patterns import fqid_from_collection_and_id
 
-from ...shared.filters import FilterOperator
+from ...shared.filters import And, FilterOperator
 
 
 class Migration(BaseModelMigration):
@@ -22,7 +22,10 @@ class Migration(BaseModelMigration):
         events: List[BaseRequestEvent] = []
         db_models = self.reader.filter(
             collection="motion",
-            filter=FilterOperator(self.old_field, "!=", None),
+            filter=And(
+                FilterOperator(self.old_field, "!=", None),
+                FilterOperator("meta_deleted", "!=", True)
+            )
         )
 
         for id, model in db_models.items():

--- a/openslides_backend/migrations/migrations/0046_fix_topic_tag_ids_error.py
+++ b/openslides_backend/migrations/migrations/0046_fix_topic_tag_ids_error.py
@@ -5,8 +5,6 @@ from datastore.writer.core import BaseRequestEvent, RequestUpdateEvent
 
 from openslides_backend.shared.patterns import fqid_from_collection_and_id
 
-from ...shared.filters import FilterOperator
-
 
 class Migration(BaseModelMigration):
     """
@@ -19,12 +17,11 @@ class Migration(BaseModelMigration):
 
     def migrate_models(self) -> Optional[List[BaseRequestEvent]]:
         events: List[BaseRequestEvent] = []
-        db_models = self.reader.filter(
-            collection="topic", filter=FilterOperator(self.field, "!=", None)
-        )
-        for id_ in db_models:
-            update: Dict[str, Any] = {self.field: None}
-            events.append(
-                RequestUpdateEvent(fqid_from_collection_and_id("topic", id_), update)
-            )
+        db_models = self.reader.get_all("topic")
+        for id, model in db_models.items():
+            if self.field in model:
+                update: Dict[str, Any] = {self.field: None}
+                events.append(
+                    RequestUpdateEvent(fqid_from_collection_and_id("topic", id), update)
+                )
         return events

--- a/tests/system/migrations/test_0045_fix_amendment_paragraph.py
+++ b/tests/system/migrations/test_0045_fix_amendment_paragraph.py
@@ -1,4 +1,4 @@
-def test_migration(write, finalize, assert_model):
+def test_migration(write, finalize, assert_model, read_model):
     write(
         {
             "type": "create",
@@ -20,7 +20,27 @@ def test_migration(write, finalize, assert_model):
                 "title": "test",
             },
         },
+        {
+            "type": "create",
+            "fqid": "motion/63",
+            "fields": {
+                "id": 63,
+                "title": "test",
+                "amendment_paragraph_$": ["0", "1", "2", "42"],
+                "amendment_paragraph_$0": "change",
+                "amendment_paragraph_$1": "",
+                "amendment_paragraph_$2": "",
+                "amendment_paragraph_$42": "change",
+            },
+        }
     )
+    write(
+        {
+            "type": "delete",
+            "fqid": "motion/63",
+        }
+    )
+
     finalize("0045_fix_amendment_paragraph")
 
     assert_model(
@@ -42,3 +62,7 @@ def test_migration(write, finalize, assert_model):
             "title": "test",
         },
     )
+
+    motion63 = read_model("motion/63")
+    assert motion63["meta_deleted"] == True
+    assert motion63["amendment_paragraph_$"] == ["0", "1", "2", "42"]

--- a/tests/system/migrations/test_0045_fix_amendment_paragraph.py
+++ b/tests/system/migrations/test_0045_fix_amendment_paragraph.py
@@ -32,7 +32,7 @@ def test_migration(write, finalize, assert_model, read_model):
                 "amendment_paragraph_$2": "",
                 "amendment_paragraph_$42": "change",
             },
-        }
+        },
     )
     write(
         {
@@ -64,5 +64,5 @@ def test_migration(write, finalize, assert_model, read_model):
     )
 
     motion63 = read_model("motion/63")
-    assert motion63["meta_deleted"] == True
+    assert motion63["meta_deleted"] is True
     assert motion63["amendment_paragraph_$"] == ["0", "1", "2", "42"]


### PR DESCRIPTION
The filter seemingly returned deleted models as well which was problematic for the update event.