### PR TITLE
Fix meeting.clone mediafile access group bug

### DIFF
--- a/openslides_backend/action/actions/meeting/clone.py
+++ b/openslides_backend/action/actions/meeting/clone.py
@@ -245,7 +245,7 @@ class MeetingClone(MeetingImport):
                 if not str(old_id) in origin_mediafiles
             }
         )
-        self.duplicate_mediafiles(meeting_json)
+        self.duplicate_mediafiles(meeting_json["mediafile"])
 
         orga_wide_mediafiles = {
             str(mediafile_id): {
@@ -333,9 +333,8 @@ class MeetingClone(MeetingImport):
             meeting_users_in_instance[str(meeting_user_id)] = meeting_user
         group_in_instance["meeting_user_ids"] = list(meeting_user_ids)
 
-    def duplicate_mediafiles(self, json_data: dict[str, Any]) -> None:
-        for mediafile_id in json_data["mediafile"]:
-            mediafile = json_data["mediafile"][mediafile_id]
+    def duplicate_mediafiles(self, mediafiles: dict[int, Any]) -> None:
+        for mediafile_id, mediafile in mediafiles.items():
             if not mediafile.get("is_directory"):
                 self.media.duplicate_mediafile(
                     mediafile["id"], self.replace_map["mediafile"][mediafile["id"]]

--- a/openslides_backend/action/actions/meeting/clone.py
+++ b/openslides_backend/action/actions/meeting/clone.py
@@ -333,8 +333,8 @@ class MeetingClone(MeetingImport):
             meeting_users_in_instance[str(meeting_user_id)] = meeting_user
         group_in_instance["meeting_user_ids"] = list(meeting_user_ids)
 
-    def duplicate_mediafiles(self, mediafiles: dict[int, Any]) -> None:
-        for mediafile_id, mediafile in mediafiles.items():
+    def duplicate_mediafiles(self, mediafiles: dict[str, Any]) -> None:
+        for mediafile in mediafiles.values():
             if not mediafile.get("is_directory"):
                 self.media.duplicate_mediafile(
                     mediafile["id"], self.replace_map["mediafile"][mediafile["id"]]

--- a/openslides_backend/action/actions/meeting/clone.py
+++ b/openslides_backend/action/actions/meeting/clone.py
@@ -419,6 +419,7 @@ class MeetingClone(ForwardMediafilesMixin, MeetingImport):
             mediafiles_back_relations[str(new_mediafile_id)] = {
                 "id": new_mediafile_id,
                 "meeting_mediafile_ids": meeting_mediafile_ids,
+                "owner_id": mediafile["owner_id"],
             }
 
         return mediafiles_back_relations

--- a/openslides_backend/action/actions/meeting/clone.py
+++ b/openslides_backend/action/actions/meeting/clone.py
@@ -242,18 +242,15 @@ class MeetingClone(ForwardMediafilesMixin, MeetingImport):
         self.create_replace_map(meeting_json)
         meeting_id = self.replace_map["meeting"][meeting["id"]]
 
-        _, mediafile_replace_map_by_meeting = (
-            self.perform_mediafiles_mapping_and_duplication(
-                {
-                    "mediafile": {
-                        int(id_): data for id_, data in origin_mediafiles.items()
-                    },
-                    "meeting_mediafile": self._update_meeting_mediafiles(
-                        origin_meeting_mediafiles, meeting["id"]
-                    ),
+        _, mediafile_replace_map_by_meeting = self.perform_mediafiles_duplication(
+            {
+                "mediafile": {
+                    int(id_): data for id_, data in origin_mediafiles.items()
                 },
-                should_create_mm=False,
-            )
+                "meeting_mediafile": self._update_meeting_mediafiles(
+                    origin_meeting_mediafiles, meeting["id"]
+                ),
+            }
         )
         self.replace_map.update(
             {

--- a/openslides_backend/action/actions/meeting/clone.py
+++ b/openslides_backend/action/actions/meeting/clone.py
@@ -235,11 +235,13 @@ class MeetingClone(ForwardMediafilesMixin, MeetingImport):
         # set imported_at
         meeting["imported_at"] = round(time.time())
 
+        # Perform mediafiles and meeting_mediafiles forwarding
         origin_mediafiles = meeting_json.pop("mediafile", {})
         origin_meeting_mediafiles = meeting_json.get("meeting_mediafile", {})
 
         self.create_replace_map(meeting_json)
         meeting_id = self.replace_map["meeting"][meeting["id"]]
+
         _, mediafile_replace_map_by_meeting = (
             self.perform_mediafiles_mapping_and_duplication(
                 {
@@ -258,7 +260,7 @@ class MeetingClone(ForwardMediafilesMixin, MeetingImport):
                 "mediafile": mediafile_replace_map_by_meeting.get(meeting_id, {}),
             }
         )
-        # TODO: remove after switching to rel-DB
+        # TODO: remove mediafiles_back_relations after switching to rel-DB
         mediafiles_back_relations = self.generate_mediafiles_back_relations(
             origin_meeting_mediafiles, origin_mediafiles
         )
@@ -396,9 +398,9 @@ class MeetingClone(ForwardMediafilesMixin, MeetingImport):
         origin_mediafiles: dict[str, dict[str, Any]],
     ) -> dict[str, dict[str, Any]]:
         """
-        Generates the back-relations for mediafiles, handling orga-wide vs. meeting-specific references.
-        Avoids replacing original `meeting_mediafile` IDs for orga-wide mediafiles.
-        Should be generated manually to avoid replacing original meeting_mediafile ids for orga-wide mediafiles.
+        Generates the back-relations from mediafiles to meeting_mediafiles.
+        Relations should be generated manually to avoid replacing original
+        meeting_mediafile ids for orga-wide mediafiles.
         """
         mediafiles_back_relations = {}
 

--- a/openslides_backend/action/actions/meeting/import_.py
+++ b/openslides_backend/action/actions/meeting/import_.py
@@ -631,7 +631,10 @@ class MeetingImport(
                             entry,
                         )
                     )
-                elif collection in ["user", "gender", "mediafile"]:
+                elif collection in ["user", "gender"] or (
+                    collection == "mediafile"
+                    and getattr(self, "action_name", None) == "clone"
+                ):
                     list_fields: ListFields = {"add": {}, "remove": {}}
                     for field, value in entry.items():
                         model_field = model_registry[collection]().try_get_field(field)

--- a/openslides_backend/action/actions/meeting/import_.py
+++ b/openslides_backend/action/actions/meeting/import_.py
@@ -631,7 +631,7 @@ class MeetingImport(
                             entry,
                         )
                     )
-                elif collection in ["user", "gender"]:
+                elif collection in ["user", "gender", "mediafile"]:
                     list_fields: ListFields = {"add": {}, "remove": {}}
                     for field, value in entry.items():
                         model_field = model_registry[collection]().try_get_field(field)

--- a/openslides_backend/action/actions/meeting_mediafile/create.py
+++ b/openslides_backend/action/actions/meeting_mediafile/create.py
@@ -9,12 +9,6 @@ from ...util.action_type import ActionType
 from ...util.default_schema import DefaultSchema
 from ...util.register import register_action
 
-EXTRA_RELATIONAL_FIELDS_TO_MEETING = [
-    field.own_field_name
-    for field in MeetingMediafile().get_fields()
-    if field.own_field_name.startswith("used_as_")
-]
-
 
 @register_action("meeting_mediafile.create", action_type=ActionType.BACKEND_INTERNAL)
 class MeetingMediafileCreate(CreateAction):
@@ -26,8 +20,7 @@ class MeetingMediafileCreate(CreateAction):
     model = MeetingMediafile()
     schema = DefaultSchema(MeetingMediafile()).get_create_schema(
         required_properties=["meeting_id", "mediafile_id", "is_public"],
-        optional_properties=["access_group_ids", "inherited_access_group_ids"]
-        + EXTRA_RELATIONAL_FIELDS_TO_MEETING,
+        optional_properties=["access_group_ids", "inherited_access_group_ids"],
     )
 
     def update_instance(self, instance: dict[str, Any]) -> dict[str, Any]:

--- a/openslides_backend/action/actions/motion/base_create_forwarded.py
+++ b/openslides_backend/action/actions/motion/base_create_forwarded.py
@@ -421,8 +421,10 @@ class BaseMotionCreateForwarded(
         )
 
         # Calculate new ids and execute dublication actions
-        meeting_mediafile_replace_map = self.perform_mediafiles_duplication(
-            fetched_data, meeting_mediafile_replace_map
+        meeting_mediafile_replace_map, _ = (
+            self.perform_mediafiles_mapping_and_duplication(
+                fetched_data, meeting_mediafile_replace_map
+            )
         )
         return forwarded_attachments, meeting_mediafile_replace_map
 

--- a/openslides_backend/action/actions/motion/base_create_forwarded.py
+++ b/openslides_backend/action/actions/motion/base_create_forwarded.py
@@ -422,7 +422,7 @@ class BaseMotionCreateForwarded(
 
         # Calculate new ids and execute dublication actions
         meeting_mediafile_replace_map, _ = self.perform_mediafiles_duplication(
-            fetched_data, meeting_mediafile_replace_map, True
+            fetched_data, meeting_mediafile_replace_map
         )
         return forwarded_attachments, meeting_mediafile_replace_map
 

--- a/openslides_backend/action/actions/motion/base_create_forwarded.py
+++ b/openslides_backend/action/actions/motion/base_create_forwarded.py
@@ -421,7 +421,7 @@ class BaseMotionCreateForwarded(
         )
 
         # Calculate new ids and execute dublication actions
-        meeting_mediafile_replace_map, _ = self.perform_mediafiles_duplication(
+        meeting_mediafile_replace_map = self.perform_mediafiles_duplication(
             fetched_data, meeting_mediafile_replace_map
         )
         return forwarded_attachments, meeting_mediafile_replace_map

--- a/openslides_backend/action/actions/motion/base_create_forwarded.py
+++ b/openslides_backend/action/actions/motion/base_create_forwarded.py
@@ -421,10 +421,8 @@ class BaseMotionCreateForwarded(
         )
 
         # Calculate new ids and execute dublication actions
-        meeting_mediafile_replace_map, _ = (
-            self.perform_mediafiles_mapping_and_duplication(
-                fetched_data, meeting_mediafile_replace_map
-            )
+        meeting_mediafile_replace_map, _ = self.perform_mediafiles_duplication(
+            fetched_data, meeting_mediafile_replace_map, True
         )
         return forwarded_attachments, meeting_mediafile_replace_map
 

--- a/openslides_backend/action/mixins/forward_mediafiles_mixin.py
+++ b/openslides_backend/action/mixins/forward_mediafiles_mixin.py
@@ -17,7 +17,6 @@ class ForwardMediafilesMixin(Action):
         self,
         fetched_data: dict[str, dict[int, dict[str, Any]]],
         meeting_mediafile_replace_map: dict[int, dict[int, int]] = {},
-        should_create_meeting_mediafiles: bool = False,
     ) -> tuple[dict[int, dict[int, int]], dict[int, dict[int, int]]]:
         """
         Duplicates meeting_mediafiles to the meetings defined in target_meeting_ids.
@@ -39,7 +38,7 @@ class ForwardMediafilesMixin(Action):
             mediafile_new_mm_map_by_meeting,
             new_mm_instances_data,
             mm_id_target_meeting_ids_map,
-        ) = self.map_mediafiles_data(fetched_data, should_create_meeting_mediafiles)
+        ) = self.map_mediafiles_data(fetched_data)
         duplicate_mediafiles_data, mediafile_replace_map_by_meeting = (
             self._build_duplication_data_and_mediafile_replace_map(
                 mediafiles,
@@ -62,7 +61,6 @@ class ForwardMediafilesMixin(Action):
     def map_mediafiles_data(
         self,
         fetched_data: dict[str, dict[int, dict[str, Any]]],
-        should_create_meeting_mediafiles: bool,
     ) -> tuple[
         dict[int, dict[str, Any]],
         dict[int, dict[int, dict[str, Any]]],
@@ -96,8 +94,7 @@ class ForwardMediafilesMixin(Action):
                     mm_instance["mediafile_id"]
                 ] = mm_instance
                 mm_id_target_meeting_ids_map[mm_id].add(meeting_id)
-                if should_create_meeting_mediafiles:
-                    new_mm_instances_data.append(mm_instance)
+                new_mm_instances_data.append(mm_instance)
 
         return (
             mediafiles,

--- a/openslides_backend/action/mixins/forward_mediafiles_mixin.py
+++ b/openslides_backend/action/mixins/forward_mediafiles_mixin.py
@@ -17,7 +17,7 @@ class ForwardMediafilesMixin(Action):
         self,
         fetched_data: dict[str, dict[int, dict[str, Any]]],
         meeting_mediafile_replace_map: dict[int, dict[int, int]] = {},
-    ) -> tuple[dict[int, dict[int, int]], dict[int, dict[int, int]]]:
+    ) -> dict[int, dict[int, int]]:
         """
         Duplicates meeting_mediafiles to the meetings defined in target_meeting_ids.
         If related mediafile is meeting-wide also duplicates it.

--- a/openslides_backend/action/mixins/forward_mediafiles_mixin.py
+++ b/openslides_backend/action/mixins/forward_mediafiles_mixin.py
@@ -56,7 +56,7 @@ class ForwardMediafilesMixin(Action):
                 mediafile_replace_map_by_meeting,
                 meeting_mediafile_replace_map,
             )
-        return meeting_mediafile_replace_map, mediafile_replace_map_by_meeting
+        return meeting_mediafile_replace_map
 
     def map_mediafiles_data(
         self,

--- a/openslides_backend/action/mixins/forward_mediafiles_mixin.py
+++ b/openslides_backend/action/mixins/forward_mediafiles_mixin.py
@@ -13,11 +13,11 @@ from ..actions.meeting_mediafile.create import MeetingMediafileCreate
 
 
 class ForwardMediafilesMixin(Action):
-    def perform_mediafiles_mapping_and_duplication(
+    def perform_mediafiles_duplication(
         self,
         fetched_data: dict[str, dict[int, dict[str, Any]]],
         meeting_mediafile_replace_map: dict[int, dict[int, int]] = {},
-        should_create_mm: bool = True,
+        should_create_meeting_mediafiles: bool = False,
     ) -> tuple[dict[int, dict[int, int]], dict[int, dict[int, int]]]:
         """
         Duplicates meeting_mediafiles to the meetings defined in target_meeting_ids.
@@ -39,7 +39,7 @@ class ForwardMediafilesMixin(Action):
             mediafile_new_mm_map_by_meeting,
             new_mm_instances_data,
             mm_id_target_meeting_ids_map,
-        ) = self.map_mediafiles_data(fetched_data)
+        ) = self.map_mediafiles_data(fetched_data, should_create_meeting_mediafiles)
         duplicate_mediafiles_data, mediafile_replace_map_by_meeting = (
             self._build_duplication_data_and_mediafile_replace_map(
                 mediafiles,
@@ -51,7 +51,7 @@ class ForwardMediafilesMixin(Action):
             self.execute_other_action(
                 MediafileDuplicateToAnotherMeetingAction, duplicate_mediafiles_data
             )
-        if new_mm_instances_data and should_create_mm:
+        if new_mm_instances_data:
             meeting_mediafile_replace_map = self._duplicate_meeting_mediafiles(
                 new_mm_instances_data,
                 mediafile_replace_map_by_meeting,
@@ -60,7 +60,9 @@ class ForwardMediafilesMixin(Action):
         return meeting_mediafile_replace_map, mediafile_replace_map_by_meeting
 
     def map_mediafiles_data(
-        self, fetched_data: dict[str, dict[int, dict[str, Any]]]
+        self,
+        fetched_data: dict[str, dict[int, dict[str, Any]]],
+        should_create_meeting_mediafiles: bool,
     ) -> tuple[
         dict[int, dict[str, Any]],
         dict[int, dict[int, dict[str, Any]]],
@@ -93,8 +95,9 @@ class ForwardMediafilesMixin(Action):
                 mediafile_new_mm_map_by_meeting[meeting_id][
                     mm_instance["mediafile_id"]
                 ] = mm_instance
-                new_mm_instances_data.append(mm_instance)
                 mm_id_target_meeting_ids_map[mm_id].add(meeting_id)
+                if should_create_meeting_mediafiles:
+                    new_mm_instances_data.append(mm_instance)
 
         return (
             mediafiles,

--- a/tests/system/action/meeting/test_clone.py
+++ b/tests/system/action/meeting/test_clone.py
@@ -1,6 +1,6 @@
 from time import time
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from datastore.shared.util import is_reserved_field
 
@@ -1066,7 +1066,10 @@ class MeetingClone(BaseActionTestCase):
         self.media.duplicate_mediafile = MagicMock()
         response = self.request("meeting.clone", {"meeting_id": 1})
         self.assert_status_code(response, 200)
-        self.media.duplicate_mediafile.assert_called_with(2, 4)
+        self.assertEqual(self.media.duplicate_mediafile.call_count, 2)
+        self.media.duplicate_mediafile.assert_has_calls(
+            calls=[call(1, 3), call(2, 4)], any_order=True
+        )
         self.assert_model_exists(
             "meeting_mediafile/21",
             {
@@ -1153,7 +1156,7 @@ class MeetingClone(BaseActionTestCase):
         self.media.duplicate_mediafile = MagicMock()
         response = self.request("meeting.clone", {"meeting_id": 1})
         self.assert_status_code(response, 200)
-        self.media.duplicate_mediafile.assert_called_with(2, 4)
+        self.media.duplicate_mediafile.assert_called_once_with(2, 4)
         self.assert_model_exists(
             "meeting_mediafile/21",
             {
@@ -1207,6 +1210,20 @@ class MeetingClone(BaseActionTestCase):
                 "mimetype": "text/plain",
                 "meeting_mediafile_ids": [22],
                 "parent_id": 3,
+            },
+        )
+        self.assert_model_exists(
+            "group/3",
+            {
+                "meeting_mediafile_access_group_ids": [21],
+                "meeting_mediafile_inherited_access_group_ids": [21, 22],
+            },
+        )
+        self.assert_model_exists(
+            "group/4",
+            {
+                "meeting_mediafile_access_group_ids": [21],
+                "meeting_mediafile_inherited_access_group_ids": [21, 22],
             },
         )
 
@@ -1312,7 +1329,7 @@ class MeetingClone(BaseActionTestCase):
         self.media.duplicate_mediafile = MagicMock()
         response = self.request("meeting.clone", {"meeting_id": 1})
         self.assert_status_code(response, 200)
-        self.media.duplicate_mediafile.assert_called_with(1, 6)
+        self.media.duplicate_mediafile.assert_called_once_with(1, 6)
         self.assert_model_exists(
             "meeting_mediafile/31",
             {
@@ -1386,6 +1403,28 @@ class MeetingClone(BaseActionTestCase):
                 "mimetype": "text/plain",
                 "meeting_mediafile_ids": [33],
                 "parent_id": 5,
+            },
+        )
+        self.assert_model_exists(
+            "group/3",
+            {
+                "meeting_mediafile_access_group_ids": [31, 32],
+                "meeting_mediafile_inherited_access_group_ids": [31, 32, 33],
+            },
+        )
+        self.assert_model_exists(
+            "group/4",
+            {
+                "meeting_mediafile_access_group_ids": [31, 32],
+                "meeting_mediafile_inherited_access_group_ids": [31, 32, 33],
+            },
+        )
+        self.assert_model_exists(
+            "list_of_speakers/301",
+            {
+                "sequential_number": 1,
+                "meeting_id": 2,
+                "content_object_id": "meeting_mediafile/33",
             },
         )
         try:
@@ -1475,7 +1514,7 @@ class MeetingClone(BaseActionTestCase):
         self.media.duplicate_mediafile = MagicMock()
         response = self.request("meeting.clone", {"meeting_id": 1})
         self.assert_status_code(response, 200)
-        self.media.duplicate_mediafile.assert_called_with(1, 6)
+        self.media.duplicate_mediafile.assert_called_once_with(1, 6)
         self.assert_model_exists(
             "meeting_mediafile/31",
             {
@@ -1549,6 +1588,27 @@ class MeetingClone(BaseActionTestCase):
                 "mimetype": "text/plain",
                 "meeting_mediafile_ids": [33],
                 "parent_id": 5,
+            },
+        )
+        self.assert_model_exists(
+            "group/3",
+            {
+                "meeting_mediafile_access_group_ids": [31, 32],
+                "meeting_mediafile_inherited_access_group_ids": [31, 32, 33],
+            },
+        )
+        self.assert_model_exists(
+            "group/4",
+            {
+                "meeting_mediafile_access_group_ids": [31, 32],
+                "meeting_mediafile_inherited_access_group_ids": [31, 32, 33],
+            },
+        )
+        self.assert_model_exists(
+            "projection/301",
+            {
+                "meeting_id": 2,
+                "content_object_id": "meeting_mediafile/33",
             },
         )
         try:
@@ -1654,7 +1714,7 @@ class MeetingClone(BaseActionTestCase):
         self.media.duplicate_mediafile = MagicMock()
         response = self.request("meeting.clone", {"meeting_id": 1})
         self.assert_status_code(response, 200)
-        self.media.duplicate_mediafile.assert_called_with(1, 6)
+        self.media.duplicate_mediafile.assert_called_once_with(1, 6)
         self.assert_model_exists(
             "meeting_mediafile/31",
             {
@@ -1729,6 +1789,23 @@ class MeetingClone(BaseActionTestCase):
                 "meeting_mediafile_ids": [33],
                 "parent_id": 5,
             },
+        )
+        self.assert_model_exists(
+            "group/3",
+            {
+                "meeting_mediafile_access_group_ids": [31, 32],
+                "meeting_mediafile_inherited_access_group_ids": [31, 32, 33],
+            },
+        )
+        self.assert_model_exists(
+            "group/4",
+            {
+                "meeting_mediafile_access_group_ids": [31, 32],
+                "meeting_mediafile_inherited_access_group_ids": [31, 32, 33],
+            },
+        )
+        self.assert_model_exists(
+            "motion/301", {"meeting_id": 2, "attachment_meeting_mediafile_ids": [33]}
         )
         try:
             self.run_db_checker()

--- a/tests/system/action/meeting/test_clone.py
+++ b/tests/system/action/meeting/test_clone.py
@@ -1329,24 +1329,16 @@ class MeetingClone(BaseActionTestCase):
         self.media.duplicate_mediafile = MagicMock()
         response = self.request("meeting.clone", {"meeting_id": 1})
         self.assert_status_code(response, 200)
-        self.media.duplicate_mediafile.assert_called_once_with(1, 6)
+        self.media.duplicate_mediafile.assert_called_once_with(1, 4)
         self.assert_model_exists(
-            "meeting_mediafile/31",
-            {
-                "meeting_id": 2,
-                "mediafile_id": 4,
-            },
+            "meeting_mediafile/31", {"meeting_id": 2, "mediafile_id": 5}
         )
         self.assert_model_exists(
-            "meeting_mediafile/32",
-            {
-                "meeting_id": 2,
-                "mediafile_id": 5,
-            },
+            "meeting_mediafile/32", {"meeting_id": 2, "mediafile_id": 6}
         )
         self.assert_model_exists(
             "meeting_mediafile/33",
-            {"meeting_id": 2, "mediafile_id": 6, "list_of_speakers_id": 301},
+            {"meeting_id": 2, "mediafile_id": 4, "list_of_speakers_id": 301},
         )
         self.assert_model_exists("meeting/2", {"meeting_mediafile_ids": [31, 32, 33]})
         self.assert_model_exists(
@@ -1378,21 +1370,11 @@ class MeetingClone(BaseActionTestCase):
             },
         )
         self.assert_model_exists(
-            "mediafile/4",
-            {
-                "owner_id": "meeting/2",
-                "is_directory": True,
-                "meeting_mediafile_ids": [31],
-                "child_ids": [5],
-            },
-        )
-        self.assert_model_exists(
             "mediafile/5",
             {
                 "owner_id": "meeting/2",
                 "is_directory": True,
-                "meeting_mediafile_ids": [32],
-                "parent_id": 4,
+                "meeting_mediafile_ids": [31],
                 "child_ids": [6],
             },
         )
@@ -1400,9 +1382,19 @@ class MeetingClone(BaseActionTestCase):
             "mediafile/6",
             {
                 "owner_id": "meeting/2",
+                "is_directory": True,
+                "meeting_mediafile_ids": [32],
+                "parent_id": 5,
+                "child_ids": [4],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/4",
+            {
+                "owner_id": "meeting/2",
                 "mimetype": "text/plain",
                 "meeting_mediafile_ids": [33],
-                "parent_id": 5,
+                "parent_id": 6,
             },
         )
         self.assert_model_exists(
@@ -1514,24 +1506,16 @@ class MeetingClone(BaseActionTestCase):
         self.media.duplicate_mediafile = MagicMock()
         response = self.request("meeting.clone", {"meeting_id": 1})
         self.assert_status_code(response, 200)
-        self.media.duplicate_mediafile.assert_called_once_with(1, 6)
+        self.media.duplicate_mediafile.assert_called_once_with(1, 4)
         self.assert_model_exists(
-            "meeting_mediafile/31",
-            {
-                "meeting_id": 2,
-                "mediafile_id": 4,
-            },
+            "meeting_mediafile/31", {"meeting_id": 2, "mediafile_id": 5}
         )
         self.assert_model_exists(
-            "meeting_mediafile/32",
-            {
-                "meeting_id": 2,
-                "mediafile_id": 5,
-            },
+            "meeting_mediafile/32", {"meeting_id": 2, "mediafile_id": 6}
         )
         self.assert_model_exists(
             "meeting_mediafile/33",
-            {"meeting_id": 2, "mediafile_id": 6, "projection_ids": [301]},
+            {"meeting_id": 2, "mediafile_id": 4, "projection_ids": [301]},
         )
         self.assert_model_exists("meeting/2", {"meeting_mediafile_ids": [31, 32, 33]})
         self.assert_model_exists(
@@ -1563,21 +1547,11 @@ class MeetingClone(BaseActionTestCase):
             },
         )
         self.assert_model_exists(
-            "mediafile/4",
-            {
-                "owner_id": "meeting/2",
-                "is_directory": True,
-                "meeting_mediafile_ids": [31],
-                "child_ids": [5],
-            },
-        )
-        self.assert_model_exists(
             "mediafile/5",
             {
                 "owner_id": "meeting/2",
                 "is_directory": True,
-                "meeting_mediafile_ids": [32],
-                "parent_id": 4,
+                "meeting_mediafile_ids": [31],
                 "child_ids": [6],
             },
         )
@@ -1585,9 +1559,19 @@ class MeetingClone(BaseActionTestCase):
             "mediafile/6",
             {
                 "owner_id": "meeting/2",
+                "is_directory": True,
+                "meeting_mediafile_ids": [32],
+                "parent_id": 5,
+                "child_ids": [4],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/4",
+            {
+                "owner_id": "meeting/2",
                 "mimetype": "text/plain",
                 "meeting_mediafile_ids": [33],
-                "parent_id": 5,
+                "parent_id": 6,
             },
         )
         self.assert_model_exists(
@@ -1714,24 +1698,16 @@ class MeetingClone(BaseActionTestCase):
         self.media.duplicate_mediafile = MagicMock()
         response = self.request("meeting.clone", {"meeting_id": 1})
         self.assert_status_code(response, 200)
-        self.media.duplicate_mediafile.assert_called_once_with(1, 6)
+        self.media.duplicate_mediafile.assert_called_once_with(1, 4)
         self.assert_model_exists(
-            "meeting_mediafile/31",
-            {
-                "meeting_id": 2,
-                "mediafile_id": 4,
-            },
+            "meeting_mediafile/31", {"meeting_id": 2, "mediafile_id": 5}
         )
         self.assert_model_exists(
-            "meeting_mediafile/32",
-            {
-                "meeting_id": 2,
-                "mediafile_id": 5,
-            },
+            "meeting_mediafile/32", {"meeting_id": 2, "mediafile_id": 6}
         )
         self.assert_model_exists(
             "meeting_mediafile/33",
-            {"meeting_id": 2, "mediafile_id": 6, "attachment_ids": ["motion/301"]},
+            {"meeting_id": 2, "mediafile_id": 4, "attachment_ids": ["motion/301"]},
         )
         self.assert_model_exists("meeting/2", {"meeting_mediafile_ids": [31, 32, 33]})
         self.assert_model_exists(
@@ -1763,21 +1739,11 @@ class MeetingClone(BaseActionTestCase):
             },
         )
         self.assert_model_exists(
-            "mediafile/4",
-            {
-                "owner_id": "meeting/2",
-                "is_directory": True,
-                "meeting_mediafile_ids": [31],
-                "child_ids": [5],
-            },
-        )
-        self.assert_model_exists(
             "mediafile/5",
             {
                 "owner_id": "meeting/2",
                 "is_directory": True,
-                "meeting_mediafile_ids": [32],
-                "parent_id": 4,
+                "meeting_mediafile_ids": [31],
                 "child_ids": [6],
             },
         )
@@ -1785,9 +1751,19 @@ class MeetingClone(BaseActionTestCase):
             "mediafile/6",
             {
                 "owner_id": "meeting/2",
+                "is_directory": True,
+                "meeting_mediafile_ids": [32],
+                "parent_id": 5,
+                "child_ids": [4],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/4",
+            {
+                "owner_id": "meeting/2",
                 "mimetype": "text/plain",
                 "meeting_mediafile_ids": [33],
-                "parent_id": 5,
+                "parent_id": 6,
             },
         )
         self.assert_model_exists(

--- a/tests/system/action/meeting/test_clone.py
+++ b/tests/system/action/meeting/test_clone.py
@@ -1206,6 +1206,492 @@ class MeetingClone(BaseActionTestCase):
             },
         )
 
+    def test_clone_with_meeting_mediafile_hierarchy_and_los(self) -> None:
+        self.test_models["meeting/1"]["user_ids"] = [1]
+        self.test_models["meeting/1"]["mediafile_ids"] = [1, 2, 3]
+        self.test_models["meeting/1"]["meeting_mediafile_ids"] = [10, 20, 30]
+        self.test_models["meeting/1"]["meeting_user_ids"] = [1]
+        self.test_models["group/2"]["meeting_user_ids"] = [1]
+        self.set_models(self.test_models)
+        self.set_models(
+            {
+                "meeting/1": {"meeting_user_ids": [1], "list_of_speakers_ids": [300]},
+                "user/1": {
+                    "meeting_user_ids": [1],
+                    "meeting_ids": [1],
+                },
+                "meeting_user/1": {
+                    "meeting_id": 1,
+                    "user_id": 1,
+                    "group_ids": [2],
+                },
+                "mediafile/1": {
+                    "owner_id": "meeting/1",
+                    "mimetype": "text/plain",
+                    "meeting_mediafile_ids": [30],
+                    "parent_id": 3,
+                },
+                "mediafile/2": {
+                    "owner_id": "meeting/1",
+                    "is_directory": True,
+                    "meeting_mediafile_ids": [10],
+                    "child_ids": [3],
+                },
+                "mediafile/3": {
+                    "owner_id": "meeting/1",
+                    "is_directory": True,
+                    "meeting_mediafile_ids": [20],
+                    "parent_id": 2,
+                    "child_ids": [1],
+                },
+                "meeting_mediafile/10": {
+                    "meeting_id": 1,
+                    "mediafile_id": 2,
+                    "attachment_ids": [],
+                    "is_public": False,
+                    "access_group_ids": [1, 2],
+                    "inherited_access_group_ids": [1, 2],
+                },
+                "meeting_mediafile/20": {
+                    "meeting_id": 1,
+                    "mediafile_id": 3,
+                    "attachment_ids": [],
+                    "is_public": False,
+                    "access_group_ids": [1, 2],
+                    "inherited_access_group_ids": [1, 2],
+                },
+                "meeting_mediafile/30": {
+                    "meeting_id": 1,
+                    "mediafile_id": 1,
+                    "attachment_ids": [],
+                    "is_public": False,
+                    "access_group_ids": [],
+                    "inherited_access_group_ids": [1, 2],
+                    "list_of_speakers_id": 300,
+                },
+                "list_of_speakers/300": {
+                    "sequential_number": 1,
+                    "meeting_id": 1,
+                    "content_object_id": "meeting_mediafile/30",
+                },
+                "group/1": {
+                    "meeting_mediafile_access_group_ids": [10, 20],
+                    "meeting_mediafile_inherited_access_group_ids": [10, 20, 30],
+                },
+                "group/2": {
+                    "meeting_mediafile_access_group_ids": [10, 20],
+                    "meeting_mediafile_inherited_access_group_ids": [10, 20, 30],
+                },
+            }
+        )
+        self.media.duplicate_mediafile = MagicMock()
+        response = self.request("meeting.clone", {"meeting_id": 1})
+        self.assert_status_code(response, 200)
+        self.media.duplicate_mediafile.assert_called_with(1, 6)
+        self.assert_model_exists(
+            "meeting_mediafile/31",
+            {
+                "meeting_id": 2,
+                "mediafile_id": 4,
+            },
+        )
+        self.assert_model_exists(
+            "meeting_mediafile/32",
+            {
+                "meeting_id": 2,
+                "mediafile_id": 5,
+            },
+        )
+        self.assert_model_exists(
+            "meeting_mediafile/33",
+            {"meeting_id": 2, "mediafile_id": 6, "list_of_speakers_id": 301},
+        )
+        self.assert_model_exists("meeting/2", {"meeting_mediafile_ids": [31, 32, 33]})
+        self.assert_model_exists(
+            "mediafile/2",
+            {
+                "owner_id": "meeting/1",
+                "is_directory": True,
+                "meeting_mediafile_ids": [10],
+                "child_ids": [3],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/3",
+            {
+                "owner_id": "meeting/1",
+                "is_directory": True,
+                "meeting_mediafile_ids": [20],
+                "parent_id": 2,
+                "child_ids": [1],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/1",
+            {
+                "owner_id": "meeting/1",
+                "mimetype": "text/plain",
+                "meeting_mediafile_ids": [30],
+                "parent_id": 3,
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/4",
+            {
+                "owner_id": "meeting/2",
+                "is_directory": True,
+                "meeting_mediafile_ids": [31],
+                "child_ids": [5],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/5",
+            {
+                "owner_id": "meeting/2",
+                "is_directory": True,
+                "meeting_mediafile_ids": [32],
+                "parent_id": 4,
+                "child_ids": [6],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/6",
+            {
+                "owner_id": "meeting/2",
+                "mimetype": "text/plain",
+                "meeting_mediafile_ids": [33],
+                "parent_id": 5,
+            },
+        )
+
+    def test_clone_with_meeting_mediafile_hierarchy_and_projection(self) -> None:
+        self.test_models["meeting/1"]["user_ids"] = [1]
+        self.test_models["meeting/1"]["mediafile_ids"] = [1, 2, 3]
+        self.test_models["meeting/1"]["meeting_mediafile_ids"] = [10, 20, 30]
+        self.test_models["meeting/1"]["meeting_user_ids"] = [1]
+        self.test_models["group/2"]["meeting_user_ids"] = [1]
+        self.set_models(self.test_models)
+        self.set_models(
+            {
+                "meeting/1": {"meeting_user_ids": [1], "all_projection_ids": [300]},
+                "user/1": {
+                    "meeting_user_ids": [1],
+                    "meeting_ids": [1],
+                },
+                "meeting_user/1": {
+                    "meeting_id": 1,
+                    "user_id": 1,
+                    "group_ids": [2],
+                },
+                "mediafile/1": {
+                    "owner_id": "meeting/1",
+                    "mimetype": "text/plain",
+                    "meeting_mediafile_ids": [30],
+                    "parent_id": 3,
+                },
+                "mediafile/2": {
+                    "owner_id": "meeting/1",
+                    "is_directory": True,
+                    "meeting_mediafile_ids": [10],
+                    "child_ids": [3],
+                },
+                "mediafile/3": {
+                    "owner_id": "meeting/1",
+                    "is_directory": True,
+                    "meeting_mediafile_ids": [20],
+                    "parent_id": 2,
+                    "child_ids": [1],
+                },
+                "meeting_mediafile/10": {
+                    "meeting_id": 1,
+                    "mediafile_id": 2,
+                    "attachment_ids": [],
+                    "is_public": False,
+                    "access_group_ids": [1, 2],
+                    "inherited_access_group_ids": [1, 2],
+                },
+                "meeting_mediafile/20": {
+                    "meeting_id": 1,
+                    "mediafile_id": 3,
+                    "attachment_ids": [],
+                    "is_public": False,
+                    "access_group_ids": [1, 2],
+                    "inherited_access_group_ids": [1, 2],
+                },
+                "meeting_mediafile/30": {
+                    "meeting_id": 1,
+                    "mediafile_id": 1,
+                    "attachment_ids": [],
+                    "is_public": False,
+                    "access_group_ids": [],
+                    "inherited_access_group_ids": [1, 2],
+                    "projection_ids": [300],
+                },
+                "projection/300": {
+                    "meeting_id": 1,
+                    "content_object_id": "meeting_mediafile/30",
+                },
+                "group/1": {
+                    "meeting_mediafile_access_group_ids": [10, 20],
+                    "meeting_mediafile_inherited_access_group_ids": [10, 20, 30],
+                },
+                "group/2": {
+                    "meeting_mediafile_access_group_ids": [10, 20],
+                    "meeting_mediafile_inherited_access_group_ids": [10, 20, 30],
+                },
+            }
+        )
+        self.media.duplicate_mediafile = MagicMock()
+        response = self.request("meeting.clone", {"meeting_id": 1})
+        self.assert_status_code(response, 200)
+        self.media.duplicate_mediafile.assert_called_with(1, 6)
+        self.assert_model_exists(
+            "meeting_mediafile/31",
+            {
+                "meeting_id": 2,
+                "mediafile_id": 4,
+            },
+        )
+        self.assert_model_exists(
+            "meeting_mediafile/32",
+            {
+                "meeting_id": 2,
+                "mediafile_id": 5,
+            },
+        )
+        self.assert_model_exists(
+            "meeting_mediafile/33",
+            {"meeting_id": 2, "mediafile_id": 6, "projection_ids": [301]},
+        )
+        self.assert_model_exists("meeting/2", {"meeting_mediafile_ids": [31, 32, 33]})
+        self.assert_model_exists(
+            "mediafile/2",
+            {
+                "owner_id": "meeting/1",
+                "is_directory": True,
+                "meeting_mediafile_ids": [10],
+                "child_ids": [3],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/3",
+            {
+                "owner_id": "meeting/1",
+                "is_directory": True,
+                "meeting_mediafile_ids": [20],
+                "parent_id": 2,
+                "child_ids": [1],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/1",
+            {
+                "owner_id": "meeting/1",
+                "mimetype": "text/plain",
+                "meeting_mediafile_ids": [30],
+                "parent_id": 3,
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/4",
+            {
+                "owner_id": "meeting/2",
+                "is_directory": True,
+                "meeting_mediafile_ids": [31],
+                "child_ids": [5],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/5",
+            {
+                "owner_id": "meeting/2",
+                "is_directory": True,
+                "meeting_mediafile_ids": [32],
+                "parent_id": 4,
+                "child_ids": [6],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/6",
+            {
+                "owner_id": "meeting/2",
+                "mimetype": "text/plain",
+                "meeting_mediafile_ids": [33],
+                "parent_id": 5,
+            },
+        )
+
+    def test_clone_with_meeting_mediafile_hierarchy_and_attachment(self) -> None:
+        self.test_models["meeting/1"]["user_ids"] = [1]
+        self.test_models["meeting/1"]["mediafile_ids"] = [1, 2, 3]
+        self.test_models["meeting/1"]["meeting_mediafile_ids"] = [10, 20, 30]
+        self.test_models["meeting/1"]["meeting_user_ids"] = [1]
+        self.test_models["group/2"]["meeting_user_ids"] = [1]
+        self.set_models(self.test_models)
+        self.set_models(
+            {
+                "meeting/1": {
+                    "meeting_user_ids": [1],
+                    "motion_ids": [300],
+                    "list_of_speakers_ids": [3000],
+                },
+                "user/1": {
+                    "meeting_user_ids": [1],
+                    "meeting_ids": [1],
+                },
+                "meeting_user/1": {
+                    "meeting_id": 1,
+                    "user_id": 1,
+                    "group_ids": [2],
+                },
+                "mediafile/1": {
+                    "owner_id": "meeting/1",
+                    "mimetype": "text/plain",
+                    "meeting_mediafile_ids": [30],
+                    "parent_id": 3,
+                },
+                "mediafile/2": {
+                    "owner_id": "meeting/1",
+                    "is_directory": True,
+                    "meeting_mediafile_ids": [10],
+                    "child_ids": [3],
+                },
+                "mediafile/3": {
+                    "owner_id": "meeting/1",
+                    "is_directory": True,
+                    "meeting_mediafile_ids": [20],
+                    "parent_id": 2,
+                    "child_ids": [1],
+                },
+                "meeting_mediafile/10": {
+                    "meeting_id": 1,
+                    "mediafile_id": 2,
+                    "attachment_ids": [],
+                    "is_public": False,
+                    "access_group_ids": [1, 2],
+                    "inherited_access_group_ids": [1, 2],
+                },
+                "meeting_mediafile/20": {
+                    "meeting_id": 1,
+                    "mediafile_id": 3,
+                    "attachment_ids": [],
+                    "is_public": False,
+                    "access_group_ids": [1, 2],
+                    "inherited_access_group_ids": [1, 2],
+                },
+                "meeting_mediafile/30": {
+                    "meeting_id": 1,
+                    "mediafile_id": 1,
+                    "is_public": False,
+                    "access_group_ids": [],
+                    "inherited_access_group_ids": [1, 2],
+                    "attachment_ids": ["motion/300"],
+                },
+                "motion/300": {
+                    "meeting_id": 1,
+                    "attachment_meeting_mediafile_ids": [30],
+                    "list_of_speakers_id": 3000,
+                    "sequential_number": 1,
+                    "state_id": 1,
+                    "title": "A motion",
+                    "text": "A motion text",
+                },
+                "list_of_speakers/3000": {
+                    "meeting_id": 1,
+                    "sequential_number": 1,
+                    "content_object_id": "motion/300",
+                },
+                "motion_state/1": {"motion_ids": [300]},
+                "group/1": {
+                    "meeting_mediafile_access_group_ids": [10, 20],
+                    "meeting_mediafile_inherited_access_group_ids": [10, 20, 30],
+                },
+                "group/2": {
+                    "meeting_mediafile_access_group_ids": [10, 20],
+                    "meeting_mediafile_inherited_access_group_ids": [10, 20, 30],
+                },
+            }
+        )
+        self.media.duplicate_mediafile = MagicMock()
+        response = self.request("meeting.clone", {"meeting_id": 1})
+        self.assert_status_code(response, 200)
+        self.media.duplicate_mediafile.assert_called_with(1, 6)
+        self.assert_model_exists(
+            "meeting_mediafile/31",
+            {
+                "meeting_id": 2,
+                "mediafile_id": 4,
+            },
+        )
+        self.assert_model_exists(
+            "meeting_mediafile/32",
+            {
+                "meeting_id": 2,
+                "mediafile_id": 5,
+            },
+        )
+        self.assert_model_exists(
+            "meeting_mediafile/33",
+            {"meeting_id": 2, "mediafile_id": 6, "attachment_ids": ["motion/301"]},
+        )
+        self.assert_model_exists("meeting/2", {"meeting_mediafile_ids": [31, 32, 33]})
+        self.assert_model_exists(
+            "mediafile/2",
+            {
+                "owner_id": "meeting/1",
+                "is_directory": True,
+                "meeting_mediafile_ids": [10],
+                "child_ids": [3],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/3",
+            {
+                "owner_id": "meeting/1",
+                "is_directory": True,
+                "meeting_mediafile_ids": [20],
+                "parent_id": 2,
+                "child_ids": [1],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/1",
+            {
+                "owner_id": "meeting/1",
+                "mimetype": "text/plain",
+                "meeting_mediafile_ids": [30],
+                "parent_id": 3,
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/4",
+            {
+                "owner_id": "meeting/2",
+                "is_directory": True,
+                "meeting_mediafile_ids": [31],
+                "child_ids": [5],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/5",
+            {
+                "owner_id": "meeting/2",
+                "is_directory": True,
+                "meeting_mediafile_ids": [32],
+                "parent_id": 4,
+                "child_ids": [6],
+            },
+        )
+        self.assert_model_exists(
+            "mediafile/6",
+            {
+                "owner_id": "meeting/2",
+                "mimetype": "text/plain",
+                "meeting_mediafile_ids": [33],
+                "parent_id": 5,
+            },
+        )
+
     def test_clone_with_mediafile_directory(self) -> None:
         self.test_models["meeting/1"]["user_ids"] = [1]
         self.test_models["meeting/1"]["meeting_user_ids"] = [1]


### PR DESCRIPTION
Had to load parent_ids of mediafiles without  to ensure their access groups were taken into consideration by the checker. Needed to load those among said parent_ids which didn't have meeting_mediafiles to ensure the checker wouldn't scream due to the missing back relations.