### PR TITLE
Add get_forwarding_committee presenter

### DIFF
--- a/openslides_backend/presenter/__init__.py
+++ b/openslides_backend/presenter/__init__.py
@@ -4,6 +4,7 @@ from . import (  # noqa
     check_mediafile_id,
     export_meeting,
     get_active_users_amount,
+    get_forwarding_committees,
     get_forwarding_meetings,
     get_history_information,
     get_user_related_models,

--- a/openslides_backend/presenter/get_forwarding_committees.py
+++ b/openslides_backend/presenter/get_forwarding_committees.py
@@ -1,0 +1,48 @@
+from typing import Any
+
+import fastjsonschema
+
+from ..shared.patterns import fqid_from_collection_and_id
+from ..shared.schema import required_id_schema, schema_version
+from .base import BasePresenter
+from .presenter import register_presenter
+
+get_forwarding_committees_schema = fastjsonschema.compile(
+    {
+        "$schema": schema_version,
+        "type": "object",
+        "title": "get_forwarding_committees",
+        "description": "get forwarding committees",
+        "properties": {
+            "committee_id": required_id_schema,
+        },
+        "required": ["committee_id"],
+    }
+)
+
+
+@register_presenter("get_forwarding_committees")
+class GetForwardingCommittees(BasePresenter):
+    """
+    Get forwarded committees.
+    """
+
+    schema = get_forwarding_committees_schema
+
+    def get_result(self) -> Any:
+        committee = self.datastore.get(
+            fqid_from_collection_and_id("committee", self.data["committee_id"]),
+            ["receive_forwardings_from_committee_ids"],
+        )
+
+        if not committee.get("receive_forwardings_from_committee_ids"):
+            return []
+
+        result = []
+        for committee_id in committee["receive_forwardings_from_committee_ids"]:
+            committee_data = self.datastore.get(
+                fqid_from_collection_and_id("committee", committee_id), ["name"]
+            )
+            if committee_data.get("name"):
+                result.append(committee_data["name"])
+        return result

--- a/tests/system/presenter/test_get_forwarding_committees.py
+++ b/tests/system/presenter/test_get_forwarding_committees.py
@@ -1,0 +1,64 @@
+from .base import BasePresenterTestCase
+
+
+class TestGetForwardingCommittees(BasePresenterTestCase):
+    def test_correct_single(self) -> None:
+        self.set_models(
+            {
+                "committee/1": {
+                    "name": "committee_1",
+                    "receive_forwardings_from_committee_ids": [2],
+                },
+                "committee/2": {
+                    "name": "com2",
+                },
+            }
+        )
+        status_code, data = self.request(
+            "get_forwarding_committees", {"committee_id": 1}
+        )
+        assert status_code == 200
+        assert data == ["com2"]
+
+    def test_correct_multiple(self) -> None:
+        self.set_models(
+            {
+                "committee/1": {
+                    "name": "committee_1",
+                    "receive_forwardings_from_committee_ids": [2, 3, 4],
+                },
+                "committee/2": {
+                    "name": "com2",
+                },
+                "committee/3": {
+                    "name": "com3",
+                },
+                "committee/4": {
+                    "name": "com4",
+                },
+            }
+        )
+        status_code, data = self.request(
+            "get_forwarding_committees", {"committee_id": 1}
+        )
+        assert status_code == 200
+        assert data == ["com2", "com3", "com4"]
+
+    def test_correct_empty(self) -> None:
+        self.set_models(
+            {
+                "committee/1": {
+                    "name": "committee_1",
+                },
+            }
+        )
+        status_code, data = self.request(
+            "get_forwarding_committees", {"committee_id": 1}
+        )
+        assert status_code == 200
+        assert data == []
+
+    def test_missing_committee_id(self) -> None:
+        status_code, data = self.request("get_forwarding_committees", {})
+        assert status_code == 400
+        assert "data must contain ['committee_id'] properties" == data["message"]

--- a/tests/system/presenter/test_get_forwarding_committees.py
+++ b/tests/system/presenter/test_get_forwarding_committees.py
@@ -1,10 +1,15 @@
 from .base import BasePresenterTestCase
 
+TEST_USER_PW = "test"
+
 
 class TestGetForwardingCommittees(BasePresenterTestCase):
     def test_correct_single(self) -> None:
         self.set_models(
             {
+                "meeting/5": {
+                    "committee_id": 1,
+                },
                 "committee/1": {
                     "name": "committee_1",
                     "receive_forwardings_from_committee_ids": [2],
@@ -14,15 +19,16 @@ class TestGetForwardingCommittees(BasePresenterTestCase):
                 },
             }
         )
-        status_code, data = self.request(
-            "get_forwarding_committees", {"committee_id": 1}
-        )
+        status_code, data = self.request("get_forwarding_committees", {"meeting_id": 5})
         assert status_code == 200
         assert data == ["com2"]
 
     def test_correct_multiple(self) -> None:
         self.set_models(
             {
+                "meeting/5": {
+                    "committee_id": 1,
+                },
                 "committee/1": {
                     "name": "committee_1",
                     "receive_forwardings_from_committee_ids": [2, 3, 4],
@@ -38,27 +44,50 @@ class TestGetForwardingCommittees(BasePresenterTestCase):
                 },
             }
         )
-        status_code, data = self.request(
-            "get_forwarding_committees", {"committee_id": 1}
-        )
+        status_code, data = self.request("get_forwarding_committees", {"meeting_id": 5})
         assert status_code == 200
         assert data == ["com2", "com3", "com4"]
 
     def test_correct_empty(self) -> None:
         self.set_models(
             {
+                "meeting/5": {
+                    "committee_id": 1,
+                },
                 "committee/1": {
                     "name": "committee_1",
                 },
             }
         )
-        status_code, data = self.request(
-            "get_forwarding_committees", {"committee_id": 1}
-        )
+        status_code, data = self.request("get_forwarding_committees", {"meeting_id": 5})
         assert status_code == 200
         assert data == []
 
     def test_missing_committee_id(self) -> None:
         status_code, data = self.request("get_forwarding_committees", {})
         assert status_code == 400
-        assert "data must contain ['committee_id'] properties" == data["message"]
+        assert "data must contain ['meeting_id'] properties" == data["message"]
+
+    def test_no_permissions(self) -> None:
+        self.set_models(
+            {
+                "user/3": {
+                    "username": "test",
+                    "is_active": True,
+                    "default_password": TEST_USER_PW,
+                    "password": self.auth.hash(TEST_USER_PW),
+                    "meeting_user_ids": [3],
+                },
+                "meeting_user/3": {
+                    "meeting_id": 3,
+                    "user_id": 3,
+                    "group_ids": [3],
+                },
+                "meeting/3": {"group_ids": [3]},
+                "group/3": {"meeting_id": 3},
+            }
+        )
+        self.client.login("test", TEST_USER_PW)
+        status_code, data = self.request("get_forwarding_committees", {"meeting_id": 3})
+        assert status_code == 403
+        assert "Missing permission" in data["message"]


### PR DESCRIPTION
Resolve #2356 

payload: A committee_id, returns: a list with committee names

@jsangmeister  I have found no matching perm. We will need to add meeting_id to the payload, if we want to use
the user.can_manage perm.