### PR TITLE
Fix wrong sorting of parsed language header

### DIFF
--- a/openslides_backend/i18n/translator.py
+++ b/openslides_backend/i18n/translator.py
@@ -56,7 +56,7 @@ class _Translator:
             code = code.split("-")[0]
             result.append((q, code))
         # sort by quality value and return only the codes
-        return [t[1] for t in sorted(result)]
+        return [t[1] for t in result]
 
 
 Translator = _Translator()


### PR DESCRIPTION
Fixed partly #2695 

Prefered language settings of browser (weighted by user, e.g. [de,en,cs]) should not sorted! In this example: [cs,de,en] -> cs translation is empty for password reset strings -> backend send empty email strings!