### PR TITLE
Ensure speaker.delete only resets projector countdown with active speakers

### DIFF
--- a/docs/actions/speaker.delete.md
+++ b/docs/actions/speaker.delete.md
@@ -5,6 +5,7 @@
 
 ## Action
 Deletes the given speaker.
+Resets the projector_countdown if he was speaking.
 
 ## Permissions
 If the `speaker/meeting_user_id` doesn't belong to the request user, he needs `list_of_speakers.can_manage`

--- a/openslides_backend/action/actions/speaker/delete.py
+++ b/openslides_backend/action/actions/speaker/delete.py
@@ -65,5 +65,6 @@ class SpeakerDeleteAction(
             and not speaker.get("pause_time")
         ):
             self.decrease_structure_level_countdown(self.end_time, speaker)
-        self.control_los_countdown(speaker["meeting_id"], CountdownCommand.RESET)
+        if speaker.get("begin_time") and not speaker.get("end_time"):
+            self.control_los_countdown(speaker["meeting_id"], CountdownCommand.RESET)
         return super().update_instance(instance)

--- a/tests/system/action/speaker/test_delete.py
+++ b/tests/system/action/speaker/test_delete.py
@@ -468,4 +468,4 @@ class SpeakerDeleteActionTest(BaseActionTestCase):
                 "meeting_id": 1,
             },
         )
-        self.assertAlmostEqual(countdown["countdown_time"], 100, delta=now)
+        self.assertAlmostEqual(countdown["countdown_time"], now, delta=200)


### PR DESCRIPTION
Closes #2655 

There were no projector_countdown-related tests in the speaker delete test file, so I added some.