### PR TITLE
Refactor permission_helper methods

### DIFF
--- a/openslides_backend/action/actions/committee/committee_common_mixin.py
+++ b/openslides_backend/action/actions/committee/committee_common_mixin.py
@@ -42,7 +42,6 @@ class CommitteeCommonCreateUpdateMixin(
             if fails := get_failing_committee_management_levels(
                 self.datastore,
                 self.user_id,
-                CommitteeManagementLevel.CAN_MANAGE,
                 list(field_difference),
             ):
                 raise MissingPermission(

--- a/openslides_backend/action/actions/committee/create.py
+++ b/openslides_backend/action/actions/committee/create.py
@@ -41,7 +41,6 @@ class CommitteeCreate(CommitteeCommonCreateUpdateMixin, CreateAction):
             if not has_committee_management_level(
                 self.datastore,
                 self.user_id,
-                CommitteeManagementLevel.CAN_MANAGE,
                 parent_id,
             ):
                 raise MissingPermission(

--- a/openslides_backend/action/actions/committee/delete.py
+++ b/openslides_backend/action/actions/committee/delete.py
@@ -33,7 +33,6 @@ class CommitteeDeleteAction(DeleteAction):
         if not has_committee_management_level(
             self.datastore,
             self.user_id,
-            CommitteeManagementLevel.CAN_MANAGE,
             instance["id"],
         ):
             raise MissingPermission(

--- a/openslides_backend/action/actions/committee/update.py
+++ b/openslides_backend/action/actions/committee/update.py
@@ -211,7 +211,6 @@ class CommitteeUpdateAction(CommitteeCommonCreateUpdateMixin, UpdateAction):
         if has_committee_management_level(
             self.datastore,
             self.user_id,
-            CommitteeManagementLevel.CAN_MANAGE,
             instance["id"],
         ):
             return

--- a/openslides_backend/action/actions/meeting/archive.py
+++ b/openslides_backend/action/actions/meeting/archive.py
@@ -1,10 +1,7 @@
 from typing import Any
 
 from ....models.models import Meeting
-from ....permissions.management_levels import (
-    CommitteeManagementLevel,
-    OrganizationManagementLevel,
-)
+from ....permissions.management_levels import OrganizationManagementLevel
 from ....permissions.permission_helper import (
     has_committee_management_level,
     has_organization_management_level,
@@ -67,7 +64,6 @@ class MeetingArchive(UpdateAction, GetMeetingIdFromIdMixin):
         if not has_committee_management_level(
             self.datastore,
             self.user_id,
-            CommitteeManagementLevel.CAN_MANAGE,
             meeting["committee_id"],
         ) and not has_organization_management_level(
             self.datastore,

--- a/openslides_backend/action/actions/meeting/mixins.py
+++ b/openslides_backend/action/actions/meeting/mixins.py
@@ -54,7 +54,6 @@ class MeetingPermissionMixin(CheckUniqueInContextMixin):
         if not has_committee_management_level(
             self.datastore,
             self.user_id,
-            CommitteeManagementLevel.CAN_MANAGE,
             committee_id,
         ):
             raise MissingPermission({CommitteeManagementLevel.CAN_MANAGE: committee_id})

--- a/openslides_backend/action/actions/meeting/update.py
+++ b/openslides_backend/action/actions/meeting/update.py
@@ -7,10 +7,7 @@ from openslides_backend.action.mixins.check_unique_name_mixin import (
 from ....i18n.translator import Translator
 from ....i18n.translator import translate as _
 from ....models.models import Meeting
-from ....permissions.management_levels import (
-    CommitteeManagementLevel,
-    OrganizationManagementLevel,
-)
+from ....permissions.management_levels import OrganizationManagementLevel
 from ....permissions.permission_helper import (
     has_committee_management_level,
     has_organization_management_level,
@@ -387,7 +384,6 @@ class MeetingUpdate(
             is_manager = has_committee_management_level(
                 self.datastore,
                 self.user_id,
-                CommitteeManagementLevel.CAN_MANAGE,
                 self.get_committee_id(instance["id"]),
             )
             if not is_manager:

--- a/openslides_backend/action/actions/user/assign_meetings.py
+++ b/openslides_backend/action/actions/user/assign_meetings.py
@@ -60,7 +60,6 @@ class UserAssignMeetings(MeetingUserHelperMixin, UpdateAction):
                 if not has_committee_management_level(
                     self.datastore,
                     self.user_id,
-                    CommitteeManagementLevel.CAN_MANAGE,
                     committee_id,
                 )
             }

--- a/openslides_backend/action/actions/user/set_present.py
+++ b/openslides_backend/action/actions/user/set_present.py
@@ -4,10 +4,7 @@ from openslides_backend.shared.typing import HistoryInformation
 
 from ....action.mixins.archived_meeting_check_mixin import CheckForArchivedMeetingMixin
 from ....models.models import User
-from ....permissions.management_levels import (
-    CommitteeManagementLevel,
-    OrganizationManagementLevel,
-)
+from ....permissions.management_levels import OrganizationManagementLevel
 from ....permissions.permission_helper import (
     has_committee_management_level,
     has_organization_management_level,
@@ -86,7 +83,6 @@ class UserSetPresentAction(UpdateAction, CheckForArchivedMeetingMixin):
             if has_committee_management_level(
                 self.datastore,
                 self.user_id,
-                CommitteeManagementLevel.CAN_MANAGE,
                 meeting["committee_id"],
             ):
                 return

--- a/openslides_backend/action/actions/user/toggle_presence_by_number.py
+++ b/openslides_backend/action/actions/user/toggle_presence_by_number.py
@@ -2,10 +2,7 @@ from typing import Any
 
 from ....action.mixins.archived_meeting_check_mixin import CheckForArchivedMeetingMixin
 from ....models.models import User
-from ....permissions.management_levels import (
-    CommitteeManagementLevel,
-    OrganizationManagementLevel,
-)
+from ....permissions.management_levels import OrganizationManagementLevel
 from ....permissions.permission_helper import (
     has_committee_management_level,
     has_organization_management_level,
@@ -100,7 +97,6 @@ class UserTogglePresenceByNumber(UpdateAction, CheckForArchivedMeetingMixin):
             if has_committee_management_level(
                 self.datastore,
                 self.user_id,
-                CommitteeManagementLevel.CAN_MANAGE,
                 meeting["committee_id"],
             ):
                 return

--- a/openslides_backend/permissions/permission_helper.py
+++ b/openslides_backend/permissions/permission_helper.py
@@ -152,8 +152,7 @@ def has_committee_management_level(
     committee_id: int,
 ) -> bool:
     """
-    Checks whether a user has CommitteeManagementLevel 'can_manage'
-    in the given committee.
+    Checks whether a user is committee manager in the given committee.
     """
     if user_id > 0:
         user = datastore.get(

--- a/openslides_backend/permissions/permission_helper.py
+++ b/openslides_backend/permissions/permission_helper.py
@@ -183,7 +183,11 @@ def get_shared_committee_management_levels(
     user_id: int,
     committee_ids: list[int],
 ) -> list[int]:
-    """Checks wether a user has CommitteeManagementLevel 'can_manage'."""
+    """
+    Checks wether a user has CommitteeManagementLevel 'can_manage'.
+    Returns: list with the intersection of the given committee_ids and
+    ids of the committees where user has management rights.
+    """
     if user_id > 0:
         user = datastore.get(
             fqid_from_collection_and_id("user", user_id),

--- a/openslides_backend/permissions/permission_helper.py
+++ b/openslides_backend/permissions/permission_helper.py
@@ -7,7 +7,7 @@ from ..services.datastore.commands import GetManyRequest
 from ..services.datastore.interface import DatastoreService
 from ..shared.exceptions import ActionException, PermissionDenied
 from ..shared.patterns import fqid_from_collection_and_id
-from .management_levels import CommitteeManagementLevel, OrganizationManagementLevel
+from .management_levels import OrganizationManagementLevel
 from .permissions import Permission, Permissions, permission_parents
 
 
@@ -31,7 +31,6 @@ def has_perm(
         if not_locked_from_editing and has_committee_management_level(
             datastore,
             user_id,
-            CommitteeManagementLevel.CAN_MANAGE,
             meeting["committee_id"],
         ):
             return True
@@ -111,13 +110,11 @@ def has_organization_management_level(
 def get_failing_committee_management_levels(
     datastore: DatastoreService,
     user_id: int,
-    expected_level: CommitteeManagementLevel,
     committee_ids: list[int],
 ) -> list[int]:
     """
-    Checks whether a user has the minimum necessary
-    CommitteeManagementLevel for the committees in the list and
-    returns the ids of all that fail.
+    Checks whether a user has CommitteeManagementLevel 'can_manage' for the committees
+    in the list and returns the ids of all that fail.
     """
     if user_id > 0:
         user = datastore.get(
@@ -152,10 +149,12 @@ def get_failing_committee_management_levels(
 def has_committee_management_level(
     datastore: DatastoreService,
     user_id: int,
-    expected_level: CommitteeManagementLevel,
     committee_id: int,
 ) -> bool:
-    """Checks whether a user has the minimum necessary CommitteeManagementLevel"""
+    """
+    Checks whether a user has CommitteeManagementLevel 'can_manage'
+    in the given committee.
+    """
     if user_id > 0:
         user = datastore.get(
             fqid_from_collection_and_id("user", user_id),
@@ -182,10 +181,9 @@ def has_committee_management_level(
 def get_shared_committee_management_levels(
     datastore: DatastoreService,
     user_id: int,
-    expected_level: CommitteeManagementLevel,
     committee_ids: list[int],
 ) -> list[int]:
-    """Checks wether a user has the minimum necessary CommitteeManagementLevel"""
+    """Checks wether a user has CommitteeManagementLevel 'can_manage'."""
     if user_id > 0:
         user = datastore.get(
             fqid_from_collection_and_id("user", user_id),

--- a/openslides_backend/permissions/permission_helper.py
+++ b/openslides_backend/permissions/permission_helper.py
@@ -113,7 +113,7 @@ def get_failing_committee_management_levels(
     committee_ids: list[int],
 ) -> list[int]:
     """
-    Checks whether a user has CommitteeManagementLevel 'can_manage' for the committees
+    Checks whether a user committee manager for the committees
     in the list and returns the ids of all that fail.
     """
     if user_id > 0:

--- a/openslides_backend/permissions/permission_helper.py
+++ b/openslides_backend/permissions/permission_helper.py
@@ -183,9 +183,8 @@ def get_shared_committee_management_levels(
     committee_ids: list[int],
 ) -> list[int]:
     """
-    Checks wether a user has CommitteeManagementLevel 'can_manage'.
-    Returns: list with the intersection of the given committee_ids and
-    ids of the committees where user has management rights.
+    Checks whether a user is manager in the given committees.
+    Returns a list where this is the case or all if the user is orga admin.
     """
     if user_id > 0:
         user = datastore.get(

--- a/openslides_backend/permissions/permission_helper.py
+++ b/openslides_backend/permissions/permission_helper.py
@@ -187,7 +187,7 @@ def get_shared_committee_management_levels(
     if user_id > 0:
         user = datastore.get(
             fqid_from_collection_and_id("user", user_id),
-            ["committee_management_ids"],
+            ["organization_management_level", "committee_management_ids"],
             lock_result=False,
             use_changed_models=False,
         )

--- a/openslides_backend/presenter/search_users.py
+++ b/openslides_backend/presenter/search_users.py
@@ -134,7 +134,6 @@ class SearchUsers(BasePresenter):
             if has_committee_management_level(
                 self.datastore,
                 self.user_id,
-                CommitteeManagementLevel.CAN_MANAGE,
                 permission_id,
             ):
                 return
@@ -158,7 +157,6 @@ class SearchUsers(BasePresenter):
             if has_committee_management_level(
                 self.datastore,
                 self.user_id,
-                CommitteeManagementLevel.CAN_MANAGE,
                 meeting["committee_id"],
             ):
                 return

--- a/openslides_backend/shared/mixins/user_create_update_permissions_mixin.py
+++ b/openslides_backend/shared/mixins/user_create_update_permissions_mixin.py
@@ -508,7 +508,6 @@ class CreateUpdatePermissionsMixin(UserScopeMixin, BaseServiceProvider):
                 if not has_committee_management_level(
                     self.datastore,
                     self.user_id,
-                    CommitteeManagementLevel.CAN_MANAGE,
                     committee_id,
                 )
             }:

--- a/openslides_backend/shared/mixins/user_scope_mixin.py
+++ b/openslides_backend/shared/mixins/user_scope_mixin.py
@@ -186,7 +186,6 @@ class UserScopeMixin(BaseServiceProvider):
             if not has_committee_management_level(
                 self.datastore,
                 self.user_id,
-                CommitteeManagementLevel.CAN_MANAGE,
                 scope_id,
             ):
                 raise MissingPermission(
@@ -204,7 +203,6 @@ class UserScopeMixin(BaseServiceProvider):
             if not has_committee_management_level(
                 self.datastore,
                 self.user_id,
-                CommitteeManagementLevel.CAN_MANAGE,
                 meeting["committee_id"],
             ) and not has_perm(
                 self.datastore, self.user_id, meeting_permission, scope_id
@@ -220,7 +218,6 @@ class UserScopeMixin(BaseServiceProvider):
             if get_shared_committee_management_levels(
                 self.datastore,
                 self.user_id,
-                CommitteeManagementLevel.CAN_MANAGE,
                 [ci for ci in committees_to_meetings.keys()],
             ):
                 return


### PR DESCRIPTION
Closes #2995 
- Removed unused 'expected_level: CommitteeManagementLevel'. Found it in 2 more methods and removed there too;
- Enabling OML check doesn't cause test failures => enabled it;
- As discussed with Luisa, although this method is currently used only in the user_scope_mixin, it logically belongs to this file => no changes.
- Added description of the return value to the docstring.