### PR TITLE
Fix presenter error

### DIFF
--- a/openslides_backend/permissions/permission_helper.py
+++ b/openslides_backend/permissions/permission_helper.py
@@ -147,4 +147,4 @@ def is_admin(datastore: DatastoreService, user_id: int, meeting_id: int) -> bool
         ["admin_group_id"],
     )
     group_ids = get_groups_from_meeting_user(datastore, meeting_id, user_id)
-    return meeting["admin_group_id"] in group_ids
+    return bool(group_ids) and meeting["admin_group_id"] in group_ids


### PR DESCRIPTION
fixes #1925 

The error occurs if a meeting user has `group_ids == None`. This should never happen in praxis, therefore I only prevent the error in the function and did not implement a seperate test.