### PR TITLE
Add migration to remove empty structure level remnants

### DIFF
--- a/global/data/example-data.json
+++ b/global/data/example-data.json
@@ -1,5 +1,5 @@
 {
-    "_migration_index": 52,
+    "_migration_index": 53,
     "organization": {
         "1": {
             "id": 1,

--- a/global/data/initial-data.json
+++ b/global/data/initial-data.json
@@ -1,5 +1,5 @@
 {
-    "_migration_index": 52,
+    "_migration_index": 53,
     "organization": {
         "1": {
             "id": 1,

--- a/openslides_backend/migrations/migrations/0052_remove_structure_level_remnants.py
+++ b/openslides_backend/migrations/migrations/0052_remove_structure_level_remnants.py
@@ -1,0 +1,26 @@
+from datastore.migrations import BaseModelMigration
+from datastore.shared.util import fqid_from_collection_and_id
+from datastore.writer.core import BaseRequestEvent, RequestUpdateEvent
+
+
+class Migration(BaseModelMigration):
+    """
+    This migration removes all remnants of the old structure level field in meeting users.
+    """
+
+    target_migration_index = 53
+
+    def migrate_models(self) -> list[BaseRequestEvent] | None:
+        events: list[BaseRequestEvent] = []
+        db_models = self.reader.get_all("meeting_user")
+        for id_, model in db_models.items():
+            if "structure_level" in model:
+                events.append(
+                    RequestUpdateEvent(
+                        fqid_from_collection_and_id("meeting_user", id_),
+                        {
+                            "structure_level": None,
+                        },
+                    )
+                )
+        return events

--- a/tests/system/migrations/test_0052_remove_structure_level_remnants.py
+++ b/tests/system/migrations/test_0052_remove_structure_level_remnants.py
@@ -1,0 +1,47 @@
+def test_migration(write, finalize, assert_model):
+    write(
+        {
+            "type": "create",
+            "fqid": "meeting_user/1",
+            "fields": {
+                "id": 1,
+                "structure_level": "WeAreNumberOne",
+            },
+        },
+        {
+            "type": "create",
+            "fqid": "meeting_user/2",
+            "fields": {
+                "id": 2,
+                "structure_level": "",
+            },
+        },
+        {
+            "type": "create",
+            "fqid": "meeting_user/3",
+            "fields": {
+                "id": 3,
+            },
+        },
+    )
+
+    finalize("0052_remove_structure_level_remnants")
+
+    assert_model(
+        "meeting_user/1",
+        {
+            "id": 1,
+        },
+    )
+    assert_model(
+        "meeting_user/2",
+        {
+            "id": 2,
+        },
+    )
+    assert_model(
+        "meeting_user/3",
+        {
+            "id": 3,
+        },
+    )

--- a/tests/system/migrations/test_with_sql_dump.py
+++ b/tests/system/migrations/test_with_sql_dump.py
@@ -34,6 +34,12 @@ def test_with_sql_dump():
                     cursor.execute("SET session_replication_role = 'origin'")
                 else:
                     cursor.execute(content, [])
+            # create dummy position if none is present
+            cursor.execute("SELECT COUNT(*) FROM positions")
+            if cursor.fetchone()[0] == 0:
+                cursor.execute(
+                    "INSERT INTO positions (timestamp, user_id, migration_index) VALUES (NOW(), 0, 49)"
+                )
     migration_handler = injector.get(MigrationHandler)
     migration_handler.register_migrations(
         *MigrationWrapper.load_migrations("openslides_backend.migrations.migrations")


### PR DESCRIPTION
Responsible for the error described in https://github.com/OpenSlides/openslides-backend/issues/2319

The error stems from these line in the original structure level migration:
https://github.com/OpenSlides/openslides-backend/blob/3328b191efcfb276cd9e5fa16496305d1dd43995/openslides_backend/migrations/migrations/0049_enhance_structure_levels.py#L48-L49
which only removes the old structure level if it had content. We had this kind of error multiple times in the past, we should try to sensibilize ourselves for spotting these, while writing the code as well as during reviews.