### PR TITLE
Rel-DB Gender tests

### DIFF
--- a/tests/system/action/gender/test_create.py
+++ b/tests/system/action/gender/test_create.py
@@ -4,50 +4,28 @@ from tests.system.action.base import BaseActionTestCase
 
 
 class GenderCreateActionTest(BaseActionTestCase):
-
     def test_create(self) -> None:
         self.set_models(
             {
-                ONE_ORGANIZATION_FQID: {
-                    "name": "test_organization1",
-                    "gender_ids": [1],
-                },
+                ONE_ORGANIZATION_FQID: {"name": "test_organization1"},
                 "user/20": {"username": "test_user20"},
                 "gender/1": {"organization_id": 1, "name": "male"},
             }
         )
         gender_name = "female"
 
-        response = self.request(
-            "gender.create",
-            {
-                "name": gender_name,
-            },
-        )
+        response = self.request("gender.create", {"name": gender_name})
         self.assert_status_code(response, 200)
+        self.assert_model_exists("gender/1", {"name": "male", "organization_id": 1})
         self.assert_model_exists(
-            "gender/1",
-            {
-                "name": "male",
-                "organization_id": 1,
-            },
-        )
-        self.assert_model_exists(
-            "gender/2",
-            {
-                "name": gender_name,
-                "organization_id": 1,
-            },
+            "gender/2", {"name": gender_name, "organization_id": 1}
         )
         self.assert_model_exists(ONE_ORGANIZATION_FQID, {"gender_ids": [1, 2]})
 
     def test_create_wrong_field(self) -> None:
         response = self.request(
             "gender.create",
-            {
-                "name": "test_gender_name",
-                "wrong_field": "test",
-            },
+            {"name": "test_gender_name", "wrong_field": "test"},
         )
 
         self.assert_status_code(response, 400)
@@ -61,9 +39,7 @@ class GenderCreateActionTest(BaseActionTestCase):
         self.set_models({"gender/1": {"name": "exists"}})
         response = self.request(
             "gender.create",
-            {
-                "name": "exists",
-            },
+            {"name": "exists"},
         )
 
         self.assert_status_code(response, 400)
@@ -101,9 +77,7 @@ class GenderCreateActionTest(BaseActionTestCase):
         self.base_permission_test(
             {},
             "gender.create",
-            {
-                "name": "test_Xcdfgee",
-            },
+            {"name": "test_Xcdfgee"},
             OrganizationManagementLevel.CAN_MANAGE_USERS,
         )
 
@@ -111,7 +85,5 @@ class GenderCreateActionTest(BaseActionTestCase):
         self.base_permission_test(
             {},
             "gender.create",
-            {
-                "name": "test_Xcdfghee",
-            },
+            {"name": "test_Xcdfghee"},
         )

--- a/tests/system/action/gender/test_delete.py
+++ b/tests/system/action/gender/test_delete.py
@@ -10,35 +10,25 @@ class GenderDeleteActionTest(BaseActionTestCase):
     def create_data(self) -> None:
         self.set_models(
             {
-                ONE_ORGANIZATION_FQID: {"gender_ids": [self.gender_id]},
-                "user/20": {"gender_id": 1},
-                "user/21": {"gender_id": self.gender_id},
+                ONE_ORGANIZATION_FQID: {"name": "test_organization1"},
+                "user/20": {"username": "human", "gender_id": 1},
+                "user/21": {"username": "fairy", "gender_id": self.gender_id},
                 "gender/1": {
                     "id": 1,
                     "name": "male",
                     "organization_id": 1,
-                    "user_ids": [20],
                 },
                 self.gender_fqid: {
                     "id": self.gender_id,
                     "name": self.gender_name,
                     "organization_id": 1,
-                    "user_ids": [21],
                 },
             }
         )
 
     def test_delete_correctly(self) -> None:
         self.create_data()
-        self.set_models(
-            {
-                "gender/6": {
-                    "name": "dragon",
-                    "organization_id": 1,
-                },
-                ONE_ORGANIZATION_FQID: {"gender_ids": [1, self.gender_id, 6]},
-            }
-        )
+        self.set_models({"gender/6": {"name": "dragon", "organization_id": 1}})
         response = self.request("gender.delete", {"id": self.gender_id})
 
         self.assert_status_code(response, 200)

--- a/tests/system/action/gender/test_update.py
+++ b/tests/system/action/gender/test_update.py
@@ -65,10 +65,7 @@ class GenderUpdateActionTest(BaseActionTestCase):
         self.create_data()
         response = self.request(
             "gender.update",
-            {
-                "id": 2,
-                "name": "so wrong to change this gender",
-            },
+            {"id": 2, "name": "so wrong to change this gender"},
         )
         self.assert_status_code(response, 400)
         self.assertIn(


### PR DESCRIPTION
* For all actions removed relational field list from model_create and refactored short dictionaries that can fit into one line;
*  Tests for create and update were running even before the changes. In tests for delete action user.username was missing, added it. 