### PR TITLE
Fix mismatch of perm check of get-forwarding-meetings

### DIFF
--- a/openslides_backend/presenter/get_forwarding_meetings.py
+++ b/openslides_backend/presenter/get_forwarding_meetings.py
@@ -41,7 +41,7 @@ class GetForwardingMeetings(BasePresenter):
             self.data["meeting_id"],
         ):
             msg = "You are not allowed to perform presenter get_forwarding_meetings"
-            msg += f" Missing permission: {Permissions.Motion.CAN_MANAGE}"
+            msg += f" Missing permission: {Permissions.Motion.CAN_FORWARD}"
             raise PermissionDenied(msg)
 
         meeting = self.datastore.get(

--- a/tests/system/presenter/test_get_forwarding_meetings.py
+++ b/tests/system/presenter/test_get_forwarding_meetings.py
@@ -311,4 +311,4 @@ class TestGetForwardingMeetings(BasePresenterTestCase):
         )
         status_code, data = self.request("get_forwarding_meetings", {"meeting_id": 3})
         assert status_code == 403
-        assert "Missing permission: motion.can_manage" in data["message"]
+        assert "Missing permission: motion.can_forward" in data["message"]


### PR DESCRIPTION
Fix a mismatch between display and check of perms in the get_forwarding_meetings presenter.