### PR TITLE
Fix return type

### DIFF
--- a/openslides_backend/action/generics/update.py
+++ b/openslides_backend/action/generics/update.py
@@ -29,5 +29,5 @@ class UpdateAction(Action):
             k: v for k, v in instance.items() if k != "id" and not k.startswith("meta_")
         }
         if not fields:
-            return []  # type: ignore # since mypy 1.10.0 appears: error: No return value expected  [return-value]
+            return
         yield self.build_event(EventType.Update, fqid, fields)


### PR DESCRIPTION
This was not a mypy bug, but rather a fix. AFAIK, mypy previously did not support empty `return`s in generators, which are valid python code, and has seemingly finally fixed this.