### PR TITLE
Allow html strikethrough short tag

### DIFF
--- a/openslides_backend/shared/util.py
+++ b/openslides_backend/shared/util.py
@@ -17,6 +17,7 @@ ALLOWED_HTML_TAGS_STRICT = {
     "blockquote",
     # text formating
     "strike",
+    "s",
     "del",
     "ins",
     "strong",


### PR DESCRIPTION
Added the `s` tag which adds strikethrough text styling to the allowed html tags. Needed for https://github.com/OpenSlides/openslides-client/pull/2890