### PR TITLE
Improve migration test with SQL dump

### DIFF
--- a/tests/system/migrations/test_with_sql_dump.py
+++ b/tests/system/migrations/test_with_sql_dump.py
@@ -1,4 +1,5 @@
 import os
+from io import StringIO
 
 import pytest
 from datastore.migrations.core.migration_handler import MigrationHandler
@@ -16,7 +17,23 @@ def test_with_sql_dump():
     with connection_handler.get_connection_context():
         with connection_handler.get_current_connection().cursor() as cursor:
             with open(SQL_FILE, "r") as file:
-                cursor.execute(file.read(), [])
+                content = file.read()
+                if content.startswith("COPY"):
+                    cursor.execute("SET session_replication_role = 'replica'")
+                    lines = content.split("\n")
+                    while lines:
+                        line = lines.pop(0).strip()
+                        if line.startswith("--") or line == "":
+                            continue
+                        assert line.startswith("COPY")
+                        data = StringIO()
+                        while (record := lines.pop(0).strip()) != "\\.":
+                            data.write(record + "\n")
+                        data.seek(0)
+                        cursor.copy_expert(line, data)
+                    cursor.execute("SET session_replication_role = 'origin'")
+                else:
+                    cursor.execute(line, [])
     migration_handler = injector.get(MigrationHandler)
     migration_handler.register_migrations(
         *MigrationWrapper.load_migrations("openslides_backend.migrations.migrations")


### PR DESCRIPTION
To make it handle dumps with `COPY` statements correctly.