### PR TITLE
Fix CI for local setup

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -70,7 +70,7 @@ jobs:
     
     - name: Checkout datastore commit
       working-directory: openslides-datastore-service
-      run: . ../openslides-backend/requirements/export_service_commits.sh git checkout $DATASTORE_COMMIT_HASH
+      run: . ../openslides-backend/requirements/export_service_commits.sh && git checkout $DATASTORE_COMMIT_HASH
 
     - name: Clone auth service
       uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
     
     - name: Checkout auth commit
       working-directory: openslides-auth-service
-      run: . ../openslides-backend/requirements/export_service_commits.sh git checkout $AUTH_COMMIT_HASH
+      run: . ../openslides-backend/requirements/export_service_commits.sh && git checkout $AUTH_COMMIT_HASH
 
     - name: Clone vote service
       uses: actions/checkout@v4

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -10,6 +10,8 @@ on:
 
 env:
   PYTHON_VERSION: 3.10.x
+  DATASTORE_COMMIT_HASH: main  # will be set during job
+  AUTH_COMMIT_HASH: main  # will be set during job
 
 jobs:
   build-production-image:
@@ -60,28 +62,27 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: openslides-backend
+    
+    - name: Set env vars
+      working-directory: openslides-backend/requirements
+      run: |
+        . export_service_commits.sh
+        echo "DATASTORE_COMMIT_HASH=$(echo $DATASTORE_COMMIT_HASH)" >> $GITHUB_ENV
+        echo "AUTH_COMMIT_HASH=$(echo $AUTH_COMMIT_HASH)" >> $GITHUB_ENV
 
     - name: Clone datastore
       uses: actions/checkout@v4
       with:
         repository: OpenSlides/openslides-datastore-service
-        ref: main
+        ref: ${{ env.DATASTORE_COMMIT_HASH }}
         path: openslides-datastore-service
-    
-    - name: Checkout datastore commit
-      working-directory: openslides-datastore-service
-      run: . ../openslides-backend/requirements/export_service_commits.sh && git checkout $DATASTORE_COMMIT_HASH
 
     - name: Clone auth service
       uses: actions/checkout@v4
       with:
         repository: OpenSlides/openslides-auth-service
-        ref: main
+        ref: ${{ env.AUTH_COMMIT_HASH }}
         path: openslides-auth-service
-    
-    - name: Checkout auth commit
-      working-directory: openslides-auth-service
-      run: . ../openslides-backend/requirements/export_service_commits.sh && git checkout $AUTH_COMMIT_HASH
 
     - name: Clone vote service
       uses: actions/checkout@v4

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -72,19 +72,23 @@ jobs:
       working-directory: openslides-datastore-service
       run: . ../openslides-backend/requirements/export_service_commits.sh git checkout $DATASTORE_COMMIT_HASH
 
-    - name: Clone vote service
-      uses: actions/checkout@v4
-      with:
-        repository: OpenSlides/openslides-vote-service
-        ref: main
-        path: openslides-vote-service
-
     - name: Clone auth service
       uses: actions/checkout@v4
       with:
         repository: OpenSlides/openslides-auth-service
         ref: main
         path: openslides-auth-service
+    
+    - name: Checkout auth commit
+      working-directory: openslides-auth-service
+      run: . ../openslides-backend/requirements/export_service_commits.sh git checkout $AUTH_COMMIT_HASH
+
+    - name: Clone vote service
+      uses: actions/checkout@v4
+      with:
+        repository: OpenSlides/openslides-vote-service
+        ref: main
+        path: openslides-vote-service
 
     - name: Run local setup
       working-directory: openslides-backend


### PR DESCRIPTION
Looks ugly, but is the official approach to setting env variables in github actions: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable and is better than the previous solution (which additionally did not work correctly and would have required to fetch the complete repository instead of only the required commit).