### PR TITLE
Fix `test_longer_migration`

### DIFF
--- a/tests/system/action/test_migration_route.py
+++ b/tests/system/action/test_migration_route.py
@@ -115,7 +115,6 @@ class TestMigrationRouteWithLocks(BaseInternalPasswordTest, BaseMigrationRouteTe
         response = self.migration_request("migrate")
         self.assert_status_code(response, 200)
         assert response.json["status"] == MigrationState.MIGRATION_RUNNING
-        assert response.json["output"] == "start\n"
 
         indicator_lock.acquire()
         response = self.migration_request("progress")


### PR DESCRIPTION
fixes https://github.com/OpenSlides/openslides-backend/issues/2105

The problem was simply a race condition which I seemingly did not realize when writing the test. When the request is send here:
https://github.com/OpenSlides/openslides-backend/blob/5146af65d63b496c40d9eafff31d823c67c4b371/tests/system/action/test_migration_route.py#L115

the backend starts a thread here:
https://github.com/OpenSlides/openslides-backend/blob/7182546dee963b6d8190d295fd8a976953426e91/openslides_backend/migrations/migration_handler.py#L80-L91

This thread is awaited for for 0.1 seconds (`THREAD_WAIT_TIME`) in case it finishes quickly. If it's still running, the `running` state together with the current output is returned.

The `execute_migrate_command` (the run method of the thread) calls `handler.execute_command`, which is mocked by the test here:
https://github.com/OpenSlides/openslides-backend/blob/5146af65d63b496c40d9eafff31d823c67c4b371/tests/system/action/test_migration_route.py#L114

and replaced with the following method:
https://github.com/OpenSlides/openslides-backend/blob/5146af65d63b496c40d9eafff31d823c67c4b371/tests/system/action/test_migration_route.py#L99-L105

The first thing this method does is write "start" into the output, but it is not guaranteed to do so while the main threads awaits it. It seems like the cases where this test failed, the output was simply not written within the first 0.1 seconds. 

The next part of the test waits for the indicator lock: https://github.com/OpenSlides/openslides-backend/blob/5146af65d63b496c40d9eafff31d823c67c4b371/tests/system/action/test_migration_route.py#L119 which is only released once the output is writter, therefore the next progress command must always return this output. Since the full problem is only a race condition in the test setup and does not impact the actual behaviour AND the output is there in the test, but just a bit later than expected, I'm simply deleting the first output assert to fix this problem :D