### PR TITLE
Fix html.parser error for empty html, add skipped file import

### DIFF
--- a/openslides_backend/shared/html.py
+++ b/openslides_backend/shared/html.py
@@ -2,4 +2,7 @@ from bs4 import BeautifulSoup
 
 
 def get_text_from_html(html: str) -> str:
-    return BeautifulSoup(html, features="html.parser").get_text()
+    if html:
+        return BeautifulSoup(html, features="html.parser").get_text()
+    else:
+        return ""

--- a/tests/system/action/meeting/test_import.py
+++ b/tests/system/action/meeting/test_import.py
@@ -2,6 +2,8 @@ import base64
 import time
 from typing import Any
 
+import pytest
+
 from openslides_backend.action.action_worker import ActionWorkerState
 from openslides_backend.migrations import get_backend_migration_index
 from openslides_backend.models.models import Meeting
@@ -2417,3 +2419,10 @@ class MeetingImport(BaseActionTestCase):
             },
         )
         self.assert_model_not_exists("user/2")
+
+    @pytest.mark.skip()
+    def test_import_os3_data(self) -> None:
+        data_raw = get_initial_data_file("global/data/export-OS3-demo.json")
+        data = {"committee_id": 1, "meeting": data_raw}
+        response = self.request("meeting.import", data)
+        self.assert_status_code(response, 200)


### PR DESCRIPTION
The html.parser can't parse empty (html-)fields, now returns an empty string