### PR TITLE
Fix fixed list order in tests

### DIFF
--- a/tests/system/action/motion/test_create.py
+++ b/tests/system/action/motion/test_create.py
@@ -266,7 +266,7 @@ class MotionCreateActionTest(BaseActionTestCase):
         )
         self.assert_status_code(response, 200)
         motion = self.get_model("motion/1")
-        self.assertCountEqual(motion.get("submitter_ids"), [1, 2])
+        self.assertCountEqual(motion["submitter_ids"], [1, 2])
         submitter_1 = self.get_model("motion_submitter/1")
         assert submitter_1.get("meeting_id") == 1
         assert submitter_1.get("meeting_user_id") == 13

--- a/tests/system/action/motion/test_create.py
+++ b/tests/system/action/motion/test_create.py
@@ -266,7 +266,7 @@ class MotionCreateActionTest(BaseActionTestCase):
         )
         self.assert_status_code(response, 200)
         motion = self.get_model("motion/1")
-        assert motion.get("submitter_ids") == [1, 2]
+        self.assertCountEqual(motion.get("submitter_ids"), [1, 2])
         submitter_1 = self.get_model("motion_submitter/1")
         assert submitter_1.get("meeting_id") == 1
         assert submitter_1.get("meeting_user_id") == 13
@@ -337,9 +337,8 @@ class MotionCreateActionTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 200)
-        self.assert_model_exists(
-            "motion/3", {"text_hash": self.hash, "identical_motion_ids": [1, 2]}
-        )
+        motion = self.assert_model_exists("motion/3", {"text_hash": self.hash})
+        self.assertCountEqual(motion["identical_motion_ids"], [1, 2])
 
     def test_create_identical_motion_with_tags(self) -> None:
         self.setup_hash_test()


### PR DESCRIPTION
The identical motion test failed in https://github.com/OpenSlides/openslides-backend/actions/runs/8330120773/job/22794053954?pr=2316. I looked for similar places and found the submitter test which might fail as well, so I'm fixing it preemptively.