### PR TITLE
Add new motion fields & fix `can_manage_metadata`

### DIFF
--- a/global/meta/models.yml
+++ b/global/meta/models.yml
@@ -415,6 +415,16 @@ meeting_user:
     to: motion/supporter_meeting_user_ids
     equal_fields: meeting_id
     restriction_mode: A
+  editor_for_motion_ids:
+    type: relation-list
+    to: motion/editor_id
+    equal_fields: meeting_id
+    restriction_mode: A
+  working_group_speaker_for_motion_ids:
+    type: relation-list
+    to: motion/working_group_speaker_id
+    equal_fields: meeting_id
+    restriction_mode: A
   motion_submitter_ids:
     type: relation-list
     to: motion_submitter/meeting_user_id
@@ -1158,6 +1168,12 @@ meeting:
     type: number
     minimum: 0
     default: 0
+    restriction_mode: B
+  motions_enable_editor:
+    type: boolean
+    restriction_mode: B
+  motions_enable_working_group_speaker:
+    type: boolean
     restriction_mode: B
   motions_export_title:
     type: string
@@ -2354,6 +2370,16 @@ motion:
     type: relation-list
     to: meeting_user/supported_motion_ids
     restriction_mode: C
+  editor_id:
+    type: relation
+    to: meeting_user/editor_for_motion_ids
+    equal_fields: meeting_id
+    restriction_mode: B
+  working_group_speaker_id:
+    type: relation
+    to: meeting_user/working_group_speaker_for_motion_ids
+    equal_fields: meeting_id
+    restriction_mode: B
   poll_ids:
     type: relation-list
     to: poll/content_object_id

--- a/openslides_backend/action/actions/meeting/update.py
+++ b/openslides_backend/action/actions/meeting/update.py
@@ -110,6 +110,8 @@ meeting_settings_keys = [
     "motions_amendments_text_mode",
     "motions_amendments_multiple_paragraphs",
     "motions_supporters_min_amount",
+    "motions_enable_editor",
+    "motions_enable_working_group_speaker",
     "motions_export_title",
     "motions_export_preamble",
     "motions_export_submitter_recommendation",

--- a/openslides_backend/action/actions/motion/update.py
+++ b/openslides_backend/action/actions/motion/update.py
@@ -50,6 +50,8 @@ class MotionUpdate(
             "category_id",
             "block_id",
             "supporter_meeting_user_ids",
+            "editor_id",
+            "working_group_speaker_id",
             "tag_ids",
             "attachment_ids",
             "created",
@@ -197,8 +199,7 @@ class MotionUpdate(
             allowed_fields += [
                 "category_id",
                 "block_id",
-                "origin",
-                "supporters_id",
+                "supporter_meeting_user_ids",
                 "recommendation_extension",
                 "start_line_number",
                 "tag_ids",

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -4,7 +4,7 @@ from . import fields
 from .base import Model
 from .mixins import AgendaItemModelMixin, MeetingModelMixin, PollModelMixin
 
-MODELS_YML_CHECKSUM = "199a53035f313e1a429476bf78c98fa8"
+MODELS_YML_CHECKSUM = "2c048cea208be1a95a4e9e6bb527f68a"
 
 
 class Organization(Model):
@@ -164,6 +164,12 @@ class MeetingUser(Model):
     )
     supported_motion_ids = fields.RelationListField(
         to={"motion": "supporter_meeting_user_ids"}, equal_fields="meeting_id"
+    )
+    editor_for_motion_ids = fields.RelationListField(
+        to={"motion": "editor_id"}, equal_fields="meeting_id"
+    )
+    working_group_speaker_for_motion_ids = fields.RelationListField(
+        to={"motion": "working_group_speaker_id"}, equal_fields="meeting_id"
     )
     motion_submitter_ids = fields.RelationListField(
         to={"motion_submitter": "meeting_user_id"},
@@ -470,6 +476,8 @@ class Meeting(Model, MeetingModelMixin):
     motions_supporters_min_amount = fields.IntegerField(
         default=0, constraints={"minimum": 0}
     )
+    motions_enable_editor = fields.BooleanField()
+    motions_enable_working_group_speaker = fields.BooleanField()
     motions_export_title = fields.CharField(default="Motions")
     motions_export_preamble = fields.TextField()
     motions_export_submitter_recommendation = fields.BooleanField(default=True)
@@ -1193,6 +1201,13 @@ class Motion(Model):
     )
     supporter_meeting_user_ids = fields.RelationListField(
         to={"meeting_user": "supported_motion_ids"}
+    )
+    editor_id = fields.RelationField(
+        to={"meeting_user": "editor_for_motion_ids"}, equal_fields="meeting_id"
+    )
+    working_group_speaker_id = fields.RelationField(
+        to={"meeting_user": "working_group_speaker_for_motion_ids"},
+        equal_fields="meeting_id",
     )
     poll_ids = fields.RelationListField(
         to={"poll": "content_object_id"},


### PR DESCRIPTION
fixes #2119 

Also some wrong fields were present in the allowlist for `can_manage_metadata` and the tests were not sufficient, so I fixed them.