### PR TITLE
Fix auth service URL in requirements

### DIFF
--- a/requirements/partial/requirements_packaged_services.txt
+++ b/requirements/partial/requirements_packaged_services.txt
@@ -1,2 +1,2 @@
 git+https://github.com/OpenSlides/openslides-datastore-service.git@${DATASTORE_COMMIT_HASH}
-git+https://github.com/jsangmeister/openslides-auth-service.git@${AUTH_COMMIT_HASH}#egg=authlib&subdirectory=auth/libraries/pip-auth
+git+https://github.com/OpenSlides/openslides-auth-service.git@${AUTH_COMMIT_HASH}#egg=authlib&subdirectory=auth/libraries/pip-auth


### PR DESCRIPTION
Seems like I accidentally left my fork URL in the requirements file in https://github.com/OpenSlides/openslides-backend/pull/2041. This should of course be changed.