### PR TITLE
Handle zero default time in projector_countdown.create

### DIFF
--- a/openslides_backend/action/actions/projector_countdown/create.py
+++ b/openslides_backend/action/actions/projector_countdown/create.py
@@ -30,7 +30,7 @@ class ProjectorCountdownCreate(CreateAction):
         self.check_title_unique(instance)
 
         # set default_time if needed and countdown_time
-        if not instance.get("default_time"):
+        if instance.get("default_time") is None:
             meeting = self.datastore.get(
                 fqid_from_collection_and_id("meeting", instance["meeting_id"]),
                 ["projector_countdown_default_time"],

--- a/tests/system/action/projector_countdown/test_create.py
+++ b/tests/system/action/projector_countdown/test_create.py
@@ -61,6 +61,22 @@ class ProjectorCountdown(BaseActionTestCase):
         assert model.get("default_time") == 11
         assert model.get("countdown_time") == 11
 
+    def test_create_zero_default_time(self) -> None:
+        response = self.request(
+            "projector_countdown.create",
+            {
+                "meeting_id": 1,
+                "title": "test2",
+                "description": "good description",
+                "default_time": 0,
+            },
+        )
+        self.assert_status_code(response, 200)
+        model = self.get_model("projector_countdown/2")
+        assert model.get("title") == "test2"
+        assert model.get("default_time") == 0
+        assert model.get("countdown_time") == 0
+
     def test_create_no_permissions(self) -> None:
         self.base_permission_test(
             {},


### PR DESCRIPTION
Resolve https://github.com/OpenSlides/openslides-backend/issues/2293

handle zero default time different, add a test for this.