### PR TITLE
Replace `lxml` with existing `bs4` methods

### DIFF
--- a/openslides_backend/action/actions/motion/mixins.py
+++ b/openslides_backend/action/actions/motion/mixins.py
@@ -2,12 +2,11 @@ from hashlib import md5
 from typing import Any
 
 import simplejson as json
-from bs4 import BeautifulSoup
-
-from openslides_backend.shared.filters import And, FilterOperator
 
 from ....services.datastore.commands import GetManyRequest
 from ....services.datastore.interface import DatastoreService
+from ....shared.filters import And, FilterOperator
+from ....shared.html import get_text_from_html
 from ....shared.patterns import fqid_from_collection_and_id
 from ....shared.util import ALLOWED_HTML_TAGS_STRICT, validate_html
 from ...action import Action
@@ -84,20 +83,15 @@ class TextHashMixin(Action):
     @staticmethod
     def get_hash_for_motion(motion: dict[str, Any]) -> str | None:
         if html := motion.get("text"):
-            text = TextHashMixin.get_text_from_html(html)
+            text = get_text_from_html(html)
         elif paragraphs := motion.get("amendment_paragraphs"):
             paragraph_texts = {
-                key: TextHashMixin.get_text_from_html(html)
-                for key, html in paragraphs.items()
+                key: get_text_from_html(html) for key, html in paragraphs.items()
             }
             text = json.dumps(paragraph_texts, sort_keys=True)
         else:
             return None
         return TextHashMixin.get_hash(text)
-
-    @staticmethod
-    def get_text_from_html(html: str) -> str:
-        return BeautifulSoup(html, features="html.parser").get_text()
 
     @staticmethod
     def get_hash(text: str) -> str:

--- a/openslides_backend/action/mixins/send_email_mixin.py
+++ b/openslides_backend/action/mixins/send_email_mixin.py
@@ -9,11 +9,9 @@ from email.message import EmailMessage
 from email.utils import format_datetime, make_msgid
 from typing import Any
 
-from lxml import html as lxml_html  # type: ignore
-from lxml.html.clean import clean_html  # type: ignore
-
 from ...shared.env import is_truthy
 from ...shared.exceptions import ActionException
+from ...shared.html import get_text_from_html
 from ..action import Action
 
 SendErrors = dict[str, tuple[int, bytes]]
@@ -141,8 +139,7 @@ class EmailUtils:
         message = EmailMessage()
         if html:
             if contentplain == "":
-                tree = lxml_html.fromstring(content)
-                contentplain = clean_html(tree).text_content().strip()
+                contentplain = get_text_from_html(content)
             if contentplain:
                 message.set_content(contentplain)
             message.add_alternative(content, subtype="html")

--- a/openslides_backend/shared/html.py
+++ b/openslides_backend/shared/html.py
@@ -1,0 +1,5 @@
+from bs4 import BeautifulSoup
+
+
+def get_text_from_html(html: str) -> str:
+    return BeautifulSoup(html, features="html.parser").get_text()

--- a/requirements/partial/requirements_production.txt
+++ b/requirements/partial/requirements_production.txt
@@ -4,7 +4,6 @@ bleach[css]==6.1.0
 dependency_injector==4.41.0
 fastjsonschema==2.19.1
 gunicorn==21.2.0
-lxml==5.1.0
 pypdf[crypto]==4.1.0
 requests==2.31.0
 roman==4.1


### PR DESCRIPTION
fixes https://github.com/OpenSlides/openslides-backend/issues/2353

moved the existing method using `bs4` into the `shared` folder and used it in the email mxin where `lxml` was previously used.