### PR TITLE
Change database checker to no longer consider default fields required

### DIFF
--- a/cli/generate_models.py
+++ b/cli/generate_models.py
@@ -164,6 +164,8 @@ class Model(Node):
             if field.get("calculated"):
                 continue
             self.attributes[field_name] = Attribute(field)
+            if not field.get("required") and field.get("default") is not None:
+                print(f"{self.collection}/{field_name}: {field.get('default')}")
 
     def get_code(self) -> str:
         verbose_name = " ".join(self.collection.split("_"))

--- a/openslides_backend/models/checker.py
+++ b/openslides_backend/models/checker.py
@@ -282,14 +282,22 @@ class Checker:
         all_collection_fields = {
             field.get_own_field_name() for field in self.get_fields(collection)
         }
-        required_or_default_collection_fields = {
+        default_collection_fields = {
             field.get_own_field_name()
             for field in self.get_fields(collection)
-            if field.required or field.default is not None
+            if field.default is not None
+        }
+
+        required_collection_fields = {
+            field.get_own_field_name()
+            for field in self.get_fields(collection)
+            if field.required
         }
 
         errors = False
-        if diff := required_or_default_collection_fields - model_fields:
+        if self.repair and (diff := (default_collection_fields) - model_fields):
+            self.fix_missing_default_values(model, collection, diff)
+        if diff := required_collection_fields - model_fields:
             if self.repair:
                 diff = self.fix_missing_default_values(model, collection, diff)
             if diff:


### PR DESCRIPTION
Closes #3020

TODO:

- [ ] What should be done about the fields that the database code is assuming are always filled (like organization/default_language)
- [ ] Remove the extra code from generate_models