### PR TITLE
Adjust models parsing

### DIFF
--- a/cli/generate_models.py
+++ b/cli/generate_models.py
@@ -95,7 +95,7 @@ def main() -> None:
     """
     args = parse_arguments(SOURCE)
     global MODELS
-    MODELS = open_yml_file(args.filename)
+    MODELS = open_yml_file(args.filename)["models"]
 
     # Load and parse models.yml
     with open_output(DESTINATION, args.check) as dest:

--- a/cli/generate_permissions.py
+++ b/cli/generate_permissions.py
@@ -82,7 +82,7 @@ def main() -> None:
             if os.path.isfile(models_file):
                 with open(models_file, "rb") as f:
                     models = yaml.safe_load(f.read())
-                enum = set(models["group"]["permissions"]["items"]["enum"])
+                enum = set(models["models"]["group"]["permissions"]["items"]["enum"])
                 permissions = {
                     str(permission)
                     for permissions in all_permissions.values()


### PR DESCRIPTION
The aliases/anchors are not easily applicable in the go-based services as the top-level key `_meta` does not follow the normal model syntax. Therefore, we decided to move the models definitions into its own key `models`; everything outside of that key can simply be ignored by the go services.