### PR TITLE
Allow assign meetings for committee admins

### DIFF
--- a/docs/actions/user.assign_meetings.md
+++ b/docs/actions/user.assign_meetings.md
@@ -25,7 +25,7 @@ Returns dictionary with `"succeeded": [meeting_ids], "standard_group": [meeting_
 Will raise an error if some of the selected meetings are locked from the inside via the `locked_from_inside` setting.
 
 ## Permissions
-The request user needs OML `can_manage_users`
+The request user needs CML `can_manage` rights in all meetings committees.
 
 explanation: Usually the field `group_ids` can be changed also with committee- or meeting-rights for
 all related objects, see [user.update#permissions](user.update.md#permissions), field group C. Currently the client allows

--- a/openslides_backend/action/actions/user/assign_meetings.py
+++ b/openslides_backend/action/actions/user/assign_meetings.py
@@ -53,11 +53,7 @@ class UserAssignMeetings(MeetingUserHelperMixin, UpdateAction):
                 [GetManyRequest("meeting", meeting_ids, ["committee_id"])],
                 lock_result=False,
             )["meeting"]
-            committee_ids = {
-                meeting["committee_id"]
-                for meeting in meetings.values()
-                if meeting.get("committee_id")
-            }
+            committee_ids = {meeting["committee_id"] for meeting in meetings.values()}
             committee_ids = {
                 committee_id
                 for committee_id in committee_ids

--- a/openslides_backend/action/actions/user/assign_meetings.py
+++ b/openslides_backend/action/actions/user/assign_meetings.py
@@ -1,9 +1,10 @@
 from typing import Any
 
 from ....models.models import User
-from ....permissions.management_levels import OrganizationManagementLevel
+from ....permissions.management_levels import CommitteeManagementLevel, OrganizationManagementLevel
+from ....permissions.permission_helper import has_committee_management_level, has_organization_management_level
 from ....services.datastore.commands import GetManyRequest
-from ....shared.exceptions import ActionException
+from ....shared.exceptions import ActionException, MissingPermission
 from ....shared.filters import And, FilterOperator
 from ....shared.patterns import fqid_from_collection_and_id
 from ....shared.schema import id_list_schema
@@ -33,6 +34,14 @@ class UserAssignMeetings(MeetingUserHelperMixin, UpdateAction):
     )
     permission = OrganizationManagementLevel.CAN_MANAGE_USERS
     use_meeting_ids_for_archived_meeting_check = True
+
+    def check_permissions(self, instance: dict[str, Any]) -> None:
+        if (not has_organization_management_level(self.datastore, self.user_id, OrganizationManagementLevel.CAN_MANAGE_USERS)) and (meeting_ids := instance.get("meeting_ids")):
+            meetings = self.datastore.get_many([GetManyRequest("meeting", meeting_ids, ["committee_id"])], lock_result=False)["meeting"]
+            committee_ids = {meeting["committee_id"] for meeting in meetings.values() if meeting.get("committee_id")}
+            committee_ids = {committee_id for committee_id in committee_ids if not has_committee_management_level(self.datastore, self.user_id, CommitteeManagementLevel.CAN_MANAGE, committee_id)}
+            if committee_ids:
+                raise MissingPermission({CommitteeManagementLevel.CAN_MANAGE: committee_ids})
 
     def update_instance(self, instance: dict[str, Any]) -> dict[str, Any]:
         self.check_meetings(instance)

--- a/tests/system/action/user/test_assign_meetings.py
+++ b/tests/system/action/user/test_assign_meetings.py
@@ -368,6 +368,8 @@ class UserAssignMeetings(BaseActionTestCase):
     def test_assign_meetings_no_permissions(self) -> None:
         self.set_models(
             {
+                "committee/1": {"meeting_ids": [1,2]},
+                "committee/2": {"meeting_ids": [3]},
                 "group/1": {"name": "Test", "meeting_id": 1},
                 "group/2": {"name": "Default Group", "meeting_id": 2},
                 "group/3": {"name": "In Meeting", "meeting_id": 3},
@@ -375,16 +377,19 @@ class UserAssignMeetings(BaseActionTestCase):
                     "name": "Find Test",
                     "group_ids": [1],
                     "is_active_in_organization_id": 1,
+                    "committee_id": 1
                 },
                 "meeting/2": {
                     "name": "No Test and Not in Meeting",
                     "group_ids": [2],
                     "is_active_in_organization_id": 1,
+                    "committee_id": 1
                 },
                 "meeting/3": {
                     "name": "No Test and in Meeting",
                     "group_ids": [3],
                     "is_active_in_organization_id": 1,
+                    "committee_id": 2
                 },
                 "user/1": {
                     "organization_management_level": None,
@@ -401,9 +406,156 @@ class UserAssignMeetings(BaseActionTestCase):
         )
         self.assert_status_code(response, 403)
         assert (
-            "Missing OrganizationManagementLevel: can_manage_users"
+            "You are not allowed to perform action user.assign_meetings. Missing permission: CommitteeManagementLevel can_manage in committees {1, 2}"
             in response.json["message"]
         )
+
+    def test_assign_meetings_some_permissions(self) -> None:
+        self.set_models(
+            {
+                "committee/1": {"meeting_ids": [1,2]},
+                "committee/2": {"meeting_ids": [3]},
+                "group/1": {"name": "Test", "meeting_id": 1},
+                "group/2": {"name": "Default Group", "meeting_id": 2},
+                "group/3": {"name": "In Meeting", "meeting_id": 3},
+                "group/4": {"name": "def", "meeting_id": 1},
+                "group/5": {"name": "def", "meeting_id": 2},
+                "group/6": {"name": "def", "meeting_id": 3},
+                "meeting/1": {
+                    "name": "Find Test",
+                    "group_ids": [1],
+                    "is_active_in_organization_id": 1,
+                    "committee_id": 1,
+                    "default_group_id": 4
+                },
+                "meeting/2": {
+                    "name": "No Test and Not in Meeting",
+                    "group_ids": [2],
+                    "is_active_in_organization_id": 1,
+                    "committee_id": 1,
+                    "default_group_id": 5
+                },
+                "meeting/3": {
+                    "name": "No Test and in Meeting",
+                    "group_ids": [3],
+                    "is_active_in_organization_id": 1,
+                    "committee_id": 2,
+                    "default_group_id": 6
+                },
+                "user/1": {
+                    "organization_management_level": None,
+                    "committee_management_ids": [1]
+                },
+            }
+        )
+        response = self.request(
+            "user.assign_meetings",
+            {
+                "id": 1,
+                "meeting_ids": [1, 2, 3],
+                "group_name": "Test",
+            },
+        )
+        self.assert_status_code(response, 403)
+        assert (
+            "You are not allowed to perform action user.assign_meetings. Missing permission: CommitteeManagementLevel can_manage in committee {2}"
+            in response.json["message"]
+        )
+
+    def test_assign_meetings_all_cml_permissions(self) -> None:
+        self.set_models(
+            {
+                "committee/1": {"meeting_ids": [1,2]},
+                "committee/2": {"meeting_ids": [3]},
+                "group/1": {"name": "Test", "meeting_id": 1},
+                "group/2": {"name": "Default Group", "meeting_id": 2},
+                "group/3": {"name": "In Meeting", "meeting_id": 3},
+                "group/4": {"name": "def", "meeting_id": 1},
+                "group/5": {"name": "def", "meeting_id": 2},
+                "group/6": {"name": "def", "meeting_id": 3},
+                "meeting/1": {
+                    "name": "Find Test",
+                    "group_ids": [1],
+                    "is_active_in_organization_id": 1,
+                    "committee_id": 1,
+                    "default_group_id": 4
+                },
+                "meeting/2": {
+                    "name": "No Test and Not in Meeting",
+                    "group_ids": [2],
+                    "is_active_in_organization_id": 1,
+                    "committee_id": 1,
+                    "default_group_id": 5
+                },
+                "meeting/3": {
+                    "name": "No Test and in Meeting",
+                    "group_ids": [3],
+                    "is_active_in_organization_id": 1,
+                    "committee_id": 2,
+                    "default_group_id": 6
+                },
+                "user/1": {
+                    "organization_management_level": None,
+                    "committee_management_ids": [1, 2]
+                },
+            }
+        )
+        response = self.request(
+            "user.assign_meetings",
+            {
+                "id": 1,
+                "meeting_ids": [1, 2, 3],
+                "group_name": "Test",
+            },
+        )
+        self.assert_status_code(response, 200)
+
+    def test_assign_meetings_oml_permission(self) -> None:
+        self.set_models(
+            {
+                "committee/1": {"meeting_ids": [1,2]},
+                "committee/2": {"meeting_ids": [3]},
+                "group/1": {"name": "Test", "meeting_id": 1},
+                "group/2": {"name": "Default Group", "meeting_id": 2},
+                "group/3": {"name": "In Meeting", "meeting_id": 3},
+                "group/4": {"name": "def", "meeting_id": 1},
+                "group/5": {"name": "def", "meeting_id": 2},
+                "group/6": {"name": "def", "meeting_id": 3},
+                "meeting/1": {
+                    "name": "Find Test",
+                    "group_ids": [1],
+                    "is_active_in_organization_id": 1,
+                    "committee_id": 1,
+                    "default_group_id": 4
+                },
+                "meeting/2": {
+                    "name": "No Test and Not in Meeting",
+                    "group_ids": [2],
+                    "is_active_in_organization_id": 1,
+                    "committee_id": 1,
+                    "default_group_id": 5
+                },
+                "meeting/3": {
+                    "name": "No Test and in Meeting",
+                    "group_ids": [3],
+                    "is_active_in_organization_id": 1,
+                    "committee_id": 2,
+                    "default_group_id": 6
+                },
+                "user/1": {
+                    "organization_management_level": "can_manage_users",
+                },
+            }
+        )
+        response = self.request(
+            "user.assign_meetings",
+            {
+                "id": 1,
+                "meeting_ids": [1, 2, 3],
+                "group_name": "Test",
+            },
+        )
+        self.assert_status_code(response, 200)
 
     def test_assign_meetings_archived_meetings(self) -> None:
         self.set_models(
@@ -414,16 +566,19 @@ class UserAssignMeetings(BaseActionTestCase):
                 "meeting/1": {
                     "name": "Archived",
                     "group_ids": [1],
+                    "committee_id": 1
                 },
                 "meeting/2": {
                     "name": "No Test and Not in Meeting",
                     "group_ids": [2],
                     "is_active_in_organization_id": 1,
+                    "committee_id": 1
                 },
                 "meeting/3": {
                     "name": "No Test and in Meeting",
                     "group_ids": [3],
                     "is_active_in_organization_id": 1,
+                    "committee_id": 1
                 },
             }
         )

--- a/tests/system/action/user/test_assign_meetings.py
+++ b/tests/system/action/user/test_assign_meetings.py
@@ -368,7 +368,7 @@ class UserAssignMeetings(BaseActionTestCase):
     def test_assign_meetings_no_permissions(self) -> None:
         self.set_models(
             {
-                "committee/1": {"meeting_ids": [1,2]},
+                "committee/1": {"meeting_ids": [1, 2]},
                 "committee/2": {"meeting_ids": [3]},
                 "group/1": {"name": "Test", "meeting_id": 1},
                 "group/2": {"name": "Default Group", "meeting_id": 2},
@@ -377,19 +377,19 @@ class UserAssignMeetings(BaseActionTestCase):
                     "name": "Find Test",
                     "group_ids": [1],
                     "is_active_in_organization_id": 1,
-                    "committee_id": 1
+                    "committee_id": 1,
                 },
                 "meeting/2": {
                     "name": "No Test and Not in Meeting",
                     "group_ids": [2],
                     "is_active_in_organization_id": 1,
-                    "committee_id": 1
+                    "committee_id": 1,
                 },
                 "meeting/3": {
                     "name": "No Test and in Meeting",
                     "group_ids": [3],
                     "is_active_in_organization_id": 1,
-                    "committee_id": 2
+                    "committee_id": 2,
                 },
                 "user/1": {
                     "organization_management_level": None,
@@ -413,7 +413,7 @@ class UserAssignMeetings(BaseActionTestCase):
     def test_assign_meetings_some_permissions(self) -> None:
         self.set_models(
             {
-                "committee/1": {"meeting_ids": [1,2]},
+                "committee/1": {"meeting_ids": [1, 2]},
                 "committee/2": {"meeting_ids": [3]},
                 "group/1": {"name": "Test", "meeting_id": 1},
                 "group/2": {"name": "Default Group", "meeting_id": 2},
@@ -426,25 +426,25 @@ class UserAssignMeetings(BaseActionTestCase):
                     "group_ids": [1],
                     "is_active_in_organization_id": 1,
                     "committee_id": 1,
-                    "default_group_id": 4
+                    "default_group_id": 4,
                 },
                 "meeting/2": {
                     "name": "No Test and Not in Meeting",
                     "group_ids": [2],
                     "is_active_in_organization_id": 1,
                     "committee_id": 1,
-                    "default_group_id": 5
+                    "default_group_id": 5,
                 },
                 "meeting/3": {
                     "name": "No Test and in Meeting",
                     "group_ids": [3],
                     "is_active_in_organization_id": 1,
                     "committee_id": 2,
-                    "default_group_id": 6
+                    "default_group_id": 6,
                 },
                 "user/1": {
                     "organization_management_level": None,
-                    "committee_management_ids": [1]
+                    "committee_management_ids": [1],
                 },
             }
         )
@@ -465,7 +465,7 @@ class UserAssignMeetings(BaseActionTestCase):
     def test_assign_meetings_all_cml_permissions(self) -> None:
         self.set_models(
             {
-                "committee/1": {"meeting_ids": [1,2]},
+                "committee/1": {"meeting_ids": [1, 2]},
                 "committee/2": {"meeting_ids": [3]},
                 "group/1": {"name": "Test", "meeting_id": 1},
                 "group/2": {"name": "Default Group", "meeting_id": 2},
@@ -478,25 +478,25 @@ class UserAssignMeetings(BaseActionTestCase):
                     "group_ids": [1],
                     "is_active_in_organization_id": 1,
                     "committee_id": 1,
-                    "default_group_id": 4
+                    "default_group_id": 4,
                 },
                 "meeting/2": {
                     "name": "No Test and Not in Meeting",
                     "group_ids": [2],
                     "is_active_in_organization_id": 1,
                     "committee_id": 1,
-                    "default_group_id": 5
+                    "default_group_id": 5,
                 },
                 "meeting/3": {
                     "name": "No Test and in Meeting",
                     "group_ids": [3],
                     "is_active_in_organization_id": 1,
                     "committee_id": 2,
-                    "default_group_id": 6
+                    "default_group_id": 6,
                 },
                 "user/1": {
                     "organization_management_level": None,
-                    "committee_management_ids": [1, 2]
+                    "committee_management_ids": [1, 2],
                 },
             }
         )
@@ -513,7 +513,7 @@ class UserAssignMeetings(BaseActionTestCase):
     def test_assign_meetings_oml_permission(self) -> None:
         self.set_models(
             {
-                "committee/1": {"meeting_ids": [1,2]},
+                "committee/1": {"meeting_ids": [1, 2]},
                 "committee/2": {"meeting_ids": [3]},
                 "group/1": {"name": "Test", "meeting_id": 1},
                 "group/2": {"name": "Default Group", "meeting_id": 2},
@@ -526,21 +526,21 @@ class UserAssignMeetings(BaseActionTestCase):
                     "group_ids": [1],
                     "is_active_in_organization_id": 1,
                     "committee_id": 1,
-                    "default_group_id": 4
+                    "default_group_id": 4,
                 },
                 "meeting/2": {
                     "name": "No Test and Not in Meeting",
                     "group_ids": [2],
                     "is_active_in_organization_id": 1,
                     "committee_id": 1,
-                    "default_group_id": 5
+                    "default_group_id": 5,
                 },
                 "meeting/3": {
                     "name": "No Test and in Meeting",
                     "group_ids": [3],
                     "is_active_in_organization_id": 1,
                     "committee_id": 2,
-                    "default_group_id": 6
+                    "default_group_id": 6,
                 },
                 "user/1": {
                     "organization_management_level": "can_manage_users",
@@ -563,22 +563,18 @@ class UserAssignMeetings(BaseActionTestCase):
                 "group/1": {"name": "Test", "meeting_id": 1},
                 "group/2": {"name": "Default Group", "meeting_id": 2},
                 "group/3": {"name": "In Meeting", "meeting_id": 3},
-                "meeting/1": {
-                    "name": "Archived",
-                    "group_ids": [1],
-                    "committee_id": 1
-                },
+                "meeting/1": {"name": "Archived", "group_ids": [1], "committee_id": 1},
                 "meeting/2": {
                     "name": "No Test and Not in Meeting",
                     "group_ids": [2],
                     "is_active_in_organization_id": 1,
-                    "committee_id": 1
+                    "committee_id": 1,
                 },
                 "meeting/3": {
                     "name": "No Test and in Meeting",
                     "group_ids": [3],
                     "is_active_in_organization_id": 1,
-                    "committee_id": 1
+                    "committee_id": 1,
                 },
             }
         )


### PR DESCRIPTION
Closes #2905

Now committee admins can do it too, if they have the rights to all meetings