### PR TITLE
Raise proper error for `meeting_id === null` in mediafile.update

### DIFF
--- a/openslides_backend/action/actions/mediafile/mixins.py
+++ b/openslides_backend/action/actions/mediafile/mixins.py
@@ -104,7 +104,7 @@ class MediafileMixin(Action):
                 raise MissingPermission(
                     OrganizationManagementLevel.CAN_MANAGE_ORGANIZATION
                 )
-            if "meeting_id" not in instance_fields:
+            if "meeting_id" not in instance_fields or instance["meeting_id"] == None:
                 return
         else:
             assert collection == "meeting"

--- a/openslides_backend/action/actions/mediafile/mixins.py
+++ b/openslides_backend/action/actions/mediafile/mixins.py
@@ -104,10 +104,7 @@ class MediafileMixin(Action):
                 raise MissingPermission(
                     OrganizationManagementLevel.CAN_MANAGE_ORGANIZATION
                 )
-            if (
-                "meeting_id" not in instance_fields
-                or instance["meeting_id"] is not None
-            ):
+            if "meeting_id" not in instance_fields:
                 return
         else:
             assert collection == "meeting"

--- a/openslides_backend/action/actions/mediafile/mixins.py
+++ b/openslides_backend/action/actions/mediafile/mixins.py
@@ -104,7 +104,10 @@ class MediafileMixin(Action):
                 raise MissingPermission(
                     OrganizationManagementLevel.CAN_MANAGE_ORGANIZATION
                 )
-            if "meeting_id" not in instance_fields or instance["meeting_id"] == None:
+            if (
+                "meeting_id" not in instance_fields
+                or instance["meeting_id"] is not None
+            ):
                 return
         else:
             assert collection == "meeting"

--- a/openslides_backend/action/actions/mediafile/update.py
+++ b/openslides_backend/action/actions/mediafile/update.py
@@ -4,7 +4,7 @@ from ....models.models import Mediafile, MeetingMediafile
 from ....permissions.permissions import Permissions
 from ....shared.exceptions import ActionException
 from ....shared.patterns import fqid_from_collection_and_id
-from ....shared.schema import optional_id_schema
+from ....shared.schema import required_id_schema
 from ...generics.update import UpdateAction
 from ...mixins.meeting_mediafile_helper import find_meeting_mediafile
 from ...util.default_schema import DefaultSchema
@@ -29,7 +29,7 @@ class MediafileUpdate(MediafileMixin, UpdateAction, MediafileCalculatedFieldsMix
     schema = DefaultSchema(Mediafile()).get_update_schema(
         optional_properties=["title", "token"],
         additional_optional_fields={
-            "meeting_id": optional_id_schema,
+            "meeting_id": required_id_schema,
             "access_group_ids": MeetingMediafile.access_group_ids.get_schema(),
         },
     )

--- a/tests/system/action/mediafile/test_update.py
+++ b/tests/system/action/mediafile/test_update.py
@@ -909,6 +909,14 @@ class MediafileUpdateActionTest(BaseActionTestCase):
             "data must not contain {'filename'} properties", response.json["message"]
         )
 
+    def test_update_title_with_orga_owner_meeting_id_none(self) -> None:
+        self.set_models(self.orga_permission_test_models)
+        response = self.request(
+            "mediafile.update", {"id": 111, "title": "blob.txt", "meeting_id": None}
+        )
+        self.assert_status_code(response, 400)
+        self.assertIn("data.meeting_id must be integer", response.json["message"])
+
     def test_update_access_group_with_orga_owner(self) -> None:
         self.set_models(self.orga_permission_test_models)
         response = self.request(


### PR DESCRIPTION
See OpenSlides/openslides-client#4135

<s>@Elblinator I leave merging to you, because I don't know, if you're going to want to put a staging label on this or not. IMO it's unnecessary, since changing the client will already fix the bug for the user. This is only a security feature.</s>