### PR TITLE
Add `equal_fields` to `motion/supporter_meeting_user_ids`

### DIFF
--- a/global/meta/models.yml
+++ b/global/meta/models.yml
@@ -2353,6 +2353,7 @@ motion:
   supporter_meeting_user_ids:
     type: relation-list
     to: meeting_user/supported_motion_ids
+    equal_fields: meeting_id
     restriction_mode: C
   poll_ids:
     type: relation-list

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -4,7 +4,7 @@ from . import fields
 from .base import Model
 from .mixins import AgendaItemModelMixin, MeetingModelMixin, PollModelMixin
 
-MODELS_YML_CHECKSUM = "199a53035f313e1a429476bf78c98fa8"
+MODELS_YML_CHECKSUM = "f7f9d2222b759a92eba7cd34f3dcf900"
 
 
 class Organization(Model):
@@ -1192,7 +1192,7 @@ class Motion(Model):
         equal_fields="meeting_id",
     )
     supporter_meeting_user_ids = fields.RelationListField(
-        to={"meeting_user": "supported_motion_ids"}
+        to={"meeting_user": "supported_motion_ids"}, equal_fields="meeting_id"
     )
     poll_ids = fields.RelationListField(
         to={"poll": "content_object_id"},

--- a/tests/system/action/motion/test_update.py
+++ b/tests/system/action/motion/test_update.py
@@ -10,7 +10,7 @@ class MotionUpdateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.permission_test_models: Dict[str, Dict[str, Any]] = {
-            "meeting/1": {"meeting_user_ids": [1]},
+            "meeting/1": {"meeting_user_ids": [1], "is_active_in_organization_id": 1},
             "motion/111": {
                 "meeting_id": 1,
                 "title": "title_srtgb123",
@@ -452,6 +452,23 @@ class MotionUpdateActionTest(BaseActionTestCase):
         )
         self.assert_model_exists(
             "motion/2", {"referenced_in_motion_recommendation_extension_ids": []}
+        )
+
+    def test_set_supporter_other_meeting(self) -> None:
+        self.create_meeting(2)
+        self.permission_test_models["meeting_user/1"]["meeting_id"] = 2
+        self.set_models(self.permission_test_models)
+        response = self.request(
+            "motion.update",
+            {
+                "id": 111,
+                "supporter_meeting_user_ids": [1],
+            },
+        )
+        self.assert_status_code(response, 400)
+        self.assertIn(
+            "The following models do not belong to meeting 1: ['meeting_user/1']",
+            response.json["message"],
         )
 
     def test_update_no_permissions(self) -> None:


### PR DESCRIPTION
fixes #2127 