### PR TITLE
Assign rrenkert for docker in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
     schedule:
       interval: "daily"
     assignees:
-      - "r-peschke"
+      - "rrenkert"
     ignore:
       - dependency-name: "python"
         update-types: ["version-update:semver-minor"]


### PR DESCRIPTION
This change is necessary since rrenkert changes the docker images and needs to be notified.