### PR TITLE
Make participant import create structure levels

### DIFF
--- a/openslides_backend/action/actions/user/base_import.py
+++ b/openslides_backend/action/actions/user/base_import.py
@@ -33,6 +33,7 @@ class BaseUserImport(ImportMixin):
 
         self.rows = [self.validate_entry(row) for row in self.rows]
 
+        self.handle_create_relations()
         if self.import_state != ImportState.ERROR:
             rows = self.flatten_copied_object_fields(
                 self.handle_remove_and_group_fields
@@ -40,6 +41,9 @@ class BaseUserImport(ImportMixin):
             self.create_other_actions(rows)
 
         return {}
+
+    def handle_create_relations(self) -> None:
+        pass
 
     def handle_remove_and_group_fields(self, entry: Dict[str, Any]) -> Dict[str, Any]:
         for field in ("groups", "structure_level"):

--- a/openslides_backend/action/actions/user/base_import.py
+++ b/openslides_backend/action/actions/user/base_import.py
@@ -33,7 +33,7 @@ class BaseUserImport(ImportMixin):
 
         self.rows = [self.validate_entry(row) for row in self.rows]
 
-        self.handle_create_relations()
+        self.handle_create_relations(instance)
         if self.import_state != ImportState.ERROR:
             rows = self.flatten_copied_object_fields(
                 self.handle_remove_and_group_fields
@@ -42,7 +42,7 @@ class BaseUserImport(ImportMixin):
 
         return {}
 
-    def handle_create_relations(self) -> None:
+    def handle_create_relations(self, instance: Dict[str, Any]) -> None:
         pass
 
     def handle_remove_and_group_fields(self, entry: Dict[str, Any]) -> Dict[str, Any]:

--- a/openslides_backend/action/actions/user/participant_import.py
+++ b/openslides_backend/action/actions/user/participant_import.py
@@ -1,10 +1,12 @@
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Set, Tuple, cast
 
 from ....services.datastore.commands import GetManyRequest
 from ....shared.exceptions import ActionException
+from ....shared.filters import FilterOperator, Or
 from ...mixins.import_mixins import ImportRow, ImportState
 from ...util.register import register_action
 from ...util.typing import ActionData
+from ..structure_level.create import StructureLevelCreateAction
 from .base_import import BaseUserImport
 from .participant_common import ParticipantCommon
 from .set_present import UserSetPresentAction
@@ -14,10 +16,83 @@ from .set_present import UserSetPresentAction
 class ParticipantImport(BaseUserImport, ParticipantCommon):
     import_name = "participant"
     lookups: Dict[str, Dict[int, str]] = {}
+    structure_level_to_create_list: List[str] = []
+    newly_found_structure_levels: Dict[int, Dict[str, Any]] = {}
 
     def prefetch(self, action_data: ActionData) -> None:
         super().prefetch(action_data)
         self.meeting_id = cast(int, self.result["meeting_id"])
+
+    def update_instance(self, instance: Dict[str, Any]) -> Dict[str, Any]:
+        structure_levels_to_create: Set[str] = set(
+            [
+                level["value"]
+                for row in self.rows
+                for level in row["data"].get("structure_level", [])
+                if level.get("info") == ImportState.NEW
+            ]
+        )
+        if len(structure_levels_to_create):
+            self.newly_found_structure_levels = self.datastore.filter(
+                "structure_level",
+                Or(
+                    [
+                        FilterOperator("name", "=", level)
+                        for level in structure_levels_to_create
+                    ]
+                ),
+                ["name", "id"],
+            )
+            for level in self.newly_found_structure_levels.values():
+                structure_levels_to_create.discard(level["name"])
+            self.structure_level_to_create_list = list(structure_levels_to_create)
+        instance = super().update_instance(instance)
+        return instance
+
+    def handle_create_relations(self) -> None:
+        if (
+            self.import_state != ImportState.ERROR
+            and len(self.structure_level_to_create_list)
+            and not len(self.newly_found_structure_levels)
+        ):
+            if created_levels := self.execute_other_action(
+                StructureLevelCreateAction,
+                [
+                    {"name": name, "meeting_id": self.meeting_id}
+                    for name in self.structure_level_to_create_list
+                ],
+            ):
+                levels_dict = dict(
+                    zip(self.structure_level_to_create_list, created_levels)
+                )
+                for row in self.rows:
+                    for level in row["data"].get("structure_level", []):
+                        if level.get("info") == ImportState.NEW:
+                            if structure_level := levels_dict.get(level["value"]):
+                                level["id"] = structure_level["id"]
+                            else:
+                                raise ActionException(
+                                    "Couldn't correctly create new structure_levels"
+                                )
+            else:
+                raise ActionException("Couldn't correctly create new structure_levels")
+        elif len(self.newly_found_structure_levels):
+            levels_set = set(
+                [model["name"] for model in self.newly_found_structure_levels.values()]
+            )
+            for row in self.rows:
+                error_levels: List[str] = []
+                for level in row["data"].get("structure_level", []):
+                    if level.get("info") == ImportState.NEW:
+                        if level["value"] in levels_set:
+                            level["info"] = ImportState.ERROR
+                            error_levels.append(level["value"])
+                            row["state"] = ImportState.ERROR
+                            self.import_state = ImportState.ERROR
+                if len(error_levels):
+                    row["messages"].append(
+                        f"Error: Failed to create the following structure levels as they were already created: {', '.join(error_levels)}"
+                    )
 
     def validate_entry(self, row: ImportRow) -> ImportRow:
         row = super().validate_entry(row)
@@ -82,6 +157,8 @@ class ParticipantImport(BaseUserImport, ParticipantCommon):
                             row["messages"].append(
                                 f"The {singular_field} '{instance_id} {instance['value']}' changed its name to '{self.lookups[field][instance_id]}'."
                             )
+                    elif instance["info"] == ImportState.NEW and instance.get("id"):
+                        valid = True
                     else:
                         instance["info"] = ImportState.WARNING
                         row["messages"].append(

--- a/openslides_backend/action/actions/user/participant_import.py
+++ b/openslides_backend/action/actions/user/participant_import.py
@@ -58,23 +58,20 @@ class ParticipantImport(BaseUserImport, ParticipantCommon):
                 model["name"]: id_
                 for id_, model in self.newly_found_structure_levels.items()
             }
-            if (
-                created_levels := (
-                    self.execute_other_action(
-                        StructureLevelCreateAction,
-                        [
-                            {"name": name, "meeting_id": self.meeting_id}
-                            for name in self.structure_level_to_create_list
-                        ],
-                    )
-                    if len(self.structure_level_to_create_list)
-                    else []
+            created_levels = (
+                self.execute_other_action(
+                    StructureLevelCreateAction,
+                    [
+                        {"name": name, "meeting_id": self.meeting_id}
+                        for name in self.structure_level_to_create_list
+                    ],
                 )
-            ) is not None:
-                levels_dict = (
-                    dict(zip(self.structure_level_to_create_list, created_levels))
-                    if len(created_levels)
-                    else {}
+                if len(self.structure_level_to_create_list)
+                else None
+            )
+            if created_levels:
+                levels_dict = dict(
+                    zip(self.structure_level_to_create_list, created_levels)
                 )
                 for row in self.rows:
                     for level in row["data"].get("structure_level", []):
@@ -92,23 +89,6 @@ class ParticipantImport(BaseUserImport, ParticipantCommon):
                                 )
             else:
                 raise ActionException("Couldn't correctly create new structure_levels")
-        # elif len(self.newly_found_structure_levels):
-        #     # levels_set = set(
-        #     #     [model["name"] for model in self.newly_found_structure_levels.values()]
-        #     # )
-        #     for row in self.rows:
-        #         error_levels: List[str] = []
-        #         for level in row["data"].get("structure_level", []):
-        #             if level.get("info") == ImportState.NEW:
-        #                 if level["value"] in newly_found_levels_dict:
-        #                     level["info"] = ImportState.ERROR
-        #                     error_levels.append(level["value"])
-        #                     row["state"] = ImportState.ERROR
-        #                     self.import_state = ImportState.ERROR
-        #         if len(error_levels):
-        #             row["messages"].append(
-        #                 f"Error: Failed to create the following structure levels as they were already created: {', '.join(error_levels)}"
-        #             )
 
     def validate_entry(self, row: ImportRow) -> ImportRow:
         row = super().validate_entry(row)

--- a/tests/system/action/user/test_participant_import.py
+++ b/tests/system/action/user/test_participant_import.py
@@ -475,12 +475,22 @@ class ParticipantJsonImportWithIncludedJsonUpload(ParticipantJsonUploadForUseInI
                 "meeting_user_ids": [38],
             },
         )
+        level_up = self.assert_model_exists("structure_level/1")
+        if level_up["name"] == "level up":
+            no_5 = self.assert_model_exists("structure_level/2", {"name": "no. 5"})
+        else:
+            assert level_up["name"] == "no. 5"
+            no_5 = level_up
+            level_up = self.assert_model_exists(
+                "structure_level/2", {"name": "level up"}
+            )
         self.assert_model_exists(
             "meeting_user/38",
             {
                 "user_id": 2,
                 "group_ids": [3],
                 "meeting_id": 1,
+                "structure_level_ids": [level_up["id"]],
             },
         )
 
@@ -546,6 +556,7 @@ class ParticipantJsonImportWithIncludedJsonUpload(ParticipantJsonUploadForUseInI
                 "user_id": 5,
                 "group_ids": [1],
                 "meeting_id": 1,
+                "structure_level_ids": [level_up["id"], no_5["id"]],
             },
         )
 
@@ -590,10 +601,102 @@ class ParticipantJsonImportWithIncludedJsonUpload(ParticipantJsonUploadForUseInI
             },
         )
 
+    def test_json_upload_one_structure_level_error(self) -> None:
+        self.json_upload_multiple_users()
+        self.request("structure_level.create", {"meeting_id": 1, "name": "no. 5"})
+        response = self.request("participant.import", {"id": 1, "import": True})
+        self.assert_status_code(response, 200)
+        assert (result := response.json["results"][0][0])["state"] == ImportState.ERROR
+        row = result["rows"][0]
+        assert row["state"] == ImportState.DONE
+        assert row["messages"] == [
+            "Because this participant is connected with a saml_id: The default_password will be ignored and password will not be changeable in OpenSlides.",
+            "Following groups were not found: 'group4'",
+        ]
+        assert row["data"] == {
+            "id": 2,
+            "saml_id": {"info": ImportState.NEW, "value": "test_saml_id2"},
+            "username": {"id": 2, "info": ImportState.DONE, "value": "user2"},
+            "default_password": {"info": ImportState.WARNING, "value": ""},
+            "groups": [
+                {"id": 3, "info": "done", "value": "group3"},
+                {"info": "warning", "value": "group4"},
+            ],
+            "structure_level": [{"info": "new", "value": "level up"}],
+        }
+
+        row = result["rows"][1]
+        assert row["state"] == ImportState.DONE
+        assert row["messages"] == [
+            "Because this participant is connected with a saml_id: The default_password will be ignored and password will not be changeable in OpenSlides.",
+        ]
+        assert row["data"] == {
+            "id": 3,
+            "saml_id": {"info": ImportState.DONE, "value": "saml3"},
+            "username": {"id": 3, "info": ImportState.DONE, "value": "user3"},
+            "default_password": {"info": ImportState.WARNING, "value": ""},
+            "vote_weight": {"info": ImportState.DONE, "value": "3.345678"},
+            "groups": [{"id": 3, "info": "done", "value": "group3"}],
+        }
+
+        row = result["rows"][2]
+        assert row["state"] == ImportState.DONE
+        assert row["messages"] == [
+            "Following groups were not found: 'group4'",
+        ]
+        assert row["data"] == {
+            "id": 4,
+            "email": {"value": "mlk@america.com", "info": ImportState.DONE},
+            "username": {"id": 4, "info": ImportState.DONE, "value": "user4"},
+            "last_name": {"value": "Luther King", "info": ImportState.DONE},
+            "first_name": {"value": "Martin", "info": ImportState.DONE},
+            "groups": [
+                {"info": "warning", "value": "group4"},
+                {"id": 1, "info": "generated", "value": "group1"},
+            ],
+        }
+
+        row = result["rows"][3]
+        assert row["state"] == ImportState.ERROR
+        assert row["messages"] == [
+            "Because this participant is connected with a saml_id: The default_password will be ignored and password will not be changeable in OpenSlides.",
+            "Error: Failed to create the following structure levels as they were already created: no. 5",
+        ]
+        assert row["data"] == {
+            "username": {"info": ImportState.DONE, "value": "new_user5"},
+            "saml_id": {"info": ImportState.NEW, "value": "saml5"},
+            "default_password": {"info": ImportState.WARNING, "value": ""},
+            "groups": [{"id": 1, "info": "generated", "value": "group1"}],
+            "structure_level": [
+                {"info": ImportState.NEW, "value": "level up"},
+                {"info": ImportState.ERROR, "value": "no. 5"},
+            ],
+        }
+
+        self.assert_model_not_exists("structure_level/2")
+
+        row = result["rows"][4]
+        assert row["state"] == ImportState.NEW
+        assert row["messages"] == [
+            "Because this participant is connected with a saml_id: The default_password will be ignored and password will not be changeable in OpenSlides.",
+            "Following groups were not found: 'group4'",
+        ]
+        assert row["data"] == {
+            "username": {"info": ImportState.GENERATED, "value": "new_saml6"},
+            "saml_id": {"info": ImportState.NEW, "value": "new_saml6"},
+            "default_password": {"info": ImportState.WARNING, "value": ""},
+            "is_present": {"info": "done", "value": True},
+            "groups": [
+                {"info": "warning", "value": "group4"},
+                {"id": 1, "info": "generated", "value": "group1"},
+            ],
+        }
+
     def test_json_upload_update_multiple_users_all_error(self) -> None:
         self.json_upload_multiple_users()
         self.request("user.delete", {"id": 2})
         self.request("user.update", {"id": 3, "meeting_id": 1, "group_ids": [1]})
+        self.request("structure_level.create", {"meeting_id": 1, "name": "no. 5"})
         self.set_models(
             {
                 "group/1": {"admin_group_for_meeting_id": 1},
@@ -632,6 +735,7 @@ class ParticipantJsonImportWithIncludedJsonUpload(ParticipantJsonUploadForUseInI
                 {"id": 3, "info": "error", "value": "group3"},
                 {"info": "warning", "value": "group4"},
             ],
+            "structure_level": [{"info": "new", "value": "level up"}],
         }
 
         row = result["rows"][1]
@@ -673,13 +777,20 @@ class ParticipantJsonImportWithIncludedJsonUpload(ParticipantJsonUploadForUseInI
         assert row["messages"] == [
             "Because this participant is connected with a saml_id: The default_password will be ignored and password will not be changeable in OpenSlides.",
             "Error: saml_id 'saml5' found in different id (11 instead of None)",
+            "Error: Failed to create the following structure levels as they were already created: no. 5",
         ]
         assert row["data"] == {
             "username": {"info": ImportState.DONE, "value": "new_user5"},
             "saml_id": {"info": ImportState.ERROR, "value": "saml5"},
             "default_password": {"info": ImportState.WARNING, "value": ""},
             "groups": [{"id": 1, "info": "generated", "value": "group1"}],
+            "structure_level": [
+                {"info": ImportState.NEW, "value": "level up"},
+                {"info": ImportState.ERROR, "value": "no. 5"},
+            ],
         }
+
+        self.assert_model_not_exists("structure_level/2")
 
         row = result["rows"][4]
         assert row["state"] == ImportState.ERROR

--- a/tests/system/action/user/test_participant_json_upload.py
+++ b/tests/system/action/user/test_participant_json_upload.py
@@ -54,7 +54,6 @@ class ParticipantJsonUpload(BaseActionTestCase):
             "state": ImportState.NEW,
             "messages": [
                 "Following groups were not found: 'notfound_group1, notfound_group2'",
-                "Following structure levels were not found: 'notfound'",
             ],
             "data": {
                 "username": {"value": "test", "info": ImportState.DONE},
@@ -64,7 +63,7 @@ class ParticipantJsonUpload(BaseActionTestCase):
                 "number": {"value": "strange number", "info": ImportState.DONE},
                 "structure_level": [
                     {"value": "testlevel", "info": ImportState.DONE, "id": 1},
-                    {"value": "notfound", "info": ImportState.WARNING},
+                    {"value": "notfound", "info": ImportState.NEW},
                 ],
                 "vote_weight": {"value": "1.120000", "info": ImportState.DONE},
                 "comment": {"value": "my comment", "info": ImportState.DONE},
@@ -253,6 +252,7 @@ class ParticipantJsonUpload(BaseActionTestCase):
                 {"name": "updated", "value": 0},
                 {"name": "error", "value": 0},
                 {"name": "warning", "value": 0},
+                {"name": "structure levels created", "value": 0},
             ],
             "state": ImportState.DONE,
         }
@@ -803,6 +803,7 @@ class ParticipantJsonUploadForUseInImport(BaseActionTestCase):
                         "username": "user2",
                         "saml_id": "test_saml_id2",
                         "groups": ["group3", "group4"],
+                        "structure_level": ["level up"],
                     },
                     {
                         "saml_id": "saml3",
@@ -818,6 +819,7 @@ class ParticipantJsonUploadForUseInImport(BaseActionTestCase):
                     {
                         "username": "new_user5",
                         "saml_id": "saml5",
+                        "structure_level": ["level up", "no. 5"],
                     },
                     {"saml_id": "new_saml6", "groups": ["group4"], "is_present": "1"},
                     {
@@ -846,6 +848,7 @@ class ParticipantJsonUploadForUseInImport(BaseActionTestCase):
                 {"id": 3, "info": "done", "value": "group3"},
                 {"info": "warning", "value": "group4"},
             ],
+            "structure_level": [{"value": "level up", "info": ImportState.NEW}],
         }
 
         assert import_preview["result"]["rows"][1]["state"] == ImportState.DONE
@@ -886,6 +889,10 @@ class ParticipantJsonUploadForUseInImport(BaseActionTestCase):
             "username": {"info": "done", "value": "new_user5"},
             "default_password": {"info": "warning", "value": ""},
             "groups": [{"id": 1, "info": "generated", "value": "group1"}],
+            "structure_level": [
+                {"value": "level up", "info": ImportState.NEW},
+                {"value": "no. 5", "info": ImportState.NEW},
+            ],
         }
 
         assert import_preview["result"]["rows"][4]["state"] == ImportState.NEW


### PR DESCRIPTION
Closes #2147 

For now I covered the edge case of "What if the corresponding structure level is created between json_upload and import?" by letting the import fail (i.e. forcing the user to start anew) , I could probably make it so that it succeeds instead with the field being switched over to an update field, what do you think @rrenkert ?