### PR TITLE
Forbid unreasonable vote amounts

### DIFF
--- a/docs/actions/poll.create.md
+++ b/docs/actions/poll.create.md
@@ -1,55 +1,57 @@
 ## Payload
 
 Helper Interface for options to create:
-```
+```js
 Interface Option {
     // Exactly one of text, content_object_id or poll_candidate_user_ids must be given
-    text: string;  // topic-poll
-    content_object_id: Fqid; // must be one of  user or motion.
-    poll_candidate_user_ids: [user_ids]; // sorted list of user ids for candidate list election
+    text: string,  // topic-poll
+    content_object_id: Fqid, // must be one of  user or motion.
+    poll_candidate_user_ids: [user_ids], // sorted list of user ids for candidate list election
 
     // Only for type==analog, optional votes can be given
-    Y?: decimal(6); // Y, YN, YNA mode
-    N?: decimal(6); // N, YN, YNA mode
-    A?: decimal(6); // YNA mode
-}}
+    Y?: decimal(6), // Y, YN, YNA mode
+    N?: decimal(6), // N, YN, YNA mode
+    A?: decimal(6)  // YNA mode
+}
 ```
 
 Payload:
-```
+```js
 {
 // Required
-    title: string;
-    type: string;
-    pollmethod: string;
+    title: string,
+    type: string,
+    pollmethod: string,
 
-    meeting_id: Id;
-    options: Option[]; // must have at least one entry.
+    meeting_id: Id,
+    options: Option[], // must have at least one entry.
 
 // Optional
-    content_object_id: Fqid;
-    description: string;
-    min_votes_amount: number;
-    max_votes_amount: number;
-    allow_multiple_votes_per_candidate: boolean;
-    global_yes: boolean;
-    global_no: boolean;
-    global_abstain: boolean;
-    onehundred_percent_base: string;
+    content_object_id: Fqid,
+    description: string,
+    min_votes_amount: number,
+    max_votes_amount: number,
+    max_votes_per_option: number,
+    allow_multiple_votes_per_candidate: boolean,
+    global_yes: boolean,
+    global_no: boolean,
+    global_abstain: boolean,
+    onehundred_percent_base: string,
+    backend: string,
 
 // Only for non analog types
-    entitled_group_ids: Id[];
+    entitled_group_ids: Id[],
 
 // Only for type==analog
-    publish_immediately: boolean;
+    publish_immediately: boolean,
 
 // Only for type==analog, optional votes can be given
-    votesvalid?: decimal(6);
-    votesinvalid?: decimal(6);
-    votescast?: decimal(6);
-    amount_global_yes?: decimal(6);
-    amount_global_no?: decimal(6);
-    amount_global_abstain?: decimal(6);
+    votesvalid?: decimal(6),
+    votesinvalid?: decimal(6),
+    votescast?: decimal(6),
+    amount_global_yes?: decimal(6),
+    amount_global_no?: decimal(6),
+    amount_global_abstain?: decimal(6)
 }
 ```
 
@@ -63,6 +65,8 @@ If the `type` is `pseudoanonymous`, `is_pseudoanonymized` has to be set to `true
 If the `content_object_id` points to a `motion` and the `motion_state` of the motion misses `allow_create_poll`, it is forbidden to create a poll.
 
 The `entitled_group_ids` may not contain the meetings `anonymous_group_id`.
+
+The `max_votes_per_option` and `min_votes_amount` must be smaller or equal to `max_votes_amount`.
 
 ## Permissions
 The request user needs:

--- a/docs/actions/poll.update.md
+++ b/docs/actions/poll.update.md
@@ -1,34 +1,36 @@
 ## Payload
-```
+```js
 {
 // Required
-    id: Id;
+    id: Id,
 
 // Optional, only if state == created
-    pollmethod: string;
-    min_votes_amount: number;
-    max_votes_amount: number;
-    allow_multiple_votes_per_candidate: boolean;
-    global_yes: boolean;
-    global_no: boolean;
-    global_abstain: boolean;
+    pollmethod: string,
+    min_votes_amount: number,
+    max_votes_amount: number,
+    max_votes_per_option: number,
+    allow_multiple_votes_per_candidate: boolean,
+    global_yes: boolean,
+    global_no: boolean,
+    global_abstain: boolean,
+    backend: string,
 
 // Optional, only if state == created, only for non analog types
-    entitled_group_ids: Id[];
+    entitled_group_ids: Id[],
 
 // Optional, every state
-    title: string;
-    description: string;
-    onehundred_percent_base: string;
+    title: string,
+    description: string,
+    onehundred_percent_base: string,
 
 // type==analog, every state
-    votesvalid?: number;
-    votesinvalid?: number;
-    votescast?: number;
-    publish_immediately: boolean;
+    votesvalid?: number,
+    votesinvalid?: number,
+    votescast?: number,
+    publish_immediately: boolean,
 
 // action called internally
-    entitled_users_at_stop: json;
+    entitled_users_at_stop: json
 }
 ```
 
@@ -38,6 +40,8 @@ For analog polls: If the state is created and at least one vote value is given (
 For electronic polls some fields can only be updated, if the state is *created*.
 
 The `entitled_group_ids` may not contain the meetings `anonymous_group_id`.
+
+The `max_votes_per_option` and `min_votes_amount` must be smaller or equal to `max_votes_amount` after the model had been updated.
 
 ## Permissions
 The request user needs:

--- a/openslides_backend/action/actions/poll/create.py
+++ b/openslides_backend/action/actions/poll/create.py
@@ -13,7 +13,7 @@ from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
 from ..option.create import OptionCreateAction
 from .base import base_check_onehundred_percent_base
-from .mixins import PollHistoryMixin, PollPermissionMixin
+from .mixins import PollHistoryMixin, PollPermissionMixin, PollValidationMixin
 
 options_schema = {
     "description": "A option inside a poll create schema",
@@ -32,6 +32,7 @@ options_schema = {
 
 @register_action("poll.create")
 class PollCreateAction(
+    PollValidationMixin,
     SequentialNumbersMixin,
     CreateAction,
     PollPermissionMixin,

--- a/openslides_backend/action/actions/poll/mixins.py
+++ b/openslides_backend/action/actions/poll/mixins.py
@@ -24,20 +24,20 @@ class PollValidationMixin(Action):
     def validate_instance(self, instance: dict[str, Any]) -> None:
         super().validate_instance(instance)
 
-        max_votes_amount = instance.get("max_votes_amount")
-        min_votes_amount = instance.get("min_votes_amount")
-        max_votes_per_option = instance.get("max_votes_per_option")
         if poll_id := instance.get("id"):
             poll = self.datastore.get(
                 fqid_from_collection_and_id("poll", poll_id),
                 ["max_votes_amount", "min_votes_amount", "max_votes_per_option"],
             )
-        if max_votes_amount is None:
-            max_votes_amount = poll["max_votes_amount"] if poll_id else 1
-        if min_votes_amount is None:
-            min_votes_amount = poll["min_votes_amount"] if poll_id else 1
-        if max_votes_per_option is None:
-            max_votes_per_option = poll["max_votes_per_option"] if poll_id else 1
+        max_votes_amount = instance.get(
+            "max_votes_amount", poll["max_votes_amount"] if poll_id else 1
+        )
+        min_votes_amount = instance.get(
+            "min_votes_amount", poll["min_votes_amount"] if poll_id else 1
+        )
+        max_votes_per_option = instance.get(
+            "max_votes_per_option", poll["max_votes_per_option"] if poll_id else 1
+        )
 
         if max_votes_amount < max_votes_per_option:
             raise ActionException(

--- a/openslides_backend/action/actions/poll/mixins.py
+++ b/openslides_backend/action/actions/poll/mixins.py
@@ -20,6 +20,35 @@ from ..vote.user_token_helper import get_user_token
 from .functions import check_poll_or_option_perms
 
 
+class PollValidationMixin(Action):
+    def validate_instance(self, instance: dict[str, Any]) -> None:
+        super().validate_instance(instance)
+
+        max_votes_amount = instance.get("max_votes_amount")
+        min_votes_amount = instance.get("min_votes_amount")
+        max_votes_per_option = instance.get("max_votes_per_option")
+        if poll_id := instance.get("id"):
+            poll = self.datastore.get(
+                fqid_from_collection_and_id("poll", poll_id),
+                ["max_votes_amount", "min_votes_amount", "max_votes_per_option"],
+            )
+        if max_votes_amount is None:
+            max_votes_amount = poll["max_votes_amount"] if poll_id else 1
+        if min_votes_amount is None:
+            min_votes_amount = poll["min_votes_amount"] if poll_id else 1
+        if max_votes_per_option is None:
+            max_votes_per_option = poll["max_votes_per_option"] if poll_id else 1
+
+        if max_votes_amount < max_votes_per_option:
+            raise ActionException(
+                "The maximum votes per option cannot be higher than the maximum amount of votes in total."
+            )
+        if max_votes_amount < min_votes_amount:
+            raise ActionException(
+                "The minimum amount of votes cannot be higher than the maximum amount of votes."
+            )
+
+
 class PollPermissionMixin(Action):
     def check_permissions(self, instance: dict[str, Any]) -> None:
         if "meeting_id" in instance:

--- a/openslides_backend/action/actions/poll/update.py
+++ b/openslides_backend/action/actions/poll/update.py
@@ -11,11 +11,12 @@ from ...mixins.forbid_anonymous_group_mixin import ForbidAnonymousGroupMixin
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
 from .base import base_check_onehundred_percent_base
-from .mixins import PollHistoryMixin, PollPermissionMixin
+from .mixins import PollHistoryMixin, PollPermissionMixin, PollValidationMixin
 
 
 @register_action("poll.update")
 class PollUpdateAction(
+    PollValidationMixin,
     ExtendHistoryMixin,
     UpdateAction,
     PollPermissionMixin,

--- a/tests/system/action/option/test_update.py
+++ b/tests/system/action/option/test_update.py
@@ -31,6 +31,9 @@ class OptionUpdateActionTest(BaseActionTestCase):
                     "type": "analog",
                     "state": "created",
                     "pollmethod": "YNA",
+                    "max_votes_amount": 1,
+                    "max_votes_per_option": 1,
+                    "min_votes_amount": 1,
                     "meeting_id": 1,
                     "option_ids": [57],
                 },
@@ -250,9 +253,6 @@ class OptionUpdateActionTest(BaseActionTestCase):
                     "data": [
                         {
                             "id": 65,
-                            "max_votes_amount": 1,
-                            "max_votes_per_option": 1,
-                            "min_votes_amount": 1,
                             "onehundred_percent_base": "YNA",
                             "pollmethod": "YNA",
                             "title": "Abstimmung",

--- a/tests/system/action/poll/test_create.py
+++ b/tests/system/action/poll/test_create.py
@@ -984,6 +984,47 @@ class CreatePoll(BasePollTestCase):
         self.assert_status_code(response, 400)
         self.assert_model_not_exists("poll/1")
 
+    def test_max_votes_per_option_smaller_max_votes_amount(self) -> None:
+        """Also asserts that default values are respected."""
+        response = self.request(
+            "poll.create",
+            {
+                "title": "test",
+                "type": "analog",
+                "pollmethod": "Y",
+                "options": [{"text": "test2", "Y": "10.000000"}],
+                "meeting_id": 1,
+                "max_votes_per_option": 2,
+            },
+        )
+        self.assert_status_code(response, 400)
+        assert (
+            response.json["message"]
+            == "The maximum votes per option cannot be higher than the maximum amount of votes in total."
+        )
+        self.assert_model_not_exists("poll/1")
+
+    def test_max_votes_amount_smaller_min(self) -> None:
+        response = self.request(
+            "poll.create",
+            {
+                "title": "test",
+                "type": "analog",
+                "pollmethod": "Y",
+                "options": [{"text": "test2", "Y": "10.000000"}],
+                "meeting_id": 1,
+                "min_votes_amount": 5,
+                "max_votes_amount": 2,
+                "max_votes_per_option": 2,
+            },
+        )
+        self.assert_status_code(response, 400)
+        assert (
+            response.json["message"]
+            == "The minimum amount of votes cannot be higher than the maximum amount of votes."
+        )
+        self.assert_model_not_exists("poll/1")
+
     def test_create_poll_candidate_list(self) -> None:
         response = self.request(
             "poll.create",


### PR DESCRIPTION
Forbid max_votes_per_option to be bigger than max_votes_amount and max_votes_amount to be smaller than min_vote_amounts.
Closes #2765 