### PR TITLE
Fix motion forward with attachments

### DIFF
--- a/openslides_backend/action/actions/mediafile/duplicate_to_another_meeting.py
+++ b/openslides_backend/action/actions/mediafile/duplicate_to_another_meeting.py
@@ -66,13 +66,17 @@ class MediafileDuplicateToAnotherMeetingAction(MediafileCreateMixin, CreateActio
                 lock_result=False,
             )
         )
-        self.verify_title_parent_unique(instance)
+        self.ensure_unique_title_within_parent(instance)
         instance["create_timestamp"] = round(time())
         if not instance.get("is_directory"):
             self.media.duplicate_mediafile(origin_id, instance["id"])
         return instance
 
-    def verify_title_parent_unique(self, instance: dict[str, Any]) -> None:
+    def ensure_unique_title_within_parent(self, instance: dict[str, Any]) -> None:
+        """
+        If mediafile with the same title exists in the same directory,
+        makes the title unique by adding a suffix.
+        """
         title: str | None = instance.get("title")
         parent_id: int | None = instance.get("parent_id")
         owner_id: str = instance.get("owner_id", "")

--- a/openslides_backend/action/actions/mediafile/duplicate_to_another_meeting.py
+++ b/openslides_backend/action/actions/mediafile/duplicate_to_another_meeting.py
@@ -1,9 +1,11 @@
+import re
 from time import time
 from typing import Any
 
 from ....models.models import Mediafile
 from ....permissions.permissions import Permissions
 from ....services.datastore.commands import GetManyRequest
+from ....shared.filters import And, FilterOperator
 from ....shared.patterns import fqid_from_collection_and_id
 from ...generics.create import CreateAction
 from ...util.action_type import ActionType
@@ -64,7 +66,65 @@ class MediafileDuplicateToAnotherMeetingAction(MediafileCreateMixin, CreateActio
                 lock_result=False,
             )
         )
+        self.verify_title_parent_unique(instance)
         instance["create_timestamp"] = round(time())
         if not instance.get("is_directory"):
             self.media.duplicate_mediafile(origin_id, instance["id"])
         return instance
+
+    def verify_title_parent_unique(self, instance: dict[str, Any]) -> None:
+        title: str | None = instance.get("title")
+        parent_id: int | None = instance.get("parent_id")
+        owner_id: str = instance.get("owner_id", "")
+
+        if title:
+            filter_ = And(
+                FilterOperator("title", "=", title),
+                FilterOperator("parent_id", "=", parent_id),
+                FilterOperator("owner_id", "=", owner_id),
+            )
+            results = self.datastore.filter(self.model.collection, filter_, ["id"])
+
+            if results:
+                instance["title"] = self.get_title_with_unique_suffix(
+                    title, owner_id, parent_id
+                )
+
+    def get_title_with_unique_suffix(
+        self,
+        origin_title: str,
+        owner_id: str,
+        parent_id: int | None,
+    ) -> str:
+        """
+        Scans for existing titles within the same folder (by `parent_id`) or root
+        (if None), matching 'base_title' or 'base_title (#n)'.
+        Returns a unique title like 'base_title (#n)'.
+        If only 'base_title' is present, returns 'base_title (#2)'.
+        """
+        filter_ = And(
+            FilterOperator("owner_id", "=", owner_id),
+            FilterOperator("parent_id", "=", parent_id),
+        )
+        existing_titles = {
+            item.get("title", "")
+            for item in self.datastore.filter(
+                self.model.collection, filter_, ["title"]
+            ).values()
+        }
+
+        pattern = re.compile(rf"^{re.escape(origin_title)}(?:\s\(#(\d+)\))?$")
+        max_suffix = 1
+
+        for title in existing_titles:
+            match = pattern.match(title)
+            if match:
+                suffix_str = match.group(1)
+                if suffix_str:
+                    try:
+                        suffix_num = int(suffix_str)
+                        max_suffix = max(max_suffix, suffix_num)
+                    except ValueError:
+                        continue
+
+        return f"{origin_title} (#{max_suffix + 1})"

--- a/openslides_backend/action/actions/motion/base_create_forwarded.py
+++ b/openslides_backend/action/actions/motion/base_create_forwarded.py
@@ -621,13 +621,11 @@ class BaseMotionCreateForwarded(TextHashMixin, MotionCreateBase):
         by their (meeting_id, mediafile_id) combination.
         """
         filter_ = Or(
-            *[
-                And(
-                    FilterOperator("mediafile_id", "=", entry["mediafile_id"]),
-                    FilterOperator("meeting_id", "=", entry["meeting_id"]),
-                )
-                for entry in instances
-            ]
+            And(
+                FilterOperator("mediafile_id", "=", entry["mediafile_id"]),
+                FilterOperator("meeting_id", "=", entry["meeting_id"]),
+            )
+            for entry in instances
         )
 
         return self.datastore.filter(

--- a/openslides_backend/action/actions/motion/base_create_forwarded.py
+++ b/openslides_backend/action/actions/motion/base_create_forwarded.py
@@ -619,19 +619,22 @@ class BaseMotionCreateForwarded(TextHashMixin, MotionCreateBase):
         Collects existing meeting_mediafile entries that match the given instances
         by their (meeting_id, mediafile_id) combination.
         """
-        filters = [
-            And(
-                FilterOperator("mediafile_id", "=", entry["mediafile_id"]),
-                FilterOperator("meeting_id", "=", entry["meeting_id"]),
-            )
-            for entry in instances
-        ]
-        if not filters:
+        if not instances:
             return {}
+
+        filter_ = Or(
+            *[
+                And(
+                    FilterOperator("mediafile_id", "=", entry["mediafile_id"]),
+                    FilterOperator("meeting_id", "=", entry["meeting_id"]),
+                )
+                for entry in instances
+            ]
+        )
 
         return self.datastore.filter(
             "meeting_mediafile",
-            Or(*filters),
+            filter_,
             ["id", "mediafile_id", "meeting_id"],
             lock_result=False,
             use_changed_models=False,

--- a/openslides_backend/action/actions/motion/base_create_forwarded.py
+++ b/openslides_backend/action/actions/motion/base_create_forwarded.py
@@ -10,7 +10,7 @@ from ....permissions.permission_helper import has_perm
 from ....permissions.permissions import Permissions
 from ....services.datastore.commands import GetManyRequest
 from ....shared.exceptions import ActionException, PermissionDenied
-from ....shared.filters import FilterOperator
+from ....shared.filters import And, FilterOperator, Or
 from ....shared.interfaces.write_request import WriteRequest
 from ....shared.patterns import fqid_from_collection_and_id
 from ...util.typing import ActionData, ActionResultElement, ActionResults
@@ -611,6 +611,57 @@ class BaseMotionCreateForwarded(TextHashMixin, MotionCreateBase):
                     duplicate_mediafiles_data.append(new_mediafile)
         return duplicate_mediafiles_data, mediafile_replace_map_by_meeting
 
+    def _get_existing_mm_entries(
+        self, instances: list[dict[str, Any]]
+    ) -> dict[int, dict[str, Any]]:
+        """
+        Helper method for _duplicate_meeting_mediafiles.
+        Collects existing meeting_mediafile entries that match the given instances
+        by their (meeting_id, mediafile_id) combination.
+        """
+        filters = [
+            And(
+                FilterOperator("mediafile_id", "=", entry["mediafile_id"]),
+                FilterOperator("meeting_id", "=", entry["meeting_id"]),
+            )
+            for entry in instances
+        ]
+        if not filters:
+            return {}
+
+        return self.datastore.filter(
+            "meeting_mediafile",
+            Or(*filters),
+            ["id", "mediafile_id", "meeting_id"],
+            lock_result=False,
+            use_changed_models=False,
+        )
+
+    def _update_mm_replace_map(
+        self,
+        origin_data: list[dict[str, Any]],
+        forwarded_data: list[dict[str, Any]],
+        mediafile_replace_map_by_meeting: dict[int, dict[int, int]],
+        meeting_mediafile_replace_map: dict[int, dict[int, int]],
+        existing_mm_imstances: dict[tuple[int, int], int],
+    ) -> None:
+        """
+        Helper method for _duplicate_meeting_mediafiles.
+        Updates meeting_mediafile_replace_map with newly created instances where
+        no prior match existed in the target (meeting_id, mediafile_id).
+        """
+        for origin, forwarded in zip(origin_data, forwarded_data):
+            meeting_id = origin["meeting_id"]
+            new_mediafile_id = mediafile_replace_map_by_meeting[meeting_id][
+                origin["mediafile_id"]
+            ]
+            key = (meeting_id, new_mediafile_id)
+
+            if key not in existing_mm_imstances:
+                meeting_mediafile_replace_map[meeting_id].update(
+                    {origin["old_id"]: forwarded["id"]}
+                )
+
     def _duplicate_meeting_mediafiles(
         self,
         new_mm_instances_data: list[dict[str, Any]],
@@ -618,28 +669,47 @@ class BaseMotionCreateForwarded(TextHashMixin, MotionCreateBase):
         meeting_mediafile_replace_map: dict[int, dict[int, int]],
     ) -> dict[int, dict[int, int]]:
         """
-        Duplicates meeting_mediafiles and creates a replace_map for assigning
-        meeting_mediafiles to the target motions.
-
-        Updates meeting_mediafile_replace_map.
+        Duplicates meeting_mediafiles and updates the replacement map for assigning them
+        to motions, avoiding duplicates based on (meeting_id, mediafile_id) combinations.
         """
-        new_mm_instances: list[dict[str, Any]] = []
-        for meeting_mediafile in new_mm_instances_data:
-            new_mm = {**meeting_mediafile}
-            new_mm.pop("old_id")
-            new_mm["mediafile_id"] = mediafile_replace_map_by_meeting[
-                new_mm["meeting_id"]
-            ][new_mm["mediafile_id"]]
-            new_mm_instances.append(new_mm)
+        retrieved_instances = self._get_existing_mm_entries(new_mm_instances_data)
+        existing_mm_imstances = {
+            (entry["meeting_id"], entry["mediafile_id"]): entry["id"]
+            for entry in retrieved_instances.values()
+        }
 
-        results = cast(
+        new_mm_action_data = []
+        for entry in new_mm_instances_data:
+            meeting_id = entry["meeting_id"]
+            old_mediafile_id = entry["mediafile_id"]
+            new_mediafile_id = mediafile_replace_map_by_meeting[meeting_id][
+                old_mediafile_id
+            ]
+            key = (meeting_id, new_mediafile_id)
+
+            if key in existing_mm_imstances:
+                meeting_mediafile_replace_map[meeting_id].update(
+                    {entry["old_id"]: existing_mm_imstances[key]}
+                )
+            else:
+                new_mm = {**entry}
+                new_mm.pop("old_id")
+                new_mm["mediafile_id"] = new_mediafile_id
+                new_mm_action_data.append(new_mm)
+
+        created_results = cast(
             list[dict[str, Any]],
-            self.execute_other_action(MeetingMediafileCreate, new_mm_instances),
+            self.execute_other_action(MeetingMediafileCreate, new_mm_action_data),
         )
-        for origin_mm, mm in zip(new_mm_instances_data, results):
-            meeting_mediafile_replace_map[origin_mm["meeting_id"]].update(
-                {origin_mm["old_id"]: mm["id"]}
-            )
+
+        self._update_mm_replace_map(
+            new_mm_instances_data,
+            created_results,
+            mediafile_replace_map_by_meeting,
+            meeting_mediafile_replace_map,
+            existing_mm_imstances,
+        )
+
         return meeting_mediafile_replace_map
 
     def forward_mediafiles(

--- a/openslides_backend/action/actions/motion/base_create_forwarded.py
+++ b/openslides_backend/action/actions/motion/base_create_forwarded.py
@@ -436,11 +436,12 @@ class BaseMotionCreateForwarded(TextHashMixin, MotionCreateBase):
             self.execute_other_action(
                 MediafileDuplicateToAnotherMeetingAction, duplicate_mediafiles_data
             )
-        meeting_mediafile_replace_map = self._duplicate_meeting_mediafiles(
-            new_mm_instances_data,
-            mediafile_replace_map_by_meeting,
-            meeting_mediafile_replace_map,
-        )
+        if new_mm_instances_data:
+            meeting_mediafile_replace_map = self._duplicate_meeting_mediafiles(
+                new_mm_instances_data,
+                mediafile_replace_map_by_meeting,
+                meeting_mediafile_replace_map,
+            )
         return forwarded_attachments, meeting_mediafile_replace_map
 
     def _extract_motion_target_meeting_ids(
@@ -619,9 +620,6 @@ class BaseMotionCreateForwarded(TextHashMixin, MotionCreateBase):
         Collects existing meeting_mediafile entries that match the given instances
         by their (meeting_id, mediafile_id) combination.
         """
-        if not instances:
-            return {}
-
         filter_ = Or(
             *[
                 And(

--- a/tests/system/action/motion/test_create_forwarded.py
+++ b/tests/system/action/motion/test_create_forwarded.py
@@ -2206,7 +2206,7 @@ class MotionCreateForwardedTest(BaseActionTestCase):
     def test_preserve_meeting_attachments_ids_with_attachments_true(self) -> None:
         self.base_test_preserve_existing_meeting_attachments_ids(with_attachments=True)
 
-    def set_2_motions_with_same_attachement(self, is_orga_wide: bool) -> None:
+    def set_2_motions_with_same_attachment(self, is_orga_wide: bool) -> None:
         self.set_models(self.test_model)
         self.set_models(
             {

--- a/tests/system/action/motion/test_create_forwarded.py
+++ b/tests/system/action/motion/test_create_forwarded.py
@@ -1691,7 +1691,7 @@ class MotionCreateForwardedTest(BaseActionTestCase):
         """
         existing = self.get_model(fqid).get(field, [])
         if isinstance(existing, list):
-            models_data[fqid] = {field: existing + [new_value]}
+            models_data.setdefault(fqid, {})[field] = existing + [new_value]
         return models_data
 
     def create_mediafiles_from_dict(

--- a/tests/system/action/motion/test_create_forwarded.py
+++ b/tests/system/action/motion/test_create_forwarded.py
@@ -1,8 +1,9 @@
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, call
 
 from openslides_backend.action.actions.motion.mixins import TextHashMixin
 from openslides_backend.permissions.permissions import Permissions
+from openslides_backend.shared.exceptions import DatastoreException
 from openslides_backend.shared.util import ONE_ORGANIZATION_FQID, ONE_ORGANIZATION_ID
 from tests.system.action.base import BaseActionTestCase
 from tests.util import Response
@@ -31,9 +32,7 @@ class MotionCreateForwardedTest(BaseActionTestCase):
                 "default_group_id": 112,
                 "group_ids": [112],
                 "meeting_user_ids": [2],
-                "user_ids": [
-                    1,
-                ],
+                "user_ids": [1],
             },
             "user/1": {
                 "meeting_ids": [1, 2],
@@ -1679,15 +1678,79 @@ class MotionCreateForwardedTest(BaseActionTestCase):
         )
         self.assert_model_not_exists("motion/6")
 
+    def _update_list_field(
+        self,
+        models_data: dict[str, dict[str, Any]],
+        fqid: str,
+        field: str,
+        new_value: int,
+    ) -> dict[str, dict[str, Any]]:
+        """
+        For the models defined by fqid retrieves the value of the given field.
+        If its type is list, appends it with the new_value.
+        """
+        existing = self.get_model(fqid).get(field, [])
+        if isinstance(existing, list):
+            models_data[fqid] = {field: existing + [new_value]}
+        return models_data
+
+    def create_mediafiles_from_dict(
+        self, meeting_mediafiles: list[dict[str, int | list[int] | bool]]
+    ) -> None:
+        """
+        Accepts data for creating mediafile and meeting mediafile and creates
+        them with all the relations.
+        Skips mediafiles creation for instances that already exist.
+        """
+        for mediafile in meeting_mediafiles:
+            meeting_mediafile_id = cast(int, mediafile.get("meeting_mediafile_id", 0))
+            mediafile_id = cast(int, mediafile.get("mediafile_id", 0))
+            meeting_id = cast(int, mediafile.get("meeting_id", 0))
+            is_directory = bool(mediafile.get("is_directory", False))
+
+            raw_motion_ids = mediafile.get("motion_ids", [])
+            motion_ids = raw_motion_ids if isinstance(raw_motion_ids, list) else []
+
+            is_orga_wide = bool(mediafile.get("is_orga_wide", False))
+            owner_meeting_id: int = 0 if is_orga_wide else meeting_id
+
+            try:
+                fqid = f"mediafile/{mediafile_id}"
+                self.assert_model_exists(fqid)
+                self.set_models(
+                    self._update_list_field(
+                        {}, fqid, "meeting_mediafile_ids", meeting_mediafile_id
+                    )
+                )
+            except DatastoreException:
+                self.create_mediafile(mediafile_id, owner_meeting_id, is_directory)
+            self.create_meeting_mediafile(
+                meeting_mediafile_id, mediafile_id, meeting_id, motion_ids
+            )
+
     def create_mediafile(
         self,
         mediafile_id: int,
         owner_meeting_id: int = 0,
         is_directory: bool = False,
     ) -> None:
-        model_data: dict[str, bool | str | int] = {"is_directory": is_directory}
+        fqid = f"mediafile/{mediafile_id}"
+        model_data: dict[str, str | int | bool] = {
+            "is_directory": is_directory,
+            "title": (
+                f"folder_{mediafile_id}" if is_directory else f"title_{mediafile_id}"
+            ),
+        }
+        models_data = {fqid: model_data}
+
         if owner_meeting_id:
             model_data["owner_id"] = f"meeting/{owner_meeting_id}"
+            self._update_list_field(
+                models_data,
+                f"meeting/{owner_meeting_id}",
+                "mediafile_ids",
+                mediafile_id,
+            )
         else:
             model_data.update(
                 {
@@ -1695,9 +1758,13 @@ class MotionCreateForwardedTest(BaseActionTestCase):
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
                 }
             )
+            self._update_list_field(
+                models_data, ONE_ORGANIZATION_FQID, "mediafile_ids", mediafile_id
+            )
+
         if not is_directory:
             model_data["mimetype"] = "text/plain"
-        self.set_models({f"mediafile/{mediafile_id}": model_data})
+        self.set_models(models_data)
 
     def create_meeting_mediafile(
         self,
@@ -1706,16 +1773,31 @@ class MotionCreateForwardedTest(BaseActionTestCase):
         meeting_id: int,
         motion_ids: list[int] = [],
     ) -> None:
+        mm_fqid = f"meeting_mediafile/{meeting_mediafile_id}"
         model_data: dict[str, int | bool | list[str]] = {
-            "meeting_id": 1,
+            "meeting_id": meeting_id,
             "mediafile_id": mediafile_id,
             "is_public": True,
         }
+        models_data = {mm_fqid: model_data}
+
+        for fqid in [f"meeting/{meeting_id}", f"mediafile/{mediafile_id}"]:
+            self._update_list_field(
+                models_data, fqid, "meeting_mediafile_ids", meeting_mediafile_id
+            )
+
         if motion_ids:
             model_data["attachment_ids"] = [
                 f"motion/{motion_id}" for motion_id in motion_ids
             ]
-        self.set_models({f"meeting_mediafile/{meeting_mediafile_id}": model_data})
+            for motion_id in motion_ids:
+                self._update_list_field(
+                    models_data,
+                    f"motion/{motion_id}",
+                    "attachment_meeting_mediafile_ids",
+                    meeting_mediafile_id,
+                )
+        self.set_models(models_data)
 
     def prepare_test_data_for_forwarding_with_attachments(
         self,
@@ -1727,6 +1809,7 @@ class MotionCreateForwardedTest(BaseActionTestCase):
         Prepares test data and performs a forwarding request, optionally
         including attachments (based on the with_attachments value).
         """
+        self.set_models(self.test_model)
         for mediafile in origin_mediafiles:
             self.create_mediafile(**mediafile)
         ORGA_WIDE_MEDIAFILES: set[int] = set()
@@ -1753,35 +1836,10 @@ class MotionCreateForwardedTest(BaseActionTestCase):
             for i in range(1, len(origin_mediafile_ids) + 1)
         ]
 
-        self.set_models(self.test_model)
-        self.set_models(
-            {
-                "meeting/1": {
-                    "meeting_mediafile_ids": origin_meeting_mediafile_ids,
-                    "mediafile_ids": [
-                        id_
-                        for id_ in origin_mediafile_ids
-                        if id_ not in ORGA_WIDE_MEDIAFILES
-                    ]
-                    or None,
-                },
-                "motion/12": {
-                    "attachment_meeting_mediafile_ids": origin_meeting_mediafile_ids
-                },
-            }
-        )
-
         for mediafile_id, meeting_mediafile_id in zip(
             origin_mediafile_ids, origin_meeting_mediafile_ids
         ):
             self.create_meeting_mediafile(meeting_mediafile_id, mediafile_id, 1, [12])
-            self.set_models(
-                {
-                    f"mediafile/{mediafile_id}": {
-                        "meeting_mediafile_ids": [meeting_mediafile_id],
-                    },
-                }
-            )
 
         if custom_models_data:
             self.set_models(custom_models_data)
@@ -2016,54 +2074,39 @@ class MotionCreateForwardedTest(BaseActionTestCase):
             ],
             nested_files_ids={1: [3, 4], 2: [5], 5: [6]},
             custom_models_data={
-                "mediafile/1": {
-                    "child_ids": [3, 4],
-                },
-                "mediafile/3": {
-                    "parent_id": 1,
-                },
-                "mediafile/4": {
-                    "parent_id": 1,
-                },
-                "mediafile/2": {
-                    "child_ids": [5],
-                },
-                "mediafile/5": {
-                    "parent_id": 2,
-                    "child_ids": [6],
-                },
-                "mediafile/6": {
-                    "parent_id": 5,
-                },
+                "mediafile/1": {"child_ids": [3, 4]},
+                "mediafile/3": {"parent_id": 1},
+                "mediafile/4": {"parent_id": 1},
+                "mediafile/2": {"child_ids": [5]},
+                "mediafile/5": {"parent_id": 2, "child_ids": [6]},
+                "mediafile/6": {"parent_id": 5},
             },
         )
 
     def base_test_preserve_existing_meeting_attachments_ids(
         self, with_attachments: bool
     ) -> None:
+        """
+        Verify that forwarding new mediafiles doesn't impact existing mediafiles
+        in the target meeting.
+        """
         self.set_models(self.test_model)
-        self.create_mediafile(mediafile_id=1, owner_meeting_id=1)
-        self.create_mediafile(mediafile_id=2, owner_meeting_id=2)
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=11, mediafile_id=1, meeting_id=1, motion_ids=[12]
-        )
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=12, mediafile_id=2, meeting_id=2
-        )
-        self.set_models(
-            {
-                "mediafile/1": {"meeting_mediafile_ids": [11]},
-                "mediafile/2": {"meeting_mediafile_ids": [12]},
-                "meeting/1": {
-                    "meeting_mediafile_ids": [11],
-                    "mediafile_ids": [1],
+        self.create_mediafiles_from_dict(
+            [
+                {
+                    "meeting_mediafile_id": 11,
+                    "mediafile_id": 1,
+                    "meeting_id": 1,
+                    "motion_ids": [12],
+                    "is_orga_wide": False,
                 },
-                "meeting/2": {
-                    "meeting_mediafile_ids": [12],
-                    "mediafile_ids": [2],
+                {
+                    "meeting_mediafile_id": 12,
+                    "mediafile_id": 2,
+                    "meeting_id": 2,
+                    "is_orga_wide": False,
                 },
-                "motion/12": {"attachment_meeting_mediafile_ids": [11]},
-            }
+            ]
         )
         response = self.request(
             "motion.create_forwarded",
@@ -2101,26 +2144,26 @@ class MotionCreateForwardedTest(BaseActionTestCase):
         self,
     ) -> None:
         self.set_models(self.test_model)
-        self.create_mediafile(mediafile_id=1, owner_meeting_id=1)
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=11, mediafile_id=1, meeting_id=1, motion_ids=[12, 13]
-        )
         self.set_models(
             {
-                "meeting/1": {
-                    "meeting_mediafile_ids": [11],
-                    "mediafile_ids": [1],
-                },
-                "mediafile/1": {"meeting_mediafile_ids": [11]},
-                "motion/12": {"attachment_meeting_mediafile_ids": [11]},
                 "motion/13": {
                     "title": "Motion 13",
                     "meeting_id": 1,
                     "state_id": 30,
-                    "attachment_meeting_mediafile_ids": [11],
                 },
                 "motion_state/30": {"motion_ids": [12, 13]},
             }
+        )
+        self.create_mediafiles_from_dict(
+            [
+                {
+                    "meeting_mediafile_id": 11,
+                    "mediafile_id": 1,
+                    "meeting_id": 1,
+                    "motion_ids": [12, 13],
+                    "is_orga_wide": False,
+                },
+            ]
         )
         self.media.duplicate_mediafile = MagicMock()
         response = self.request_multi(
@@ -2166,25 +2209,26 @@ class MotionCreateForwardedTest(BaseActionTestCase):
         for fqid, model_data in expected_models.items():
             self.assert_model_exists(fqid, model_data)
 
-    def test_forward_1_motion_with_attachments_to_2_meetings_in_1_transaction(
+    def test_forward_to_2_meetings_1_transaction_orga_wide_mediafiles(
         self,
     ) -> None:
         self.set_models(self.test_model)
         self.create_meeting(3)
-        self.create_mediafile(mediafile_id=1, owner_meeting_id=1)
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=11, mediafile_id=1, meeting_id=1, motion_ids=[12]
+        self.create_mediafiles_from_dict(
+            [
+                {
+                    "meeting_mediafile_id": 11,
+                    "mediafile_id": 1,
+                    "meeting_id": 1,
+                    "motion_ids": [12],
+                    "is_orga_wide": False,
+                },
+            ]
         )
         self.set_models(
             {
-                "meeting/1": {
-                    "meeting_mediafile_ids": [11],
-                    "mediafile_ids": [1],
-                },
                 "meeting/3": {"committee_id": 52},
                 "committee/52": {"meeting_ids": [2, 3]},
-                "mediafile/1": {"meeting_mediafile_ids": [11]},
-                "motion/12": {"attachment_meeting_mediafile_ids": [11]},
             }
         )
         self.media.duplicate_mediafile = MagicMock()
@@ -2271,49 +2315,52 @@ class MotionCreateForwardedTest(BaseActionTestCase):
           duplicated only once and referenced correctly in the meeting_mediafiles
         """
         self.set_models(self.test_model)
-        self.create_mediafile(mediafile_id=1, owner_meeting_id=1)
-        self.create_mediafile(mediafile_id=6, owner_meeting_id=1)
-        self.create_mediafile(mediafile_id=8)
-        self.create_mediafile(mediafile_id=19, owner_meeting_id=1)
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=11, mediafile_id=1, meeting_id=1, motion_ids=[13]
-        )
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=14, mediafile_id=6, meeting_id=1, motion_ids=[12, 13]
-        )
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=17, mediafile_id=8, meeting_id=1, motion_ids=[12]
-        )
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=24, mediafile_id=19, meeting_id=1, motion_ids=[12]
-        )
         self.set_models(
             {
-                "meeting/1": {
-                    "meeting_mediafile_ids": [11, 14, 17, 24],
-                    "mediafile_ids": [1, 6, 19],
-                },
-                "mediafile/1": {"meeting_mediafile_ids": [11]},
-                "mediafile/6": {"meeting_mediafile_ids": [14]},
-                "mediafile/8": {"meeting_mediafile_ids": [17]},
-                "mediafile/19": {"meeting_mediafile_ids": [24]},
-                "motion/12": {
-                    "state_id": 30,
-                    "amendment_ids": [13],
-                    "attachment_meeting_mediafile_ids": [17, 14],
-                },
+                "motion/12": {"amendment_ids": [13]},
                 "motion/13": {
                     "title": "Amendment 13",
                     "meeting_id": 1,
                     "state_id": 30,
                     "lead_motion_id": 12,
-                    "attachment_meeting_mediafile_ids": [11, 24, 14],
                 },
                 "motion_state/30": {"motion_ids": [12, 13]},
             }
         )
         if custom_model_data:
             self.set_models(custom_model_data)
+        self.create_mediafiles_from_dict(
+            [
+                {
+                    "meeting_mediafile_id": 11,
+                    "mediafile_id": 1,
+                    "meeting_id": 1,
+                    "motion_ids": [13],
+                    "is_orga_wide": False,
+                },
+                {
+                    "meeting_mediafile_id": 14,
+                    "mediafile_id": 6,
+                    "meeting_id": 1,
+                    "motion_ids": [12, 13],
+                    "is_orga_wide": False,
+                },
+                {
+                    "meeting_mediafile_id": 17,
+                    "mediafile_id": 8,
+                    "meeting_id": 1,
+                    "motion_ids": [12],
+                    "is_orga_wide": True,
+                },
+                {
+                    "meeting_mediafile_id": 24,
+                    "mediafile_id": 19,
+                    "meeting_id": 1,
+                    "motion_ids": [13],
+                    "is_orga_wide": False,
+                },
+            ]
+        )
         self.media.duplicate_mediafile = MagicMock()
         response = self.request(
             "motion.create_forwarded",
@@ -2392,8 +2439,8 @@ class MotionCreateForwardedTest(BaseActionTestCase):
                 "is_public": True,
                 "attachment_ids": ["motion/15"],
             },
-            "motion/14": {"attachment_meeting_mediafile_ids": [26, 25]},
-            "motion/15": {"attachment_meeting_mediafile_ids": [27, 28, 25]},
+            "motion/14": {"attachment_meeting_mediafile_ids": [25, 26]},
+            "motion/15": {"attachment_meeting_mediafile_ids": [27, 25, 28]},
         }
         self.base_forward_with_attachments_and_amendments(
             expected_models,
@@ -2405,27 +2452,34 @@ class MotionCreateForwardedTest(BaseActionTestCase):
     def test_forward_with_attachments_true_with_amendments_true_with_nested_amendments(
         self,
     ) -> None:
-        self.create_mediafile(mediafile_id=20, owner_meeting_id=1)
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=20, mediafile_id=20, meeting_id=1, motion_ids=[14]
+        self.set_models(self.test_model)
+        self.set_models(
+            {
+                "motion/13": {
+                    "amendment_ids": [14],
+                },
+                "motion/14": {
+                    "title": "Amendment 14",
+                    "meeting_id": 1,
+                    "state_id": 30,
+                    "lead_motion_id": 13,
+                },
+            }
+        )
+        self.create_mediafiles_from_dict(
+            [
+                {
+                    "meeting_mediafile_id": 20,
+                    "mediafile_id": 20,
+                    "meeting_id": 1,
+                    "motion_ids": [14],
+                    "is_orga_wide": False,
+                },
+            ]
         )
         custom_model_data: dict[str, dict[str, Any]] = {
-            "meeting/1": {
-                "meeting_mediafile_ids": [11, 14, 17, 20, 24],
-                "mediafile_ids": [1, 6, 19, 20],
-            },
-            "mediafile/20": {"meeting_mediafile_ids": [20]},
             "meeting_mediafile/11": {"attachment_ids": ["motion/13", "motion/14"]},
-            "motion/13": {
-                "amendment_ids": [14],
-            },
-            "motion/14": {
-                "title": "Amendment 14",
-                "meeting_id": 1,
-                "state_id": 30,
-                "lead_motion_id": 13,
-                "attachment_meeting_mediafile_ids": [20, 11],
-            },
+            "motion/14": {"attachment_meeting_mediafile_ids": [20, 11]},
         }
         expected_mediaservice_calls = [(6, 21), (1, 22), (19, 23), (20, 24)]
         expected_models: dict[str, dict[str, Any]] = {
@@ -2486,8 +2540,8 @@ class MotionCreateForwardedTest(BaseActionTestCase):
                 "is_public": True,
                 "attachment_ids": ["motion/17"],
             },
-            "motion/15": {"attachment_meeting_mediafile_ids": [26, 25]},
-            "motion/16": {"attachment_meeting_mediafile_ids": [27, 28, 25]},
+            "motion/15": {"attachment_meeting_mediafile_ids": [25, 26]},
+            "motion/16": {"attachment_meeting_mediafile_ids": [27, 25, 28]},
             "motion/17": {"attachment_meeting_mediafile_ids": [29, 27]},
         }
         self.base_forward_with_attachments_and_amendments(
@@ -2535,7 +2589,6 @@ class MotionCreateForwardedTest(BaseActionTestCase):
                 "is_public": True,
                 "attachment_ids": ["motion/14"],
             },
-            "motion/14": {"attachment_meeting_mediafile_ids": [26, 25]},
         }
         custom_model_data: dict[str, dict[str, Any]] = {}
         if not allow_amendment_forwarding:
@@ -2615,64 +2668,67 @@ class MotionCreateForwardedTest(BaseActionTestCase):
         self,
     ) -> None:
         self.set_models(self.test_model)
-        self.create_mediafile(mediafile_id=1, owner_meeting_id=1)
-        self.create_mediafile(mediafile_id=6, owner_meeting_id=1)
-        self.create_mediafile(mediafile_id=9)
-        self.create_mediafile(mediafile_id=16, owner_meeting_id=1)
-        self.create_mediafile(mediafile_id=19)
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=8, mediafile_id=1, meeting_id=1, motion_ids=[16]
-        )
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=14, mediafile_id=6, meeting_id=1, motion_ids=[13]
-        )
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=17, mediafile_id=9, meeting_id=1, motion_ids=[12]
-        )
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=31, mediafile_id=16, meeting_id=1, motion_ids=[13, 17]
-        )
-        self.create_meeting_mediafile(
-            meeting_mediafile_id=30, mediafile_id=19, meeting_id=1, motion_ids=[16]
-        )
         self.set_models(
             {
-                "meeting/1": {
-                    "meeting_mediafile_ids": [8, 14, 17, 30, 31],
-                    "mediafile_ids": [1, 6, 16],
-                },
-                "mediafile/1": {"meeting_mediafile_ids": [8]},
-                "mediafile/6": {"meeting_mediafile_ids": [14]},
-                "mediafile/9": {"meeting_mediafile_ids": [17]},
-                "mediafile/16": {"meeting_mediafile_ids": [31]},
-                "mediafile/19": {"meeting_mediafile_ids": [30]},
-                "motion/12": {
-                    "state_id": 30,
-                    "amendment_ids": [13],
-                    "attachment_meeting_mediafile_ids": [17],
-                },
+                "motion/12": {"amendment_ids": [13]},
                 "motion/13": {
                     "title": "Amendment 13",
                     "meeting_id": 1,
                     "state_id": 30,
                     "lead_motion_id": 12,
-                    "attachment_meeting_mediafile_ids": [31, 14],
                 },
                 "motion/16": {
                     "title": "Motion 16",
                     "meeting_id": 1,
                     "state_id": 30,
-                    "attachment_meeting_mediafile_ids": [30, 8],
                 },
                 "motion/17": {
-                    "title": "Motion 16",
+                    "title": "Motion 17",
                     "meeting_id": 1,
                     "state_id": 30,
-                    "attachment_meeting_mediafile_ids": [31],
                 },
-                "motion_state/30": {"motion_ids": [12, 13, 16, 17]},
             }
         )
+        self.create_mediafiles_from_dict(
+            [
+                {
+                    "meeting_mediafile_id": 8,
+                    "mediafile_id": 1,
+                    "meeting_id": 1,
+                    "motion_ids": [16],
+                    "is_orga_wide": False,
+                },
+                {
+                    "meeting_mediafile_id": 14,
+                    "mediafile_id": 6,
+                    "meeting_id": 1,
+                    "motion_ids": [13],
+                    "is_orga_wide": False,
+                },
+                {
+                    "meeting_mediafile_id": 17,
+                    "mediafile_id": 9,
+                    "meeting_id": 1,
+                    "motion_ids": [12],
+                    "is_orga_wide": True,
+                },
+                {
+                    "meeting_mediafile_id": 31,
+                    "mediafile_id": 16,
+                    "meeting_id": 1,
+                    "motion_ids": [13, 17],
+                    "is_orga_wide": False,
+                },
+                {
+                    "meeting_mediafile_id": 30,
+                    "mediafile_id": 19,
+                    "meeting_id": 1,
+                    "motion_ids": [16],
+                    "is_orga_wide": True,
+                },
+            ]
+        )
+        self.set_models({"motion_state/30": {"motion_ids": [12, 13, 16, 17]}})
         self.media.duplicate_mediafile = MagicMock()
         response = self.request_multi(
             "motion.create_forwarded",
@@ -2715,9 +2771,9 @@ class MotionCreateForwardedTest(BaseActionTestCase):
                 "mediafile_ids": [20, 21, 22],
             },
             "motion/18": {"attachment_meeting_mediafile_ids": [33]},
-            "motion/19": {"attachment_meeting_mediafile_ids": [34, 32]},
+            "motion/19": {"attachment_meeting_mediafile_ids": [32, 34]},
             "motion/20": {"attachment_meeting_mediafile_ids": [35]},
-            "motion/21": {"attachment_meeting_mediafile_ids": [35, 36]},
+            "motion/21": {"attachment_meeting_mediafile_ids": [36, 35]},
             "mediafile/20": {
                 "meeting_mediafile_ids": [32],
                 "owner_id": "meeting/2",

--- a/tests/system/action/motion/test_create_forwarded.py
+++ b/tests/system/action/motion/test_create_forwarded.py
@@ -1744,10 +1744,11 @@ class MotionCreateForwardedTest(BaseActionTestCase):
         models_data = {fqid: model_data}
 
         if owner_meeting_id:
-            model_data["owner_id"] = f"meeting/{owner_meeting_id}"
+            owner_fqid = f"meeting/{owner_meeting_id}"
+            model_data["owner_id"] = owner_fqid
             self._update_list_field(
                 models_data,
-                f"meeting/{owner_meeting_id}",
+                owner_fqid,
                 "mediafile_ids",
                 mediafile_id,
             )

--- a/tests/system/action/motion/test_create_forwarded.py
+++ b/tests/system/action/motion/test_create_forwarded.py
@@ -2238,7 +2238,7 @@ class MotionCreateForwardedTest(BaseActionTestCase):
         Verify forwarding two motions with the same meeting-wide mediafile in one
         transaction creates only 1 new mediafile and 1 new meeting_mediafile.
         """
-        self.set_2_motions_with_same_attachement(is_orga_wide=False)
+        self.set_2_motions_with_same_attachment(is_orga_wide=False)
         response = self.request_multi(
             "motion.create_forwarded",
             [
@@ -2289,7 +2289,7 @@ class MotionCreateForwardedTest(BaseActionTestCase):
         Verify forwarding two motions with the same orga-wide mediafile in one
         transaction creates only one new meeting_mediafile.
         """
-        self.set_2_motions_with_same_attachement(is_orga_wide=True)
+        self.set_2_motions_with_same_attachment(is_orga_wide=True)
         response = self.request_multi(
             "motion.create_forwarded",
             [
@@ -2336,7 +2336,7 @@ class MotionCreateForwardedTest(BaseActionTestCase):
         Verify separately forwarded motions with the same attachment get mediafiles
         with correct title suffixes.
         """
-        self.set_2_motions_with_same_attachement(is_orga_wide=False)
+        self.set_2_motions_with_same_attachment(is_orga_wide=False)
         self.set_models(
             {
                 "motion/14": {
@@ -2445,7 +2445,7 @@ class MotionCreateForwardedTest(BaseActionTestCase):
         self,
     ) -> None:
         """Verify identical titles in other directories don't trigger suffix addition."""
-        self.set_2_motions_with_same_attachement(is_orga_wide=False)
+        self.set_2_motions_with_same_attachment(is_orga_wide=False)
         self.create_mediafiles_from_dict(
             [
                 {
@@ -2545,7 +2545,7 @@ class MotionCreateForwardedTest(BaseActionTestCase):
         self,
     ) -> None:
         """Verify orga-wide mediafile is reused across separate forwardings correctly."""
-        self.set_2_motions_with_same_attachement(is_orga_wide=True)
+        self.set_2_motions_with_same_attachment(is_orga_wide=True)
         response1 = self.request(
             "motion.create_forwarded",
             {


### PR DESCRIPTION
Closes #3008 

This PR is split into 3 commits:

**1. Refactored existing tests for motion_forward with_attachments functionality.**

I've noticed that original create_mediafile and create_meeting_mediafile are not really useful because I still had to set relations to the other models manually with set_models. Not only did it lead to inconsistencies, but also made it harder to read the tests.

I changed these methods so they handle the relations and also added a new helper method 
create_mediafiles_from_dict which creates mediafiles and meeting_mediafiles together also handling relations between them.

While doing that, I did found a couple of incosistencies in the test data setup, fixed them and also added/updated a couple of docstrings.

**2. Solves case 1 from issue 3008:** If meeting_mediafile for the orga-wide mediafile already exists in the target meeting, it is attached to the corresponding motions without the attempt of duplication.

**3. Solves case 2:** During meeting-wide mediafile duplication it is now checked if a mediafile with the same parent_id (or root if None) already exists with a conflicting name: either the origin title (origin_title) or a variant like 'origin_title (#n)'.

If yes, a new unique title like 'origin_title (#n)' is generated for the mediafile. If only 'origin_title' is present, n=2, else n is calculated as max n for this origin_title + 1.