### PR TITLE
Update unique mediafile title suffixes

### DIFF
--- a/openslides_backend/action/actions/mediafile/duplicate_to_another_meeting.py
+++ b/openslides_backend/action/actions/mediafile/duplicate_to_another_meeting.py
@@ -117,8 +117,8 @@ class MediafileDuplicateToAnotherMeetingAction(MediafileCreateMixin, CreateActio
             ).values()
         }
 
-        pattern = re.compile(rf"^{re.escape(origin_title)}(?:\s\(#(\d+)\))?$")
-        max_suffix = 1
+        pattern = re.compile(rf"^{re.escape(origin_title)}(?:\s\((\d+)\))?$")
+        max_suffix = 0
 
         for title in existing_titles:
             match = pattern.match(title)
@@ -131,4 +131,4 @@ class MediafileDuplicateToAnotherMeetingAction(MediafileCreateMixin, CreateActio
                     except ValueError:
                         continue
 
-        return f"{origin_title} (#{max_suffix + 1})"
+        return f"{origin_title} ({max_suffix + 1})"

--- a/openslides_backend/action/actions/mediafile/duplicate_to_another_meeting.py
+++ b/openslides_backend/action/actions/mediafile/duplicate_to_another_meeting.py
@@ -102,9 +102,9 @@ class MediafileDuplicateToAnotherMeetingAction(MediafileCreateMixin, CreateActio
     ) -> str:
         """
         Scans for existing titles within the same folder (by `parent_id`) or root
-        (if None), matching 'base_title' or 'base_title (#n)'.
-        Returns a unique title like 'base_title (#n)'.
-        If only 'base_title' is present, returns 'base_title (#2)'.
+        (if None), matching 'base_title' or 'base_title (#)'.
+        Returns a unique title like 'base_title (#)' where: # = max found # + 1.
+        If only 'base_title' is present, returns 'base_title (1)'.
         """
         filter_ = And(
             FilterOperator("owner_id", "=", owner_id),

--- a/tests/system/action/motion/test_create_forwarded.py
+++ b/tests/system/action/motion/test_create_forwarded.py
@@ -2349,6 +2349,7 @@ class MotionCreateForwardedTest(BaseActionTestCase):
                 "meeting_mediafile/11": {
                     "attachment_ids": ["motion/12", "motion/13", "motion/14"]
                 },
+                "mediafile/1": {"title": "title_1 (12)"},
             }
         )
         response1 = self.request(
@@ -2395,19 +2396,19 @@ class MotionCreateForwardedTest(BaseActionTestCase):
                 "meeting_mediafile_ids": [12],
                 "owner_id": "meeting/2",
                 "mimetype": "text/plain",
-                "title": "title_1",
+                "title": "title_1 (12)",
             },
             "mediafile/3": {
                 "meeting_mediafile_ids": [13],
                 "owner_id": "meeting/2",
                 "mimetype": "text/plain",
-                "title": "title_1 (#2)",
+                "title": "title_1 (12) (1)",
             },
             "mediafile/4": {
                 "meeting_mediafile_ids": [14],
                 "owner_id": "meeting/2",
                 "mimetype": "text/plain",
-                "title": "title_1 (#3)",
+                "title": "title_1 (12) (2)",
             },
             "meeting_mediafile/12": {
                 "meeting_id": 2,


### PR DESCRIPTION
Closes #3024 

1. As requested, removed hashtag sign from the unique suffixes.
2. In the example of the desired behaviour numeration of the copies starts from 1, not from 2 like in the previous fix. Updated that.
3. Updated tests. Made sure that if the origin name already contains a suffix, it is treated as the part of the origin title.