### PR TITLE
Add coupling between speakers and structure levels

### DIFF
--- a/openslides_backend/action/actions/speaker/end_speech.py
+++ b/openslides_backend/action/actions/speaker/end_speech.py
@@ -1,4 +1,10 @@
 import time
+from typing import Any, Dict
+
+from openslides_backend.action.actions.structure_level_list_of_speakers.update import (
+    StructureLevelListOfSpeakersUpdateAction,
+)
+from openslides_backend.action.mixins.singular_action_mixin import SingularActionMixin
 
 from ....models.models import Speaker
 from ....permissions.permissions import Permissions
@@ -7,12 +13,11 @@ from ....shared.patterns import fqid_from_collection_and_id
 from ...generics.update import UpdateAction
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
-from ...util.typing import ActionData
 from ..projector_countdown.mixins import CountdownControl
 
 
 @register_action("speaker.end_speech")
-class SpeakerEndSpeach(CountdownControl, UpdateAction):
+class SpeakerEndSpeach(SingularActionMixin, CountdownControl, UpdateAction):
     """
     Action to stop speakers.
     """
@@ -25,30 +30,47 @@ class SpeakerEndSpeach(CountdownControl, UpdateAction):
     )
     permission = Permissions.ListOfSpeakers.CAN_MANAGE
 
-    def get_updated_instances(self, action_data: ActionData) -> ActionData:
-        for instance in action_data:
-            speaker = self.datastore.get(
-                fqid_from_collection_and_id(self.model.collection, instance["id"]),
-                mapped_fields=["begin_time", "end_time", "meeting_id"],
+    def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
+        instance = super().update_instance(instance)
+        speaker = self.datastore.get(
+            fqid_from_collection_and_id(self.model.collection, instance["id"]),
+            mapped_fields=[
+                "begin_time",
+                "end_time",
+                "meeting_id",
+                "structure_level_list_of_speakers_id",
+            ],
+        )
+        if speaker.get("begin_time") is None or speaker.get("end_time") is not None:
+            raise ActionException(
+                f"Speaker {instance['id']} is not speaking at the moment."
             )
-            if speaker.get("begin_time") is None or speaker.get("end_time") is not None:
-                raise ActionException(
-                    f"Speaker {instance['id']} is not speaking at the moment."
-                )
-            instance["end_time"] = round(time.time())
+        instance["end_time"] = round(time.time())
 
-            # reset projector_countdown
-            meeting = self.datastore.get(
-                fqid_from_collection_and_id("meeting", speaker["meeting_id"]),
+        # reset projector_countdown
+        meeting = self.datastore.get(
+            fqid_from_collection_and_id("meeting", speaker["meeting_id"]),
+            [
+                "list_of_speakers_couple_countdown",
+                "list_of_speakers_countdown_id",
+            ],
+        )
+        if meeting.get("list_of_speakers_couple_countdown") and meeting.get(
+            "list_of_speakers_countdown_id"
+        ):
+            self.control_countdown(meeting["list_of_speakers_countdown_id"], "reset")
+
+        # update structure level countdown
+        if level_id := speaker.get("structure_level_list_of_speakers_id"):
+            self.execute_other_action(
+                StructureLevelListOfSpeakersUpdateAction,
                 [
-                    "list_of_speakers_couple_countdown",
-                    "list_of_speakers_countdown_id",
+                    {
+                        "id": level_id,
+                        "current_start_time": None,
+                        "spoken_time": instance["end_time"] - speaker["begin_time"],
+                    }
                 ],
             )
-            if meeting.get("list_of_speakers_couple_countdown") and meeting.get(
-                "list_of_speakers_countdown_id"
-            ):
-                self.control_countdown(
-                    meeting["list_of_speakers_countdown_id"], "reset"
-                )
-            yield instance
+
+        return instance

--- a/openslides_backend/action/actions/speaker/speak.py
+++ b/openslides_backend/action/actions/speaker/speak.py
@@ -1,19 +1,25 @@
 import time
+from typing import Any, Dict
+
+from openslides_backend.action.actions.speaker.end_speech import SpeakerEndSpeach
+from openslides_backend.action.actions.structure_level_list_of_speakers.update import (
+    StructureLevelListOfSpeakersUpdateAction,
+)
+from openslides_backend.action.mixins.singular_action_mixin import SingularActionMixin
+from openslides_backend.shared.filters import And, FilterOperator
 
 from ....models.models import Speaker
 from ....permissions.permissions import Permissions
-from ....services.datastore.interface import GetManyRequest
 from ....shared.exceptions import ActionException
 from ....shared.patterns import fqid_from_collection_and_id
 from ...generics.update import UpdateAction
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
-from ...util.typing import ActionData
 from ..projector_countdown.mixins import CountdownControl
 
 
 @register_action("speaker.speak")
-class SpeakerSpeak(CountdownControl, UpdateAction):
+class SpeakerSpeak(SingularActionMixin, CountdownControl, UpdateAction):
     """
     Action to let speakers speak.
     """
@@ -26,57 +32,61 @@ class SpeakerSpeak(CountdownControl, UpdateAction):
     )
     permission = Permissions.ListOfSpeakers.CAN_MANAGE
 
-    def get_updated_instances(self, action_data: ActionData) -> ActionData:
-        for instance in action_data:
-            this_speaker = self.datastore.get(
-                fqid_from_collection_and_id(self.model.collection, instance["id"]),
-                mapped_fields=["list_of_speakers_id", "meeting_id"],
-            )
-            list_of_speakers = self.datastore.get(
-                fqid_from_collection_and_id(
-                    "list_of_speakers", this_speaker["list_of_speakers_id"]
+    def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
+        instance = super().update_instance(instance)
+        db_instance = self.datastore.get(
+            fqid_from_collection_and_id(self.model.collection, instance["id"]),
+            mapped_fields=[
+                "list_of_speakers_id",
+                "meeting_id",
+                "begin_time",
+                "end_time",
+                "structure_level_list_of_speakers_id",
+            ],
+        )
+        # find current speaker, if exists, and end their speech
+        result = self.datastore.filter(
+            self.model.collection,
+            And(
+                FilterOperator("meeting_id", "=", db_instance["meeting_id"]),
+                FilterOperator(
+                    "list_of_speakers_id", "=", db_instance["list_of_speakers_id"]
                 ),
-                mapped_fields=["speaker_ids"],
+                FilterOperator("begin_time", "!=", None),
+                FilterOperator("end_time", "=", None),
+            ),
+            mapped_fields=["id"],
+        )
+        if result:
+            self.execute_other_action(
+                SpeakerEndSpeach, [{"id": next(iter(result.keys()))}]
             )
-            gmr = GetManyRequest(
-                self.model.collection,
-                list_of_speakers["speaker_ids"],
-                ["begin_time", "end_time"],
-            )
-            speakers = self.datastore.get_many([gmr])
-            now = round(time.time())
-            current_speaker = None
-            for speaker_id, speaker in speakers[self.model.collection].items():
-                if speaker_id == instance["id"]:
-                    if speaker.get("begin_time") is not None:
-                        raise ActionException("Speaker has already started to speak.")
-                    assert speaker.get("end_time") is None
-                    instance["begin_time"] = now
-                    continue
-                if (
-                    speaker.get("begin_time") is not None
-                    and speaker.get("end_time") is None
-                ):
-                    assert current_speaker is None
-                    # stop current speaker
-                    yield {
-                        "id": speaker_id,
-                        "end_time": now,
-                    }
 
-            # reset projector countdown
-            meeting = self.datastore.get(
-                fqid_from_collection_and_id("meeting", this_speaker["meeting_id"]),
-                [
-                    "list_of_speakers_couple_countdown",
-                    "list_of_speakers_countdown_id",
-                ],
-                lock_result=False,
+        now = round(time.time())
+        if db_instance.get("begin_time") is not None:
+            raise ActionException("Speaker has already started to speak.")
+        assert db_instance.get("end_time") is None
+        instance["begin_time"] = now
+
+        # reset projector countdown
+        meeting = self.datastore.get(
+            fqid_from_collection_and_id("meeting", db_instance["meeting_id"]),
+            [
+                "list_of_speakers_couple_countdown",
+                "list_of_speakers_countdown_id",
+            ],
+            lock_result=False,
+        )
+        if meeting.get("list_of_speakers_couple_countdown") and meeting.get(
+            "list_of_speakers_countdown_id"
+        ):
+            self.control_countdown(meeting["list_of_speakers_countdown_id"], "restart")
+
+        # update structure level countdown
+        if level_id := db_instance.get("structure_level_list_of_speakers_id"):
+            self.execute_other_action(
+                StructureLevelListOfSpeakersUpdateAction,
+                [{"id": level_id, "current_start_time": now}],
             )
-            if meeting.get("list_of_speakers_couple_countdown") and meeting.get(
-                "list_of_speakers_countdown_id"
-            ):
-                self.control_countdown(
-                    meeting["list_of_speakers_countdown_id"], "restart"
-                )
-            yield instance
+
+        return instance

--- a/openslides_backend/action/actions/structure_level_list_of_speakers/__init__.py
+++ b/openslides_backend/action/actions/structure_level_list_of_speakers/__init__.py
@@ -1,1 +1,1 @@
-from . import add_time, create, delete  # noqa
+from . import add_time, create, delete, update  # noqa

--- a/openslides_backend/action/actions/structure_level_list_of_speakers/update.py
+++ b/openslides_backend/action/actions/structure_level_list_of_speakers/update.py
@@ -1,0 +1,30 @@
+from typing import Any, Dict
+
+from openslides_backend.action.generics.update import UpdateAction
+from openslides_backend.action.util.action_type import ActionType
+from openslides_backend.shared.patterns import fqid_from_collection_and_id
+
+from ....models.models import StructureLevelListOfSpeakers
+from ...util.default_schema import DefaultSchema
+from ...util.register import register_action
+
+
+@register_action("structure_level_list_of_speakers.update", ActionType.BACKEND_INTERNAL)
+class StructureLevelListOfSpeakersUpdateAction(UpdateAction):
+    model = StructureLevelListOfSpeakers()
+    schema = DefaultSchema(StructureLevelListOfSpeakers()).get_update_schema(
+        optional_properties=["current_start_time"],
+        additional_optional_fields={
+            "spoken_time": {"type": "integer", "minimum": 1},
+        },
+    )
+
+    def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
+        instance = super().update_instance(instance)
+        db_instance = self.datastore.get(
+            fqid_from_collection_and_id(self.model.collection, instance["id"]),
+            ["remaining_time"],
+        )
+        if spoken_time := instance.pop("spoken_time", None):
+            instance["remaining_time"] = db_instance["remaining_time"] - spoken_time
+        return instance

--- a/tests/system/action/speaker/test_end_speech.py
+++ b/tests/system/action/speaker/test_end_speech.py
@@ -1,3 +1,5 @@
+from math import floor
+from time import time
 from typing import Any, Dict
 
 from openslides_backend.permissions.permissions import Permissions
@@ -7,7 +9,7 @@ from tests.system.action.base import BaseActionTestCase
 class SpeakerEndSpeachTester(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models: Dict[str, Dict[str, Any]] = {
+        self.models: Dict[str, Dict[str, Any]] = {
             "meeting/1": {
                 "list_of_speakers_couple_countdown": True,
                 "list_of_speakers_countdown_id": 11,
@@ -30,170 +32,67 @@ class SpeakerEndSpeachTester(BaseActionTestCase):
                 "meeting_id": 1,
             },
         }
+        self.set_models(self.models)
 
     def test_correct(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {
-                    "list_of_speakers_couple_countdown": True,
-                    "list_of_speakers_countdown_id": 11,
-                    "is_active_in_organization_id": 1,
-                    "meeting_user_ids": [7],
-                },
-                "projector_countdown/11": {
-                    "running": True,
-                    "default_time": 60,
-                    "countdown_time": 31.0,
-                    "meeting_id": 1,
-                },
-                "user/7": {
-                    "username": "test_username1",
-                    "meeting_user_ids": [7],
-                },
-                "meeting_user/7": {"meeting_id": 1, "user_id": 7, "speaker_ids": [890]},
-                "list_of_speakers/23": {"speaker_ids": [890], "meeting_id": 1},
-                "speaker/890": {
-                    "meeting_user_id": 7,
-                    "list_of_speakers_id": 23,
-                    "begin_time": 10000,
-                    "meeting_id": 1,
-                },
-            }
-        )
         response = self.request("speaker.end_speech", {"id": 890})
         self.assert_status_code(response, 200)
         model = self.get_model("speaker/890")
-        self.assertTrue(model.get("end_time") is not None)
+        self.assertIsNotNone(model.get("end_time"))
 
     def test_wrong_id(self) -> None:
-        self.set_models(
-            {
-                "user/7": {"username": "test_username1", "meeting_user_ids": [7]},
-                "meeting_user/7": {"meeting_id": 1, "user_id": 7, "speaker_ids": [890]},
-                "list_of_speakers/23": {"speaker_ids": [890]},
-                "speaker/890": {
-                    "meeting_user_id": 7,
-                    "list_of_speakers_id": 23,
-                    "begin_time": 10000,
-                },
-            }
-        )
         response = self.request("speaker.end_speech", {"id": 889})
         self.assert_status_code(response, 400)
         model = self.get_model("speaker/890")
-        self.assertTrue(model.get("end_time") is None)
-        self.assertTrue(
-            "Model 'speaker/889' does not exist." in response.json["message"]
-        )
+        self.assertIsNone(model.get("end_time"))
+        self.assertIn("Model 'speaker/889' does not exist.", response.json["message"])
 
-    def test_existing_speaker(self) -> None:
+    def test_end_time_set(self) -> None:
         self.set_models(
             {
-                "meeting/1": {"is_active_in_organization_id": 1},
-                "user/7": {"username": "test_username1"},
-                "meeting_user/7": {"meeting_id": 1, "user_id": 7, "speaker_ids": [890]},
-                "list_of_speakers/23": {"speaker_ids": [890], "meeting_id": 1},
                 "speaker/890": {
-                    "meeting_user_id": 7,
-                    "list_of_speakers_id": 23,
-                    "begin_time": 100000,
                     "end_time": 200000,
-                    "meeting_id": 1,
                 },
             }
         )
         response = self.request("speaker.end_speech", {"id": 890})
         self.assert_status_code(response, 400)
         model = self.get_model("speaker/890")
-        self.assertEqual(model.get("begin_time"), 100000)
+        self.assertEqual(model.get("begin_time"), 10000)
         self.assertEqual(model.get("end_time"), 200000)
-        self.assertTrue(
-            "Speaker 890 is not speaking at the moment." in response.json["message"]
+        self.assertIn(
+            "Speaker 890 is not speaking at the moment.", response.json["message"]
         )
 
-    def test_existing_speaker_2(self) -> None:
+    def test_no_begin_time(self) -> None:
         self.set_models(
             {
-                "meeting/1": {"is_active_in_organization_id": 1},
-                "user/7": {"username": "test_username1"},
-                "meeting_user/7": {"meeting_id": 1, "user_id": 7, "speaker_ids": [890]},
-                "list_of_speakers/23": {"speaker_ids": [890], "meeting_id": 1},
                 "speaker/890": {
-                    "meeting_user_id": 7,
-                    "list_of_speakers_id": 23,
-                    "meeting_id": 1,
+                    "begin_time": None,
                 },
             }
         )
         response = self.request("speaker.end_speech", {"id": 890})
         self.assert_status_code(response, 400)
         model = self.get_model("speaker/890")
-        self.assertTrue(model.get("begin_time") is None)
-        self.assertTrue(model.get("end_time") is None)
-        self.assertTrue(
-            "Speaker 890 is not speaking at the moment." in response.json["message"]
+        self.assertIsNone(model.get("begin_time"))
+        self.assertIsNone(model.get("end_time"))
+        self.assertIn(
+            "Speaker 890 is not speaking at the moment.", response.json["message"]
         )
 
     def test_reset_countdown(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {
-                    "list_of_speakers_couple_countdown": True,
-                    "list_of_speakers_countdown_id": 11,
-                    "is_active_in_organization_id": 1,
-                },
-                "projector_countdown/11": {
-                    "running": True,
-                    "default_time": 60,
-                    "countdown_time": 31.0,
-                    "meeting_id": 1,
-                },
-                "user/7": {"username": "test_username1"},
-                "meeting_user/7": {"meeting_id": 1, "user_id": 7, "speaker_ids": [890]},
-                "list_of_speakers/23": {"speaker_ids": [890], "meeting_id": 1},
-                "speaker/890": {
-                    "meeting_user_id": 7,
-                    "list_of_speakers_id": 23,
-                    "begin_time": 10000,
-                    "meeting_id": 1,
-                },
-            }
-        )
         response = self.request("speaker.end_speech", {"id": 890})
         self.assert_status_code(response, 200)
         countdown = self.get_model("projector_countdown/11")
-        assert countdown.get("running") is False
-        assert countdown.get("countdown_time") == 60
-
-    def test_end_speech_no_permissions(self) -> None:
-        self.base_permission_test(
-            self.permission_test_models, "speaker.end_speech", {"id": 890}
-        )
-
-    def test_end_speech_permissions(self) -> None:
-        self.base_permission_test(
-            self.permission_test_models,
-            "speaker.end_speech",
-            {"id": 890},
-            Permissions.ListOfSpeakers.CAN_MANAGE,
-        )
+        self.assertFalse(countdown.get("running"))
+        self.assertEqual(countdown.get("countdown_time"), 60)
 
     def test_correct_on_closed_los(self) -> None:
         self.set_models(
             {
-                "meeting/1": {"is_active_in_organization_id": 1},
-                "user/7": {"username": "test_username1"},
-                "meeting_user/7": {"meeting_id": 1, "user_id": 7, "speaker_ids": [890]},
                 "list_of_speakers/23": {
-                    "speaker_ids": [890],
-                    "meeting_id": 1,
                     "closed": True,
-                },
-                "speaker/890": {
-                    "meeting_user_id": 7,
-                    "list_of_speakers_id": 23,
-                    "begin_time": 10000,
-                    "meeting_id": 1,
                 },
             }
         )
@@ -201,3 +100,50 @@ class SpeakerEndSpeachTester(BaseActionTestCase):
         self.assert_status_code(response, 200)
         model = self.get_model("speaker/890")
         self.assertIsNotNone(model.get("end_time"))
+
+    def test_with_structure_level(self) -> None:
+        start = floor(time())
+        self.set_models(
+            {
+                "meeting/1": {
+                    "structure_level_ids": [1],
+                    "structure_level_list_of_speakers_ids": [2],
+                },
+                "structure_level/1": {
+                    "meeting_id": 1,
+                    "structure_level_list_of_speakers_ids": [2],
+                },
+                "structure_level_list_of_speakers/2": {
+                    "meeting_id": 1,
+                    "list_of_speakers_id": 23,
+                    "structure_level_id": 1,
+                    "speaker_ids": [890],
+                    "remaining_time": 500,
+                    "current_start_time": start - 100,
+                },
+                "list_of_speakers/23": {"structure_level_list_of_speakers_ids": [2]},
+                "speaker/890": {
+                    "begin_time": start - 100,
+                    "structure_level_list_of_speakers_id": 2,
+                },
+            }
+        )
+        response = self.request("speaker.end_speech", {"id": 890})
+        self.assert_status_code(response, 200)
+        speaker = self.get_model("speaker/890")
+        model = self.get_model("structure_level_list_of_speakers/2")
+        self.assertEqual(
+            model["remaining_time"], 500 - (speaker["end_time"] - speaker["begin_time"])
+        )
+        self.assertIsNone(model.get("current_start_time"))
+
+    def test_end_speech_no_permissions(self) -> None:
+        self.base_permission_test(self.models, "speaker.end_speech", {"id": 890})
+
+    def test_end_speech_permissions(self) -> None:
+        self.base_permission_test(
+            self.models,
+            "speaker.end_speech",
+            {"id": 890},
+            Permissions.ListOfSpeakers.CAN_MANAGE,
+        )

--- a/tests/system/action/speaker/test_speak.py
+++ b/tests/system/action/speaker/test_speak.py
@@ -1,4 +1,5 @@
-import time
+from math import ceil, floor
+from time import time
 from typing import Any, Dict
 
 from openslides_backend.permissions.permissions import Permissions
@@ -8,7 +9,8 @@ from tests.system.action.base import BaseActionTestCase
 class SpeakerSpeakTester(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models: Dict[str, Dict[str, Any]] = {
+        self.models: Dict[str, Dict[str, Any]] = {
+            "meeting/1": {"is_active_in_organization_id": 1},
             "user/7": {"username": "test_username1"},
             "meeting_user/7": {"meeting_id": 1, "user_id": 7, "speaker_ids": [890]},
             "list_of_speakers/23": {"speaker_ids": [890], "meeting_id": 1},
@@ -18,57 +20,25 @@ class SpeakerSpeakTester(BaseActionTestCase):
                 "meeting_id": 1,
             },
         }
+        self.set_models(self.models)
 
     def test_speak_correct(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {"is_active_in_organization_id": 1},
-                "user/7": {"username": "test_username1"},
-                "meeting_user/7": {"meeting_id": 1, "user_id": 7, "speaker_ids": [890]},
-                "list_of_speakers/23": {"speaker_ids": [890], "meeting_id": 1},
-                "speaker/890": {
-                    "meeting_user_id": 7,
-                    "list_of_speakers_id": 23,
-                    "meeting_id": 1,
-                },
-            }
-        )
         response = self.request("speaker.speak", {"id": 890})
         self.assert_status_code(response, 200)
         model = self.get_model("speaker/890")
-        self.assertTrue(model.get("begin_time") is not None)
+        self.assertIsNotNone(model.get("begin_time"))
 
     def test_speak_wrong_id(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {"is_active_in_organization_id": 1},
-                "user/7": {"username": "test_username1"},
-                "meeting_user/7": {"meeting_id": 1, "user_id": 7, "speaker_ids": [890]},
-                "list_of_speakers/23": {"speaker_ids": [890], "meeting_id": 1},
-                "speaker/890": {
-                    "meeting_user_id": 7,
-                    "list_of_speakers_id": 23,
-                    "meeting_id": 1,
-                },
-            }
-        )
         response = self.request("speaker.speak", {"id": 889})
         self.assert_status_code(response, 400)
         model = self.get_model("speaker/890")
-        self.assertTrue(model.get("begin_time") is None)
+        self.assertIsNone(model.get("begin_time"))
 
     def test_speak_existing_speaker(self) -> None:
         self.set_models(
             {
-                "meeting/1": {"is_active_in_organization_id": 1},
-                "user/7": {"username": "test_username1"},
-                "meeting_user/7": {"meeting_id": 1, "user_id": 7, "speaker_ids": [890]},
-                "list_of_speakers/23": {"speaker_ids": [890], "meeting_id": 1},
                 "speaker/890": {
-                    "meeting_user_id": 7,
-                    "list_of_speakers_id": 23,
                     "begin_time": 100000,
-                    "meeting_id": 1,
                 },
             }
         )
@@ -80,19 +50,12 @@ class SpeakerSpeakTester(BaseActionTestCase):
     def test_speak_next_speaker(self) -> None:
         self.set_models(
             {
-                "meeting/1": {"is_active_in_organization_id": 1},
-                "user/7": {"username": "test_username1"},
                 "meeting_user/7": {
-                    "meeting_id": 1,
-                    "user_id": 7,
                     "speaker_ids": [890, 891],
                 },
-                "list_of_speakers/23": {"speaker_ids": [890, 891], "meeting_id": 1},
+                "list_of_speakers/23": {"speaker_ids": [890, 891]},
                 "speaker/890": {
-                    "meeting_user_id": 7,
-                    "list_of_speakers_id": 23,
                     "begin_time": 100000,
-                    "meeting_id": 1,
                 },
                 "speaker/891": {
                     "meeting_user_id": 7,
@@ -101,29 +64,18 @@ class SpeakerSpeakTester(BaseActionTestCase):
                 },
             }
         )
-
         response = self.request("speaker.speak", {"id": 891})
         self.assert_status_code(response, 200)
         model2 = self.get_model("speaker/891")
-        self.assertTrue(model2.get("begin_time") is not None)
+        self.assertIsNotNone(model2.get("begin_time"))
         model1 = self.get_model("speaker/890")
         self.assertEqual(model1.get("end_time"), model2["begin_time"])
 
     def test_closed(self) -> None:
         self.set_models(
             {
-                "meeting/1": {"is_active_in_organization_id": 1},
-                "user/7": {"username": "test_username1"},
-                "meeting_user/7": {"meeting_id": 1, "user_id": 7, "speaker_ids": [890]},
                 "list_of_speakers/23": {
-                    "speaker_ids": [890],
                     "closed": True,
-                    "meeting_id": 1,
-                },
-                "speaker/890": {
-                    "meeting_user_id": 7,
-                    "list_of_speakers_id": 23,
-                    "meeting_id": 1,
                 },
             }
         )
@@ -138,7 +90,6 @@ class SpeakerSpeakTester(BaseActionTestCase):
                 "meeting/1": {
                     "list_of_speakers_couple_countdown": True,
                     "list_of_speakers_countdown_id": 75,
-                    "is_active_in_organization_id": 1,
                 },
                 "projector_countdown/75": {
                     "running": False,
@@ -146,31 +97,99 @@ class SpeakerSpeakTester(BaseActionTestCase):
                     "countdown_time": 30.0,
                     "meeting_id": 1,
                 },
-                "user/7": {"username": "test_username1"},
-                "meeting_user/7": {"meeting_id": 1, "user_id": 7, "speaker_ids": [890]},
-                "list_of_speakers/23": {"meeting_id": 1, "speaker_ids": [890]},
-                "speaker/890": {
+            }
+        )
+        now = floor(time())
+        response = self.request("speaker.speak", {"id": 890})
+        self.assert_status_code(response, 200)
+        countdown = self.get_model("projector_countdown/75")
+        assert countdown.get("running")
+        assert now <= countdown["countdown_time"] <= ceil(time()) + 300
+
+    def test_speak_with_structure_level(self) -> None:
+        self.set_models(
+            {
+                "meeting/1": {
+                    "structure_level_ids": [1],
+                    "structure_level_list_of_speakers_ids": [2],
+                },
+                "structure_level/1": {
                     "meeting_id": 1,
+                    "structure_level_list_of_speakers_ids": [2],
+                },
+                "structure_level_list_of_speakers/2": {
+                    "meeting_id": 1,
+                    "list_of_speakers_id": 23,
+                    "structure_level_id": 1,
+                    "speaker_ids": [890],
+                    "remaining_time": 100,
+                },
+                "list_of_speakers/23": {"structure_level_list_of_speakers_ids": [2]},
+                "speaker/890": {
+                    "structure_level_list_of_speakers_id": 2,
+                },
+            }
+        )
+        now = floor(time())
+        response = self.request("speaker.speak", {"id": 890})
+        self.assert_status_code(response, 200)
+        model = self.get_model("structure_level_list_of_speakers/2")
+        self.assertEqual(model["remaining_time"], 100)
+        assert now <= model["current_start_time"] <= ceil(time())
+
+    def test_speak_with_structure_level_and_current_speaker(self) -> None:
+        now = floor(time())
+        self.set_models(
+            {
+                "meeting/1": {
+                    "structure_level_ids": [1],
+                    "structure_level_list_of_speakers_ids": [2],
+                },
+                "meeting_user/7": {
+                    "speaker_ids": [889, 890],
+                },
+                "list_of_speakers/23": {
+                    "speaker_ids": [889, 890],
+                    "structure_level_list_of_speakers_ids": [2],
+                },
+                "structure_level/1": {
+                    "meeting_id": 1,
+                    "structure_level_list_of_speakers_ids": [2],
+                },
+                "structure_level_list_of_speakers/2": {
+                    "meeting_id": 1,
+                    "list_of_speakers_id": 23,
+                    "structure_level_id": 1,
+                    "speaker_ids": [889, 890],
+                    "remaining_time": 500,
+                },
+                "speaker/889": {
+                    "structure_level_list_of_speakers_id": 2,
                     "meeting_user_id": 7,
                     "list_of_speakers_id": 23,
+                    "meeting_id": 1,
+                    "begin_time": now - 100,
+                },
+                "speaker/890": {
+                    "structure_level_list_of_speakers_id": 2,
                 },
             }
         )
         response = self.request("speaker.speak", {"id": 890})
         self.assert_status_code(response, 200)
-        countdown = self.get_model("projector_countdown/75")
-        assert countdown.get("running")
-        now = time.time()
-        assert now <= countdown.get("countdown_time", 0.0) <= now + 300
+        speaker = self.get_model("speaker/889")
+        model = self.get_model("structure_level_list_of_speakers/2")
+        self.assertEqual(
+            model["remaining_time"], 500 - (speaker["end_time"] - speaker["begin_time"])
+        )
+        assert now <= model["current_start_time"] <= ceil(time())
 
     def test_speak_no_permissions(self) -> None:
-        self.base_permission_test(
-            self.permission_test_models, "speaker.speak", {"id": 890}
-        )
+        self.base_permission_test(self.models, "speaker.speak", {"id": 890})
 
     def test_speak_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
+            self.models,
             "speaker.speak",
             {"id": 890},
             Permissions.ListOfSpeakers.CAN_MANAGE,

--- a/tests/system/action/structure_level_list_of_speakers/test_update.py
+++ b/tests/system/action/structure_level_list_of_speakers/test_update.py
@@ -1,0 +1,71 @@
+from time import time
+
+from tests.system.action.base import BaseActionTestCase
+
+
+class StructureLevelListOfSpeakersUpdateTest(BaseActionTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.set_models(
+            {
+                "meeting/1": {
+                    "is_active_in_organization_id": 1,
+                    "structure_level_ids": [1],
+                    "list_of_speakers_ids": [2],
+                    "structure_level_list_of_speakers_ids": [3],
+                },
+                "structure_level/1": {
+                    "meeting_id": 1,
+                    "structure_level_list_of_speakers_ids": [3],
+                },
+                "list_of_speakers/2": {
+                    "meeting_id": 1,
+                    "structure_level_list_of_speakers_ids": [3],
+                },
+                "structure_level_list_of_speakers/3": {
+                    "structure_level_id": 1,
+                    "list_of_speakers_id": 2,
+                    "meeting_id": 1,
+                    "initial_time": 600,
+                    "remaining_time": 500,
+                },
+            }
+        )
+
+    def test_set_start_time(self) -> None:
+        now = round(time())
+        response = self.request(
+            "structure_level_list_of_speakers.update",
+            {"id": 3, "current_start_time": now},
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "structure_level_list_of_speakers/3",
+            {
+                "initial_time": 600,
+                "remaining_time": 500,
+                "current_start_time": now,
+            },
+        )
+
+    def test_set_spoken_time(self) -> None:
+        self.set_models(
+            {
+                "structure_level_list_of_speakers/3": {
+                    "current_start_time": round(time())
+                }
+            }
+        )
+        response = self.request(
+            "structure_level_list_of_speakers.update",
+            {"id": 3, "current_start_time": None, "spoken_time": 100},
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "structure_level_list_of_speakers/3",
+            {
+                "initial_time": 600,
+                "remaining_time": 400,
+                "current_start_time": None,
+            },
+        )


### PR DESCRIPTION
part of https://github.com/OpenSlides/openslides-backend/issues/1948

I updated the code and tests of `speaker.{speak|end_speech}` as they were not up to our current standards. I also made them both singular actions as they should never be called with more than one payload item - there is always only one current speaker on a LOS.