### PR TITLE
Move conditional speaker deletion from user- to meeting_user.delete

### DIFF
--- a/openslides_backend/action/actions/meeting_user/delete.py
+++ b/openslides_backend/action/actions/meeting_user/delete.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from openslides_backend.shared.patterns import fqid_from_collection_and_id
 from openslides_backend.shared.typing import HistoryInformation
 
@@ -6,10 +8,13 @@ from ...generics.delete import DeleteAction
 from ...util.action_type import ActionType
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
+from ..user.conditional_speaker_cascade_mixin import (
+    ConditionalSpeakerCascadeMixinHelper,
+)
 
 
 @register_action("meeting_user.delete", action_type=ActionType.BACKEND_INTERNAL)
-class MeetingUserDelete(DeleteAction):
+class MeetingUserDelete(ConditionalSpeakerCascadeMixinHelper, DeleteAction):
     """
     Action to delete a meeting user.
     """
@@ -26,3 +31,12 @@ class MeetingUserDelete(DeleteAction):
             ]
             for user in users
         }
+
+    def update_instance(self, instance: dict[str, Any]) -> dict[str, Any]:
+        meeting_user = self.datastore.get(
+            fqid_from_collection_and_id("meeting_user", instance["id"]), ["speaker_ids"]
+        )
+        speaker_ids = meeting_user.get("speaker_ids", [])
+        self.conditionally_delete_speakers(speaker_ids)
+
+        return super().update_instance(instance)

--- a/openslides_backend/action/actions/user/conditional_speaker_cascade_mixin.py
+++ b/openslides_backend/action/actions/user/conditional_speaker_cascade_mixin.py
@@ -3,11 +3,46 @@ from typing import Any
 from openslides_backend.shared.filters import And, FilterOperator
 
 from ....services.datastore.commands import GetManyRequest
+from ....shared.patterns import fqid_from_collection_and_id
 from ...action import Action
 from ..speaker.delete import SpeakerDeleteAction
 
 
-class ConditionalSpeakerCascadeMixin(Action):
+class ConditionalSpeakerCascadeMixinHelper(Action):
+    def conditionally_delete_speakers(self, speaker_ids: list[int]) -> None:
+        speaker_to_read_ids = [
+            speaker_id
+            for speaker_id in speaker_ids
+            if not self.datastore.is_deleted(
+                fqid_from_collection_and_id("speaker", speaker_id)
+            )
+        ]
+        speakers = self.datastore.get_many(
+            [
+                GetManyRequest(
+                    "speaker",
+                    speaker_to_read_ids,
+                    [
+                        "begin_time",
+                        "id",
+                    ],
+                )
+            ]
+        ).get("speaker", {})
+        speakers_to_delete = [
+            speaker
+            for speaker in speakers.values()
+            if speaker.get("begin_time") is None
+        ]
+
+        if len(speakers_to_delete):
+            self.execute_other_action(
+                SpeakerDeleteAction,
+                [{"id": speaker["id"]} for speaker in speakers_to_delete],
+            )
+
+
+class ConditionalSpeakerCascadeMixin(ConditionalSpeakerCascadeMixinHelper):
     """
     Mixin for user actions that deletes unstarted speeches of users that were either deleted, or removed from a meeting
     """
@@ -29,29 +64,7 @@ class ConditionalSpeakerCascadeMixin(Action):
                 if val.get("speaker_ids")
                 for speaker_id in val.get("speaker_ids", [])
             ]
-            speakers = self.datastore.get_many(
-                [
-                    GetManyRequest(
-                        "speaker",
-                        speaker_ids,
-                        [
-                            "begin_time",
-                            "id",
-                        ],
-                    )
-                ]
-            )
-            speakers_to_delete = [
-                speaker
-                for speaker in speakers.get("speaker", {}).values()
-                if speaker.get("begin_time") is None
-            ]
-
-            if len(speakers_to_delete):
-                self.execute_other_action(
-                    SpeakerDeleteAction,
-                    [{"id": speaker["id"]} for speaker in speakers_to_delete],
-                )
+            self.conditionally_delete_speakers(speaker_ids)
 
         return super().update_instance(instance)
 

--- a/openslides_backend/action/actions/user/delete.py
+++ b/openslides_backend/action/actions/user/delete.py
@@ -6,11 +6,10 @@ from ....shared.mixins.user_scope_mixin import UserScopeMixin
 from ...generics.delete import DeleteAction
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
-from .conditional_speaker_cascade_mixin import ConditionalSpeakerCascadeMixin
 
 
 @register_action("user.delete")
-class UserDelete(UserScopeMixin, ConditionalSpeakerCascadeMixin, DeleteAction):
+class UserDelete(UserScopeMixin, DeleteAction):
     """
     Action to delete a user.
     """

--- a/tests/system/action/meeting/test_delete.py
+++ b/tests/system/action/meeting/test_delete.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from openslides_backend.shared.util import ONE_ORGANIZATION_FQID
 from tests.system.action.base import BaseActionTestCase
 
@@ -310,3 +312,106 @@ class MeetingDeleteActionTest(BaseActionTestCase):
         response = self.request("meeting.delete", {"id": 1})
         self.assert_status_code(response, 200)
         self.assert_model_deleted("meeting/1")
+
+    def test_delete_with_poll_candidates_and_speakers(self) -> None:
+        data: dict[str, dict[str, Any]] = {
+            "meeting/100": {
+                "committee_id": 1,
+                "meeting_user_ids": [110, 111, 112],
+                "group_ids": [120],
+                "assignment_ids": [140],
+                "poll_ids": [150],
+                "option_ids": [160],
+                "poll_candidate_list_ids": [170],
+                "poll_candidate_ids": [180, 181],
+                "list_of_speakers_ids": [190],
+                "speaker_ids": [210, 211, 212],
+            },
+            "meeting_user/110": {
+                "meeting_id": 100,
+                "user_id": 220,
+                "group_ids": [120],
+                "speaker_ids": [210],
+            },
+            "meeting_user/111": {
+                "meeting_id": 100,
+                "user_id": 221,
+                "group_ids": [120],
+                "speaker_ids": [211],
+            },
+            "meeting_user/112": {
+                "meeting_id": 100,
+                "user_id": 222,
+                "group_ids": [120],
+                "speaker_ids": [212],
+            },
+            "group/120": {"meeting_id": 100, "meeting_user_ids": [110, 111, 112]},
+            "assignment/140": {"meeting_id": 100, "poll_ids": [150]},
+            "poll/150": {
+                "meeting_id": 100,
+                "content_object_id": "assignment/140",
+                "option_ids": [160],
+            },
+            "option/160": {
+                "meeting_id": 100,
+                "poll_id": 150,
+                "content_object_id": "poll_candidate_list/170",
+            },
+            "poll_candidate_list/170": {
+                "meeting_id": 100,
+                "option_id": 160,
+                "poll_candidate_ids": [180, 181],
+            },
+            "poll_candidate/180": {
+                "meeting_id": 100,
+                "poll_candidate_list_id": 170,
+                "user_id": 220,
+            },
+            "poll_candidate/181": {
+                "meeting_id": 100,
+                "poll_candidate_list_id": 170,
+                "user_id": 221,
+            },
+            "list_of_speakers/190": {
+                "meeting_id": 100,
+                "content_object_id": "assignment/140",
+                "speaker_ids": [210, 211, 212],
+            },
+            "speaker/210": {
+                "meeting_id": 100,
+                "list_of_speakers_id": 190,
+                "meeting_user_id": 110,
+                "begin_time": 1234567,
+                "end_time": 1234578,
+            },
+            "speaker/211": {
+                "meeting_id": 100,
+                "list_of_speakers_id": 190,
+                "meeting_user_id": 111,
+                "begin_time": 1234589,
+            },
+            "speaker/212": {
+                "meeting_id": 100,
+                "list_of_speakers_id": 190,
+                "meeting_user_id": 112,
+            },
+        }
+        self.set_models(
+            {
+                **data,
+                ONE_ORGANIZATION_FQID: {"active_meeting_ids": [101]},
+                "committee/1": {
+                    "user_ids": [1, 220, 221, 222],
+                    "manager_ids": [1],
+                },
+                "user/220": {"meeting_user_ids": [110], "poll_candidate_ids": [180]},
+                "user/221": {"meeting_user_ids": [111], "poll_candidate_ids": [181]},
+                "user/222": {"meeting_user_ids": [112]},
+            }
+        )
+        response = self.request("meeting.delete", {"id": 100})
+        self.assert_status_code(response, 200)
+        for fqid in data:
+            self.assert_model_deleted(fqid)
+        for i in range(220, 222):
+            self.assert_model_exists(f"user/{i}", {})

--- a/tests/system/action/meeting_user/test_delete.py
+++ b/tests/system/action/meeting_user/test_delete.py
@@ -12,3 +12,29 @@ class MeetingUserDelete(BaseActionTestCase):
         response = self.request("meeting_user.delete", {"id": 5})
         self.assert_status_code(response, 200)
         self.assert_model_deleted("meeting_user/5")
+
+    def test_delete_with_speaker(self) -> None:
+        self.set_models(
+            {
+                "meeting/10": {"is_active_in_organization_id": 1},
+                "meeting_user/5": {
+                    "user_id": 1,
+                    "meeting_id": 10,
+                    "speaker_ids": [1, 2],
+                },
+                "speaker/1": {
+                    "meeting_user_id": 5,
+                    "meeting_id": 10,
+                },
+                "speaker/2": {
+                    "meeting_user_id": 5,
+                    "meeting_id": 10,
+                    "begin_time": 123456,
+                },
+            }
+        )
+        response = self.request("meeting_user.delete", {"id": 5})
+        self.assert_status_code(response, 200)
+        self.assert_model_deleted("meeting_user/5")
+        self.assert_model_deleted("speaker/1")
+        self.assert_model_exists("speaker/2", {"meeting_id": 10, "begin_time": 123456})

--- a/tests/system/action/option/test_delete.py
+++ b/tests/system/action/option/test_delete.py
@@ -6,8 +6,9 @@ class OptionDeleteTest(BaseActionTestCase):
         super().setUp()
         self.set_models(
             {
-                "option/111": {"meeting_id": 1},
+                "option/111": {"meeting_id": 1, "content_object_id": "motion/1"},
                 "meeting/1": {"is_active_in_organization_id": 1},
+                "motion/1": {"option_ids": [111]},
             }
         )
 
@@ -15,6 +16,7 @@ class OptionDeleteTest(BaseActionTestCase):
         response = self.request("option.delete", {"id": 111})
         self.assert_status_code(response, 200)
         self.assert_model_deleted("option/111")
+        self.assert_model_exists("motion/1")
 
     def test_delete_wrong_id(self) -> None:
         response = self.request("option.delete", {"id": 112})
@@ -27,9 +29,11 @@ class OptionDeleteTest(BaseActionTestCase):
                 "option/112": {
                     "vote_ids": [42],
                     "meeting_id": 1,
+                    "content_object_id": "poll_candidate_list/2",
                 },
                 "vote/42": {"option_id": 112, "meeting_id": 1},
                 "meeting/1": {"is_active_in_organization_id": 1},
+                "poll_candidate_list/2": {"option_id": 112, "meeting_id": 1},
             }
         )
         response = self.request("option.delete", {"id": 112})


### PR DESCRIPTION
Noticed that this may otherwise cause problems when using the meeting_user.delete elsewhere (as is planned in #2111 f.E.).
Also checked for deletion status before carrying out the deletion to avoid breaking the cascades in meeting.delete and wrote a new test in meeting.delete