### PR TITLE
Lengthen migrate thread join timeout

### DIFF
--- a/openslides_backend/migrations/migration_handler.py
+++ b/openslides_backend/migrations/migration_handler.py
@@ -13,7 +13,7 @@ from ..shared.interfaces.services import Services
 from . import MigrationWrapper
 
 # Amount of time that should be waited for a result from the migrate thread before returning an empty result
-THREAD_WAIT_TIME = 0.14
+THREAD_WAIT_TIME = 0.2
 
 
 class MigrationState(str, Enum):


### PR DESCRIPTION
Background: Recently there have been cases of failing tests in PRs because the threads in the code took too long to write data. I changed the timeout to be bigger, so this will perhaps be less common.

@m-schieder I would like you to tell me if it is okay if migration requests can potentially take 0.6 seconds longer