### PR TITLE
Try to fix failing auth token test

### DIFF
--- a/tests/system/action/base.py
+++ b/tests/system/action/base.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from openslides_backend.action.action_handler import ActionHandler
 from openslides_backend.action.action_worker import gunicorn_post_request
 from openslides_backend.action.relations.relation_manager import RelationManager
 from openslides_backend.action.util.action_type import ActionType
@@ -38,6 +39,21 @@ ACTION_URL_SEPARATELY = get_route_path(ActionView.action_route, "handle_separate
 
 
 class BaseActionTestCase(BaseSystemTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        ActionHandler.MAX_RETRY = 1
+        # access auth database directly to reset it
+        redis = self.auth.auth_handler.database.redis
+        prefix = ":".join(
+            (
+                self.auth.auth_handler.database.AUTH_PREFIX,
+                self.auth.auth_handler.TOKEN_DB_KEY,
+            )
+        )
+        for key in redis.keys():
+            if key.decode().startswith(prefix):
+                redis.delete(key)
+
     def get_application(self) -> WSGIApplication:
         return create_action_test_application()
 

--- a/tests/system/action/motion/test_create_sequential_number.py
+++ b/tests/system/action/motion/test_create_sequential_number.py
@@ -1,6 +1,7 @@
 import threading
 from typing import Optional
 
+from openslides_backend.action.action_handler import ActionHandler
 from tests.system.action.base import ACTION_URL, BaseActionTestCase
 from tests.system.action.lock import (
     monkeypatch_datastore_adapter_write,
@@ -157,6 +158,7 @@ class MotionCreateActionTestSequentialNumber(BaseActionTestCase):
         The lock-object will be shared in threading.local(), instance created in lock.py.
         If possible you should pass as an argument to the thread function(s).
         """
+        ActionHandler.MAX_RETRY = 3
         self.set_thread_watch_timeout(-2)
         pytest_thread_local.name = "MainThread_RC"
         self.set_models(


### PR DESCRIPTION
- set `MAX_RETRY` to 1 in tests in case that the token is used because for some reason the action has to be repeated
- flush the redis database before each test just to be sure

I, too, cannot reproduce the failure locally, so these are just guesses what might help.