### PR TITLE
[rel-db] Complete motion-related tests (Part 1)

### DIFF
--- a/openslides_backend/action/actions/motion_category/number_motions.py
+++ b/openslides_backend/action/actions/motion_category/number_motions.py
@@ -1,5 +1,6 @@
-import time
 from collections import defaultdict
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from ....models.models import Motion, MotionCategory
 from ....permissions.permissions import Permissions
@@ -73,7 +74,7 @@ class MotionCategoryNumberMotions(UpdateAction):
                     "id": motion_id,
                     "number": number,
                     "number_value": number_value,
-                    "last_modified": round(time.time()),
+                    "last_modified": datetime.now(ZoneInfo("UTC")),
                 }
 
     def init_memory(self, main_category_id: int) -> None:

--- a/openslides_backend/action/actions/motion_change_recommendation/create.py
+++ b/openslides_backend/action/actions/motion_change_recommendation/create.py
@@ -1,5 +1,6 @@
-from time import time
+from datetime import datetime
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from ....models.models import MotionChangeRecommendation
 from ....permissions.permissions import Permissions
@@ -56,5 +57,5 @@ class MotionChangeRecommendationCreateAction(
                 f"The recommendation collides with an existing one (line {line_from} - {line_to})."
             )
 
-        instance["creation_time"] = int(time())
+        instance["creation_time"] = datetime.now(ZoneInfo("UTC"))
         return instance

--- a/openslides_backend/action/actions/motion_workflow/delete.py
+++ b/openslides_backend/action/actions/motion_workflow/delete.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any
 
 from ....models.models import MotionWorkflow
 from ....permissions.permissions import Permissions
@@ -43,12 +43,6 @@ class MotionWorkflowDeleteAction(DeleteAction):
             if instance["id"] == meeting.get("motions_default_amendment_workflow_id"):
                 raise ActionException(
                     "You cannot delete the workflow as long as it is selected as default workflow for new amendments in the settings. Please set another workflow as default in the settings and try to delete the workflow again."
-                )
-
-            workflow_ids = cast(list[int], meeting.get("motion_workflow_ids"))
-            if len(workflow_ids) == 1:
-                raise ActionException(
-                    "You cannot delete the last workflow of a meeting."
                 )
 
         return instance

--- a/tests/system/action/motion_block/test_create.py
+++ b/tests/system/action/motion_block/test_create.py
@@ -5,24 +5,16 @@ from tests.system.action.base import BaseActionTestCase
 
 class MotionBlockActionTest(BaseActionTestCase):
     def test_create(self) -> None:
-        self.create_model(
-            "meeting/42",
-            {
-                "name": "test",
-                "agenda_item_creation": "always",
-                "is_active_in_organization_id": 1,
-                "committee_id": 1,
-            },
-        )
+        self.create_meeting(42, {"agenda_item_creation": "always"})
         response = self.request(
             "motion_block.create", {"title": "test_Xcdfgee", "meeting_id": 42}
         )
         self.assert_status_code(response, 200)
-        model = self.get_model("motion_block/1")
-        self.assertEqual(model.get("title"), "test_Xcdfgee")
-        self.assertEqual(model.get("sequential_number"), 1)
         self.assert_model_exists(
-            f"agenda_item/{model['agenda_item_id']}",
+            "motion_block/1", {"title": "test_Xcdfgee", "sequential_number": 1}
+        )
+        self.assert_model_exists(
+            "agenda_item/1",
             {
                 "id": 1,
                 "is_hidden": False,
@@ -32,7 +24,7 @@ class MotionBlockActionTest(BaseActionTestCase):
                 "weight": 1,
                 "meeting_id": 42,
                 "content_object_id": "motion_block/1",
-                "meta_deleted": False,
+                "meta_deleted": None,
             },
         )
         self.assert_model_exists(
@@ -42,8 +34,8 @@ class MotionBlockActionTest(BaseActionTestCase):
     def test_create_empty_data(self) -> None:
         response = self.request("motion_block.create", {})
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must contain ['meeting_id', 'title'] properties",
+        self.assertEqual(
+            "Action motion_block.create: data must contain ['meeting_id', 'title'] properties",
             response.json["message"],
         )
 
@@ -52,33 +44,21 @@ class MotionBlockActionTest(BaseActionTestCase):
             "motion_block.create", {"wrong_field": "text_AefohteiF8"}
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must contain ['meeting_id', 'title'] properties",
+        self.assertEqual(
+            "Action motion_block.create: data must contain ['meeting_id', 'title'] properties",
             response.json["message"],
         )
 
     def test_create_no_permissions(self) -> None:
         self.base_permission_test(
-            {
-                "meeting/1": {
-                    "name": "test",
-                    "agenda_item_creation": "always",
-                    "is_active_in_organization_id": 1,
-                }
-            },
+            {"meeting/1": {"agenda_item_creation": "always"}},
             "motion_block.create",
             {"title": "test_Xcdfgee", "meeting_id": 1},
         )
 
     def test_create_permissions(self) -> None:
         self.base_permission_test(
-            {
-                "meeting/1": {
-                    "name": "test",
-                    "agenda_item_creation": "always",
-                    "is_active_in_organization_id": 1,
-                }
-            },
+            {"meeting/1": {"agenda_item_creation": "always"}},
             "motion_block.create",
             {"title": "test_Xcdfgee", "meeting_id": 1},
             Permissions.Motion.CAN_MANAGE,
@@ -86,13 +66,7 @@ class MotionBlockActionTest(BaseActionTestCase):
 
     def test_create_permissions_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            {
-                "meeting/1": {
-                    "name": "test",
-                    "agenda_item_creation": "always",
-                    "is_active_in_organization_id": 1,
-                }
-            },
+            {"meeting/1": {"agenda_item_creation": "always"}},
             "motion_block.create",
             {"title": "test_Xcdfgee", "meeting_id": 1},
         )

--- a/tests/system/action/motion_block/test_delete.py
+++ b/tests/system/action/motion_block/test_delete.py
@@ -3,61 +3,54 @@ from tests.system.action.base import BaseActionTestCase
 
 
 class MotionBlockActionTest(BaseActionTestCase):
-    def test_delete_correct(self) -> None:
-        self.create_meeting(11)
+    def setUp(self) -> None:
+        super().setUp()
+        self.create_meeting()
         self.set_models(
             {
-                "motion_block/111": {"meeting_id": 11},
+                "motion_block/111": {
+                    "title": "title_srtgb123",
+                    "sequential_number": 111,
+                    "list_of_speakers_id": 222,
+                    "meeting_id": 1,
+                },
+                "list_of_speakers/222": {
+                    "closed": False,
+                    "sequential_number": 15,
+                    "content_object_id": "motion_block/111",
+                    "meeting_id": 1,
+                },
             }
         )
+
+    def test_delete_correct(self) -> None:
         response = self.request("motion_block.delete", {"id": 111})
         self.assert_status_code(response, 200)
         self.assert_model_not_exists("motion_block/111")
 
     def test_delete_wrong_id(self) -> None:
-        self.set_models(
-            {
-                "meeting/11": {"is_active_in_organization_id": 1},
-                "motion_block/112": {"meeting_id": 11},
-            }
-        )
-        response = self.request("motion_block.delete", {"id": 111})
+        response = self.request("motion_block.delete", {"id": 112})
         self.assert_status_code(response, 400)
-        self.assert_model_exists("motion_block/112")
+        self.assertEqual(
+            "Model 'motion_block/112' does not exist.", response.json["message"]
+        )
+        self.assert_model_exists("motion_block/111")
 
     def test_delete_correct_cascading(self) -> None:
         self.set_models(
             {
-                "meeting/12": {
-                    "committee_id": 1,
-                    "is_active_in_organization_id": 1,
-                    "all_projection_ids": [1],
-                },
-                "motion_block/111": {
-                    "list_of_speakers_id": 222,
-                    "agenda_item_id": 333,
-                    "projection_ids": [1],
-                    "meeting_id": 12,
-                },
-                "list_of_speakers/222": {
-                    "closed": False,
-                    "content_object_id": "motion_block/111",
-                    "meeting_id": 12,
-                },
+                "motion_block/111": {"agenda_item_id": 333},
                 "agenda_item/333": {
                     "comment": "test_comment_ewoirzewoirioewr",
                     "content_object_id": "motion_block/111",
-                    "meeting_id": 12,
+                    "meeting_id": 1,
                 },
                 "projection/1": {
                     "content_object_id": "motion_block/111",
                     "current_projector_id": 1,
-                    "meeting_id": 12,
+                    "meeting_id": 1,
                 },
-                "projector/1": {
-                    "current_projection_ids": [1],
-                    "meeting_id": 12,
-                },
+                "projector/1": {"sequential_number": 1, "meeting_id": 1},
             }
         )
         response = self.request("motion_block.delete", {"id": 111})
@@ -66,18 +59,14 @@ class MotionBlockActionTest(BaseActionTestCase):
         self.assert_model_not_exists("agenda_item/333")
         self.assert_model_not_exists("list_of_speakers/222")
         self.assert_model_not_exists("projection/1")
-        self.assert_model_exists("projector/1", {"current_projection_ids": []})
+        self.assert_model_exists("projector/1", {"current_projection_ids": None})
 
     def test_delete_no_permissions(self) -> None:
-        self.base_permission_test(
-            {"motion_block/111": {"meeting_id": 1}},
-            "motion_block.delete",
-            {"id": 111},
-        )
+        self.base_permission_test({}, "motion_block.delete", {"id": 111})
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            {"motion_block/111": {"meeting_id": 1}},
+            {},
             "motion_block.delete",
             {"id": 111},
             Permissions.Motion.CAN_MANAGE,
@@ -85,7 +74,5 @@ class MotionBlockActionTest(BaseActionTestCase):
 
     def test_delete_permissions_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            {"motion_block/111": {"meeting_id": 1}},
-            "motion_block.delete",
-            {"id": 111},
+            {}, "motion_block.delete", {"id": 111}
         )

--- a/tests/system/action/motion_block/test_update.py
+++ b/tests/system/action/motion_block/test_update.py
@@ -3,49 +3,51 @@ from tests.system.action.base import BaseActionTestCase
 
 
 class MotionBlockActionTest(BaseActionTestCase):
-    def test_update_correct(self) -> None:
-        self.create_meeting(11)
+    def setUp(self) -> None:
+        super().setUp()
+        self.create_meeting()
         self.set_models(
             {
-                "motion_block/111": {"title": "title_srtgb123", "meeting_id": 11},
+                "motion_block/111": {
+                    "title": "title_srtgb123",
+                    "sequential_number": 111,
+                    "list_of_speakers_id": 222,
+                    "meeting_id": 1,
+                },
+                "list_of_speakers/222": {
+                    "closed": False,
+                    "sequential_number": 15,
+                    "content_object_id": "motion_block/111",
+                    "meeting_id": 1,
+                },
             }
         )
+
+    def test_update_correct(self) -> None:
         response = self.request(
             "motion_block.update", {"id": 111, "title": "title_Xcdfgee"}
         )
         self.assert_status_code(response, 200)
-        self.assert_model_exists("motion_block/111")
-        model = self.get_model("motion_block/111")
-        assert model.get("title") == "title_Xcdfgee"
+        self.assert_model_exists("motion_block/111", {"title": "title_Xcdfgee"})
 
     def test_update_wrong_id(self) -> None:
-        self.set_models(
-            {
-                "meeting/11": {"is_active_in_organization_id": 1},
-                "motion_block/111": {"title": "title_srtgb123", "meeting_id": 11},
-            }
-        )
         response = self.request(
             "motion_block.update", {"id": 112, "title": "title_Xcdfgee"}
         )
         self.assert_status_code(response, 400)
-        model = self.get_model("motion_block/111")
-        assert model.get("title") == "title_srtgb123"
+        self.assertEqual(
+            "Model 'motion_block/112' does not exist.", response.json["message"]
+        )
+        self.assert_model_exists("motion_block/111", {"title": "title_srtgb123"})
 
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
-            {
-                "motion_block/111": {"meeting_id": 1, "title": "title_srtgb123"},
-            },
-            "motion_block.update",
-            {"id": 111, "title": "title_Xcdfgee"},
+            {}, "motion_block.update", {"id": 111, "title": "title_Xcdfgee"}
         )
 
     def test_update_permissions(self) -> None:
         self.base_permission_test(
-            {
-                "motion_block/111": {"meeting_id": 1, "title": "title_srtgb123"},
-            },
+            {},
             "motion_block.update",
             {"id": 111, "title": "title_Xcdfgee"},
             Permissions.Motion.CAN_MANAGE,
@@ -53,9 +55,5 @@ class MotionBlockActionTest(BaseActionTestCase):
 
     def test_update_permissions_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            {
-                "motion_block/111": {"meeting_id": 1, "title": "title_srtgb123"},
-            },
-            "motion_block.update",
-            {"id": 111, "title": "title_Xcdfgee"},
+            {}, "motion_block.update", {"id": 111, "title": "title_Xcdfgee"}
         )

--- a/tests/system/action/motion_category/test_create.py
+++ b/tests/system/action/motion_category/test_create.py
@@ -10,13 +10,11 @@ class MotionCategorySystemTest(BaseActionTestCase):
     def test_create_good_case_full_fields(self) -> None:
         self.set_models(
             {
-                "meeting/222": {
-                    "motion_category_ids": [123],
-                },
                 "motion_category/123": {
                     "name": "name_bWdKLQxL",
                     "meeting_id": 222,
                     "sequential_number": 1,
+                    "weight": 1,
                 },
             }
         )
@@ -37,7 +35,7 @@ class MotionCategorySystemTest(BaseActionTestCase):
                 "prefix": "prefix_niqCxoXA",
                 "meeting_id": 222,
                 "parent_id": 123,
-                "weight": 1,
+                "weight": 2,
                 "sequential_number": 2,
             },
         )
@@ -46,10 +44,7 @@ class MotionCategorySystemTest(BaseActionTestCase):
     def test_create_good_case_only_required_fields(self) -> None:
         response = self.request(
             "motion_category.create",
-            {
-                "name": "test_Xcdfgee",
-                "meeting_id": 222,
-            },
+            {"name": "test_Xcdfgee", "meeting_id": 222},
         )
         self.assert_status_code(response, 200)
         self.assert_model_exists(
@@ -64,6 +59,7 @@ class MotionCategorySystemTest(BaseActionTestCase):
                     "name": "name_bWdKLQxL",
                     "meeting_id": 222,
                     "weight": 1,
+                    "sequential_number": 1,
                 },
             }
         )
@@ -94,7 +90,7 @@ class MotionCategorySystemTest(BaseActionTestCase):
                 "meeting_id": 222,
                 "parent_id": 123,
                 "weight": 2,
-                "sequential_number": 1,
+                "sequential_number": 2,
             },
         )
         self.assert_model_exists(
@@ -103,7 +99,7 @@ class MotionCategorySystemTest(BaseActionTestCase):
                 "name": "test_Xcdfgee2",
                 "meeting_id": 222,
                 "weight": 3,
-                "sequential_number": 2,
+                "sequential_number": 3,
             },
         )
         self.assert_model_exists(
@@ -113,15 +109,15 @@ class MotionCategorySystemTest(BaseActionTestCase):
                 "meeting_id": 222,
                 "parent_id": 123,
                 "weight": 4,
-                "sequential_number": 3,
+                "sequential_number": 4,
             },
         )
 
     def test_create_empty_data(self) -> None:
         response = self.request("motion_category.create", {})
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must contain ['meeting_id', 'name'] properties",
+        self.assertEqual(
+            "Action motion_category.create: data must contain ['meeting_id', 'name'] properties",
             response.json["message"],
         )
 
@@ -135,8 +131,8 @@ class MotionCategorySystemTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must not contain {'wrong_field'} properties",
+        self.assertEqual(
+            "Action motion_category.create: data must not contain {'wrong_field'} properties",
             response.json["message"],
         )
 
@@ -149,78 +145,56 @@ class MotionCategorySystemTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "Model 'meeting/223' does not exist",
-            response.json["message"],
+        self.assertEqual(
+            "Model 'meeting/223' does not exist.", response.json["message"]
         )
 
     def test_create_prefix_none(self) -> None:
         response = self.request(
             "motion_category.create",
-            {
-                "name": "test_Xcdfgee",
-                "meeting_id": 222,
-                "prefix": None,
-            },
+            {"name": "test_Xcdfgee", "meeting_id": 222, "prefix": None},
         )
         self.assert_status_code(response, 200)
-        model = self.assert_model_exists("motion_category/1", {"name": "test_Xcdfgee"})
-        assert "prefix" not in model
+        self.assert_model_exists(
+            "motion_category/1",
+            {"name": "test_Xcdfgee", "prefix": None, "sequential_number": 1},
+        )
 
     def test_create_not_unique_prefix(self) -> None:
         self.set_models(
             {
-                "meeting/222": {
-                    "motion_category_ids": [1],
-                },
-                "motion_category/1": {"meeting_id": 222, "prefix": "test"},
+                "motion_category/1": {
+                    "name": "name_bWdKLQxL",
+                    "meeting_id": 222,
+                    "prefix": "test",
+                    "sequential_number": 1,
+                }
             }
         )
         response = self.request(
             "motion_category.create",
-            {
-                "name": "test_Xcdfgee",
-                "meeting_id": 222,
-                "prefix": "test",
-            },
+            {"name": "test_Xcdfgee", "meeting_id": 222, "prefix": "test"},
         )
         self.assert_status_code(response, 200)
         self.assert_model_exists(
             "motion_category/2",
-            {
-                "name": "test_Xcdfgee",
-                "meeting_id": 222,
-                "prefix": "test",
-            },
+            {"name": "test_Xcdfgee", "meeting_id": 222, "prefix": "test"},
         )
 
     def test_create_no_permissions(self) -> None:
         self.base_permission_test(
-            {},
-            "motion_category.create",
-            {
-                "name": "test_Xcdfgee",
-                "meeting_id": 1,
-            },
+            {}, "motion_category.create", {"name": "test_Xcdfgee", "meeting_id": 1}
         )
 
     def test_create_permissions(self) -> None:
         self.base_permission_test(
             {},
             "motion_category.create",
-            {
-                "name": "test_Xcdfgee",
-                "meeting_id": 1,
-            },
+            {"name": "test_Xcdfgee", "meeting_id": 1},
             Permissions.Motion.CAN_MANAGE,
         )
 
     def test_create_permissions_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            {},
-            "motion_category.create",
-            {
-                "name": "test_Xcdfgee",
-                "meeting_id": 1,
-            },
+            {}, "motion_category.create", {"name": "test_Xcdfgee", "meeting_id": 1}
         )

--- a/tests/system/action/motion_category/test_delete.py
+++ b/tests/system/action/motion_category/test_delete.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -7,66 +5,47 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCategorySystemTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models: dict[str, dict[str, Any]] = {
-            "motion_category/111": {"name": "name_srtgb123", "meeting_id": 1}
-        }
-
-    def test_delete_correct(self) -> None:
-        self.create_meeting(222)
+        self.create_meeting()
         self.set_models(
             {
-                "motion_category/111": {"name": "name_srtgb123", "meeting_id": 222},
+                "motion_category/111": {
+                    "name": "name_srtgb123",
+                    "meeting_id": 1,
+                    "sequential_number": 111,
+                },
             }
         )
+
+    def test_delete_correct(self) -> None:
         response = self.request("motion_category.delete", {"id": 111})
         self.assert_status_code(response, 200)
         self.assert_model_not_exists("motion_category/111")
 
     def test_delete_wrong_id(self) -> None:
-        self.create_model("motion_category/112", {"name": "name_srtgb123"})
-        response = self.request("motion_category.delete", {"id": 111})
+        response = self.request("motion_category.delete", {"id": 112})
         self.assert_status_code(response, 400)
-        self.assert_model_exists("motion_category/112")
+        self.assertEqual(
+            "Model 'motion_category/112' does not exist.", response.json["message"]
+        )
+        self.assert_model_exists("motion_category/111")
 
     def test_delete_handle_remove_relation(self) -> None:
-        self.create_meeting(222)
-        self.set_models(
-            {
-                "meeting/222": {
-                    "motion_category_ids": [111],
-                },
-                "motion/89": {"meeting_id": 222, "category_id": 111},
-                "motion_category/111": {
-                    "name": "name_srtgb123",
-                    "prefix": "prefix_JmDHFgvH",
-                    "meeting_id": 222,
-                    "motion_ids": [89],
-                },
-            }
-        )
+        self.create_motion(1, 89)
+        self.set_models({"motion/89": {"category_id": 111}})
 
         self.request("motion_category.delete", {"id": 111})
-        motion = self.get_model("motion/89")
-        assert motion.get("category_id") is None
-        meeting = self.get_model("meeting/222")
-        assert meeting.get("motion_category_ids") == []
+        self.assert_model_exists("motion/89", {"category_id": None})
+        self.assert_model_exists("meeting/1", {"motion_category_ids": None})
 
     def test_delete_no_permissions(self) -> None:
-        self.base_permission_test(
-            self.permission_test_models, "motion_category.delete", {"id": 111}
-        )
+        self.base_permission_test({}, "motion_category.delete", {"id": 111})
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
-            "motion_category.delete",
-            {"id": 111},
-            Permissions.Motion.CAN_MANAGE,
+            {}, "motion_category.delete", {"id": 111}, Permissions.Motion.CAN_MANAGE
         )
 
     def test_delete_permissions_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            self.permission_test_models,
-            "motion_category.delete",
-            {"id": 111},
+            {}, "motion_category.delete", {"id": 111}
         )

--- a/tests/system/action/motion_category/test_number_motions.py
+++ b/tests/system/action/motion_category/test_number_motions.py
@@ -1,5 +1,6 @@
-import time
+from datetime import datetime
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
@@ -8,452 +9,399 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCategoryNumberMotionsTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
+        self.create_meeting()
         self.permission_test_models: dict[str, dict[str, Any]] = {
-            "committee/1": {"meeting_ids": [1]},
-            "meeting/1": {
-                "name": "meeting_1",
-                "motion_category_ids": [111],
-                "motion_ids": [69],
-                "is_active_in_organization_id": 1,
-                "committee_id": 1,
-            },
             "motion_category/111": {
                 "name": "name_MKKAcYQu",
                 "prefix": "prefix_A",
-                "motion_ids": [69],
                 "meeting_id": 1,
+                "sequential_number": 111,
             },
             "motion/69": {
                 "title": "title_NAZOknoM",
                 "category_id": 111,
                 "meeting_id": 1,
+                "state_id": 1,
+                "sequential_number": 69,
             },
         }
 
     def test_good_single_motion(self) -> None:
-        check_time = round(time.time())
+        check_time = datetime.now(ZoneInfo("UTC"))
         self.set_models(self.permission_test_models)
-        response = self.request(
-            "motion_category.number_motions",
-            {
-                "id": 111,
-            },
-        )
+
+        response = self.request("motion_category.number_motions", {"id": 111})
         self.assert_status_code(response, 200)
-        motion_69 = self.get_model("motion/69")
-        assert motion_69.get("number") == "prefix_A1"
-        assert motion_69.get("last_modified", 0) >= check_time
+        model = self.assert_model_exists("motion/69", {"number": "prefix_A01"})
+        assert (
+            model.get("last_modified", datetime.fromtimestamp(0, ZoneInfo("UTC")))
+            >= check_time
+        )
         self.assert_history_information("motion/69", ["Number set"])
 
     def test_two_motions(self) -> None:
-        self.create_meeting(35)
         self.set_models(
             {
-                "meeting/35": {
+                "meeting/1": {
                     "motions_number_with_blank": True,
                     "motions_number_min_digits": 3,
-                    "motion_ids": [78, 85],
-                    "motion_category_ids": [111, 78, 114],
                 },
                 "motion/78": {
                     "title": "title_NAZOknoM",
                     "category_id": 78,
-                    "meeting_id": 35,
+                    "meeting_id": 1,
+                    "state_id": 1,
+                    "sequential_number": 78,
                 },
                 "motion/85": {
                     "title": "title_MyMayxxr",
                     "category_id": 78,
-                    "meeting_id": 35,
+                    "meeting_id": 1,
+                    "state_id": 1,
+                    "sequential_number": 85,
                 },
                 "motion_category/111": {
                     "name": "name_MKKAcYQu",
-                    "child_ids": [78, 114],
                     "prefix": "prefix_A",
-                    "meeting_id": 35,
+                    "meeting_id": 1,
+                    "sequential_number": 111,
                 },
                 "motion_category/78": {
                     "name": "name_xSBwbHAT",
                     "parent_id": 111,
-                    "motion_ids": [78, 85],
-                    "meeting_id": 35,
+                    "meeting_id": 1,
+                    "sequential_number": 78,
                 },
                 "motion_category/114": {
                     "name": "name_pIObKJwT",
                     "parent_id": 111,
                     "prefix": "prefix_C",
-                    "meeting_id": 35,
+                    "meeting_id": 1,
+                    "sequential_number": 114,
                 },
             }
         )
-        response = self.request(
-            "motion_category.number_motions",
-            {
-                "id": 111,
-            },
-        )
+        response = self.request("motion_category.number_motions", {"id": 111})
         self.assert_status_code(response, 200)
-        motion_78 = self.get_model("motion/78")
-        assert motion_78.get("number") == "prefix_A 001"
-        motion_85 = self.get_model("motion/85")
-        assert motion_85.get("number") == "prefix_A 002"
+        self.assert_model_exists("motion/78", {"number": "prefix_A 001"})
+        self.assert_model_exists("motion/85", {"number": "prefix_A 002"})
 
     def test_check_amendments_error_case(self) -> None:
-        self.create_meeting()
         self.set_models(
             {
-                "meeting/1": {
-                    "motion_ids": [78, 85, 666],
-                    "motion_category_ids": [111, 78, 114],
+                "motion/78": {
+                    "title": "title_NAZOknoM",
+                    "meeting_id": 1,
+                    "state_id": 1,
+                    "category_id": 78,
+                    "sequential_number": 78,
                 },
-                "motion/78": {"title": "title_NAZOknoM", "meeting_id": 1},
+                "motion/666": {
+                    "title": "title_XtzUEFdl",
+                    "meeting_id": 1,
+                    "state_id": 1,
+                    "sequential_number": 666,
+                },
                 "motion/85": {
                     "title": "title_MyMayxxr",
                     "lead_motion_id": 666,
                     "meeting_id": 1,
+                    "state_id": 1,
+                    "category_id": 78,
+                    "sequential_number": 85,
                 },
-                "motion/666": {"title": "title_XtzUEFdl", "meeting_id": 1},
                 "motion_category/111": {
                     "name": "name_MKKAcYQu",
-                    "child_ids": [78, 114],
                     "meeting_id": 1,
+                    "sequential_number": 111,
                 },
                 "motion_category/78": {
                     "name": "name_xSBwbHAT",
                     "parent_id": 111,
-                    "motion_ids": [78, 85],
                     "meeting_id": 1,
+                    "sequential_number": 78,
                 },
                 "motion_category/114": {
                     "name": "name_pIObKJwT",
                     "parent_id": 111,
                     "meeting_id": 1,
+                    "sequential_number": 114,
                 },
             }
         )
-        response = self.request(
-            "motion_category.number_motions",
-            {
-                "id": 111,
-            },
-        )
+        response = self.request("motion_category.number_motions", {"id": 111})
         self.assert_status_code(response, 400)
-        self.assertIn(
+        self.assertEqual(
             'Amendment "85" cannot be numbered, because it\'s lead motion (666) is not in category 111 or any subcategory.',
             response.json["message"],
         )
 
     def test_3_categories_5_motions_some_with_lead_motion_ids(self) -> None:
-        self.create_meeting()
         self.set_models(
             {
                 "meeting/1": {
                     "motions_number_with_blank": True,
                     "motions_number_min_digits": 3,
                     "motions_amendments_prefix": "X",
-                    "motion_category_ids": [1, 2, 3],
-                    "motion_ids": [1, 2, 3, 4, 5],
                 },
                 "motion_category/1": {
                     "name": "name_category_1",
-                    "child_ids": [2, 3],
-                    "parent_id": None,
                     "meeting_id": 1,
+                    "sequential_number": 1,
                 },
                 "motion_category/2": {
                     "name": "name_category_2",
-                    "child_ids": [],
                     "parent_id": 1,
                     "prefix": "A",
                     "meeting_id": 1,
-                    "motion_ids": [1, 2],
+                    "sequential_number": 2,
                 },
                 "motion_category/3": {
                     "name": "name_category_3",
-                    "child_ids": [],
                     "parent_id": 1,
                     "prefix": "B",
                     "meeting_id": 1,
-                    "motion_ids": [3, 4, 5],
+                    "sequential_number": 13,
                 },
                 "motion/1": {
                     "title": "title_motion_1",
                     "category_id": 2,
                     "meeting_id": 1,
+                    "state_id": 1,
+                    "sequential_number": 1,
                 },
                 "motion/2": {
                     "title": "title_motion_2",
                     "category_id": 2,
                     "meeting_id": 1,
+                    "state_id": 1,
+                    "sequential_number": 2,
                 },
                 "motion/3": {
                     "title": "title_motion_3",
                     "category_id": 3,
                     "meeting_id": 1,
+                    "state_id": 1,
+                    "sequential_number": 3,
                 },
                 "motion/4": {
                     "title": "title_motion_4",
                     "category_id": 3,
                     "meeting_id": 1,
                     "lead_motion_id": 3,
+                    "state_id": 1,
+                    "sequential_number": 4,
                 },
                 "motion/5": {
                     "title": "title_motion_5",
                     "category_id": 3,
                     "meeting_id": 1,
                     "lead_motion_id": 3,
+                    "state_id": 1,
+                    "sequential_number": 5,
                 },
             }
         )
 
-        response = self.request(
-            "motion_category.number_motions",
-            {
-                "id": 1,
-            },
-        )
+        response = self.request("motion_category.number_motions", {"id": 1})
         self.assert_status_code(response, 200)
 
-        self.check_helper("motion/1", "A 001")
-        self.check_helper("motion/2", "A 002")
-        self.check_helper("motion/3", "B 003")
-        self.check_helper("motion/4", "B 003 X 001")
-        self.check_helper("motion/5", "B 003 X 002")
+        self.assert_model_exists("motion/1", {"number": "A 001"})
+        self.assert_model_exists("motion/2", {"number": "A 002"})
+        self.assert_model_exists("motion/3", {"number": "B 003"})
+        self.assert_model_exists("motion/4", {"number": "B 003 X 001"})
+        self.assert_model_exists("motion/5", {"number": "B 003 X 002"})
 
     def test_already_existing_number(self) -> None:
-        self.create_meeting()
+        self.set_models(self.permission_test_models)
         self.set_models(
             {
-                "meeting/1": {
-                    "motion_category_ids": [111],
-                    "motion_ids": [69, 70],
-                },
-                "motion_category/111": {
-                    "name": "name_MKKAcYQu",
-                    "prefix": "prefix_A",
-                    "motion_ids": [69],
-                    "meeting_id": 1,
-                },
-                "motion/69": {
-                    "title": "title_NAZOknoM",
-                    "category_id": 111,
-                    "meeting_id": 1,
-                },
                 "motion/70": {
                     "title": "title_NAZOknoM",
                     "meeting_id": 1,
-                    "number": "prefix_A1",
+                    "number": "prefix_A01",
+                    "state_id": 1,
+                    "sequential_number": 70,
                 },
             }
         )
-        response = self.request(
-            "motion_category.number_motions",
-            {
-                "id": 111,
-            },
-        )
+        response = self.request("motion_category.number_motions", {"id": 111})
         self.assert_status_code(response, 400)
-        self.assertIn(
-            'Numbering aborted because the motion identifier "prefix_A1" already exists.',
+        self.assertEqual(
+            'Numbering aborted because the motion identifier "prefix_A01" already exists.',
             response.json["message"],
         )
 
     def test_sort_categories(self) -> None:
-        self.create_meeting()
         self.set_models(
             {
-                "meeting/1": {
-                    "motion_category_ids": [1, 2, 3, 4],
-                    "motion_ids": [1, 2, 3],
-                },
                 "motion_category/1": {
                     "name": "category_1",
                     "meeting_id": 1,
-                    "parent_id": None,
-                    "child_ids": [2, 3, 4],
+                    "sequential_number": 1,
                 },
                 "motion_category/2": {
                     "name": "category_2",
                     "meeting_id": 1,
                     "parent_id": 1,
-                    "child_ids": [],
                     "prefix": "C",
                     "weight": 100,
-                    "motion_ids": [1],
+                    "sequential_number": 2,
                 },
                 "motion_category/3": {
                     "name": "category_3",
                     "meeting_id": 1,
                     "parent_id": 1,
-                    "child_ids": [],
                     "prefix": "A",
                     "weight": 1,
-                    "motion_ids": [2],
+                    "sequential_number": 3,
                 },
                 "motion_category/4": {
                     "name": "category_4",
                     "meeting_id": 1,
                     "parent_id": 1,
-                    "child_ids": [],
                     "prefix": "B",
                     "weight": 10,
-                    "motion_ids": [3],
+                    "sequential_number": 4,
                 },
-                "motion/1": {"title": "m1", "category_id": 2, "meeting_id": 1},
-                "motion/2": {"title": "m2", "category_id": 3, "meeting_id": 1},
-                "motion/3": {"title": "m3", "category_id": 4, "meeting_id": 1},
+                "motion/1": {
+                    "title": "m1",
+                    "category_id": 2,
+                    "meeting_id": 1,
+                    "state_id": 1,
+                    "category_weight": 100,
+                    "sequential_number": 1,
+                },
+                "motion/2": {
+                    "title": "m2",
+                    "category_id": 3,
+                    "meeting_id": 1,
+                    "state_id": 1,
+                    "category_weight": 10,
+                    "sequential_number": 2,
+                },
+                "motion/3": {
+                    "title": "m3",
+                    "category_id": 4,
+                    "meeting_id": 1,
+                    "state_id": 1,
+                    "category_weight": 1,
+                    "sequential_number": 3,
+                },
             }
         )
-        response = self.request(
-            "motion_category.number_motions",
-            {
-                "id": 1,
-            },
-        )
+        response = self.request("motion_category.number_motions", {"id": 1})
         self.assert_status_code(response, 200)
 
-        self.check_helper("motion/1", "C3")
-        self.check_helper("motion/2", "A1")
-        self.check_helper("motion/3", "B2")
-
-    def check_helper(self, model_str: str, excepted_number: str) -> None:
-        motion = self.get_model(model_str)
-        assert motion.get("number") == excepted_number
+        self.assert_model_exists("motion/1", {"number": "C03"})
+        self.assert_model_exists("motion/2", {"number": "A01"})
+        self.assert_model_exists("motion/3", {"number": "B02"})
 
     def test_sort_motions(self) -> None:
-        self.create_meeting()
         self.set_models(
             {
-                "meeting/1": {
-                    "motion_category_ids": [1],
-                    "motion_ids": [1, 2, 3],
-                },
                 "motion_category/1": {
                     "name": "category_1",
                     "meeting_id": 1,
-                    "parent_id": None,
-                    "child_ids": [],
-                    "motion_ids": [1, 2, 3],
+                    "sequential_number": 1,
                 },
                 "motion/1": {
                     "title": "m1",
                     "category_id": 1,
                     "meeting_id": 1,
+                    "state_id": 1,
                     "category_weight": 100,
+                    "sequential_number": 1,
                 },
                 "motion/2": {
                     "title": "m2",
                     "category_id": 1,
                     "meeting_id": 1,
+                    "state_id": 1,
                     "category_weight": 10,
+                    "sequential_number": 2,
                 },
                 "motion/3": {
                     "title": "m3",
                     "category_id": 1,
                     "meeting_id": 1,
+                    "state_id": 1,
                     "category_weight": 1,
+                    "sequential_number": 3,
                 },
             }
         )
-        response = self.request(
-            "motion_category.number_motions",
-            {
-                "id": 1,
-            },
-        )
+        response = self.request("motion_category.number_motions", {"id": 1})
         self.assert_status_code(response, 200)
-        self.check_helper("motion/1", "3")
-        self.check_helper("motion/2", "2")
-        self.check_helper("motion/3", "1")
+        self.assert_model_exists("motion/1", {"number": "03"})
+        self.assert_model_exists("motion/2", {"number": "02"})
+        self.assert_model_exists("motion/3", {"number": "01"})
 
     def test_stop_prefix_lookup_at_main_category(self) -> None:
-        self.create_meeting()
         self.set_models(
             {
-                "meeting/1": {
-                    "motion_category_ids": [1, 2],
-                    "motion_ids": [1],
-                },
                 "motion_category/1": {
                     "name": "category_1",
                     "meeting_id": 1,
-                    "parent_id": None,
-                    "child_ids": [2],
-                    "motion_ids": [],
                     "prefix": "A",
+                    "sequential_number": 1,
                 },
                 "motion_category/2": {
                     "name": "category_2",
                     "meeting_id": 1,
                     "parent_id": 1,
-                    "child_ids": [],
-                    "motion_ids": [1],
+                    "sequential_number": 2,
                 },
                 "motion/1": {
                     "title": "m1",
                     "category_id": 2,
                     "meeting_id": 1,
+                    "state_id": 1,
                     "category_weight": 100,
+                    "sequential_number": 1,
                 },
             }
         )
 
-        response = self.request(
-            "motion_category.number_motions",
-            {
-                "id": 2,
-            },
-        )
+        response = self.request("motion_category.number_motions", {"id": 2})
         self.assert_status_code(response, 200)
-        self.check_helper("motion/1", "1")
+        self.assert_model_exists("motion/1", {"number": "01"})
 
     def test_invalid_id(self) -> None:
-        self.create_meeting()
         self.set_models(
             {
-                "meeting/1": {
-                    "motion_category_ids": [1, 2],
-                    "motion_ids": [1],
-                },
                 "motion_category/1": {
                     "name": "category_1",
                     "meeting_id": 1,
-                    "parent_id": None,
-                    "child_ids": [2],
-                    "motion_ids": [],
                     "prefix": "A",
+                    "sequential_number": 1,
                 },
                 "motion_category/2": {
                     "name": "category_2",
                     "meeting_id": 1,
                     "parent_id": 1,
-                    "child_ids": [],
-                    "motion_ids": [1],
+                    "sequential_number": 2,
                 },
                 "motion/1": {
                     "title": "m1",
                     "category_id": 2,
                     "meeting_id": 1,
+                    "state_id": 1,
                     "category_weight": 100,
+                    "sequential_number": 1,
                 },
             }
         )
 
-        response = self.request(
-            "motion_category.number_motions",
-            {
-                "id": 222,
-            },
-        )
+        response = self.request("motion_category.number_motions", {"id": 222})
         self.assert_status_code(response, 400)
-        assert "Model 'motion_category/222' does not exist." in response.json.get(
-            "message", ""
+        self.assertEqual(
+            "Model 'motion_category/222' does not exist.", response.json["message"]
         )
 
     def test_number_motions_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
-            "motion_category.number_motions",
-            {"id": 111},
+            self.permission_test_models, "motion_category.number_motions", {"id": 111}
         )
 
     def test_number_motions_permissions(self) -> None:
@@ -466,7 +414,5 @@ class MotionCategoryNumberMotionsTest(BaseActionTestCase):
 
     def test_number_motions_permissions_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            self.permission_test_models,
-            "motion_category.number_motions",
-            {"id": 111},
+            self.permission_test_models, "motion_category.number_motions", {"id": 111}
         )

--- a/tests/system/action/motion_category/test_sort.py
+++ b/tests/system/action/motion_category/test_sort.py
@@ -9,50 +9,51 @@ class MotionCategorySortActionTest(BaseActionTestCase):
         super().setUp()
         self.create_meeting(222)
         self.permission_test_models: dict[str, dict[str, Any]] = {
-            "motion_category/22": {"meeting_id": 1},
+            "motion_category/22": {
+                "name": "category 22",
+                "meeting_id": 1,
+                "sequential_number": 22,
+            },
         }
 
-    def test_sort_singe_node_correct(self) -> None:
+    def create_motion_category(self, base: int) -> None:
         self.set_models(
             {
-                "motion_category/22": {"meeting_id": 222},
+                f"motion_category/{base}": {
+                    "name": f"category {base}",
+                    "meeting_id": 222,
+                    "sequential_number": base,
+                }
             }
         )
+
+    def test_sort_singe_node_correct(self) -> None:
+        self.create_motion_category(22)
         response = self.request(
             "motion_category.sort", {"meeting_id": 222, "tree": [{"id": 22}]}
         )
         self.assert_status_code(response, 200)
-        assert "Actions handled successfully" in response.json["message"]
-        model_22 = self.get_model("motion_category/22")
-        assert model_22.get("weight") == 1
-        assert model_22.get("parent_id") is None
-        assert model_22.get("child_ids") == []
-        assert model_22.get("level") == 0
+        self.assert_model_exists(
+            "motion_category/22",
+            {"weight": 1, "parent_id": None, "child_ids": None, "level": 0},
+        )
 
     def test_sort_not_all_sorted(self) -> None:
-        self.set_models(
-            {
-                "motion_category/22": {"meeting_id": 222},
-                "motion_category/23": {"meeting_id": 222},
-            }
-        )
+        self.create_motion_category(22)
+        self.create_motion_category(23)
         response = self.request(
             "motion_category.sort", {"meeting_id": 222, "tree": [{"id": 22}]}
         )
         self.assert_status_code(response, 400)
-        assert "Did not recieve 2 ids, got 1" in response.json["message"]
+        self.assertEqual("Did not recieve 2 ids, got 1.", response.json["message"])
 
     def test_sort_complex_correct(self) -> None:
-        self.set_models(
-            {
-                "motion_category/1": {"meeting_id": 222},
-                "motion_category/11": {"meeting_id": 222},
-                "motion_category/12": {"meeting_id": 222},
-                "motion_category/21": {"meeting_id": 222},
-                "motion_category/22": {"meeting_id": 222},
-                "motion_category/23": {"meeting_id": 222},
-            }
-        )
+        self.create_motion_category(1)
+        self.create_motion_category(11)
+        self.create_motion_category(12)
+        self.create_motion_category(21)
+        self.create_motion_category(22)
+        self.create_motion_category(23)
 
         valid_data = {
             "meeting_id": 222,
@@ -77,13 +78,9 @@ class MotionCategorySortActionTest(BaseActionTestCase):
         self.assert_model_exists("motion_category/23", {"level": 2, "weight": 2})
 
     def test_sort_not_a_tree(self) -> None:
-        self.set_models(
-            {
-                "motion_category/1": {"meeting_id": 222},
-                "motion_category/11": {"meeting_id": 222},
-                "motion_category/12": {"meeting_id": 222},
-            }
-        )
+        self.create_motion_category(1)
+        self.create_motion_category(11)
+        self.create_motion_category(12)
 
         not_tree_data = {
             "meeting_id": 222,
@@ -96,16 +93,12 @@ class MotionCategorySortActionTest(BaseActionTestCase):
         }
         response = self.request("motion_category.sort", not_tree_data)
         self.assert_status_code(response, 400)
-        assert "Duplicate id in sort tree: 12" in response.json["message"]
+        self.assertEqual("Duplicate id in sort tree: 12", response.json["message"])
 
     def test_sort_circle_fail(self) -> None:
-        self.set_models(
-            {
-                "motion_category/1": {"meeting_id": 222},
-                "motion_category/11": {"meeting_id": 222},
-                "motion_category/12": {"meeting_id": 222},
-            }
-        )
+        self.create_motion_category(1)
+        self.create_motion_category(11)
+        self.create_motion_category(12)
 
         circle_data = {
             "meeting_id": 222,
@@ -120,16 +113,12 @@ class MotionCategorySortActionTest(BaseActionTestCase):
         }
         response = self.request("motion_category.sort", circle_data)
         self.assert_status_code(response, 400)
-        assert "Duplicate id in sort tree: 1" in response.json["message"]
+        self.assertEqual("Duplicate id in sort tree: 1", response.json["message"])
 
     def test_small_tree_correct(self) -> None:
-        self.set_models(
-            {
-                "motion_category/1": {"meeting_id": 222},
-                "motion_category/11": {"meeting_id": 222},
-                "motion_category/12": {"meeting_id": 222},
-            }
-        )
+        self.create_motion_category(1)
+        self.create_motion_category(11)
+        self.create_motion_category(12)
 
         small_tree_data = {
             "meeting_id": 222,
@@ -137,46 +126,30 @@ class MotionCategorySortActionTest(BaseActionTestCase):
         }
         response = self.request("motion_category.sort", small_tree_data)
         self.assert_status_code(response, 200)
-        model_1 = self.get_model("motion_category/1")
-        assert model_1.get("weight") == 1
-        assert model_1.get("parent_id") is None
-        assert model_1.get("child_ids") == [11, 12]
-        assert model_1.get("level") == 0
-        model_11 = self.get_model("motion_category/11")
-        assert model_11.get("weight") == 1
-        assert model_11.get("parent_id") == 1
-        assert model_11.get("child_ids") == []
-        assert model_11.get("level") == 1
-        model_12 = self.get_model("motion_category/12")
-        assert model_12.get("weight") == 2
-        assert model_12.get("parent_id") == 1
-        assert model_12.get("child_ids") == []
-        assert model_12.get("level") == 1
+        self.assert_model_exists(
+            "motion_category/1",
+            {"weight": 1, "parent_id": None, "child_ids": [11, 12], "level": 0},
+        )
+        self.assert_model_exists(
+            "motion_category/11",
+            {"weight": 1, "parent_id": 1, "child_ids": None, "level": 1},
+        )
+        self.assert_model_exists(
+            "motion_category/12",
+            {"weight": 2, "parent_id": 1, "child_ids": None, "level": 1},
+        )
 
     def test_with_deleted_model(self) -> None:
-        self.set_models(
-            {
-                "meeting/222": {"motion_category_ids": [2, 3]},
-            }
-        )
-        self.create_model("motion_category/1", {"meeting_id": 222}, deleted=True)
-        self.set_models(
-            {
-                "motion_category/2": {"meeting_id": 222},
-                "motion_category/3": {"meeting_id": 222},
-            }
-        )
+        self.create_motion_category(2)
+        self.create_motion_category(3)
+
         response = self.request(
             "motion_category.sort", {"meeting_id": 222, "tree": [{"id": 2}, {"id": 3}]}
         )
         self.assert_status_code(response, 200)
-        assert "Actions handled successfully" in response.json["message"]
-        category_1 = self.get_model("motion_category/1")
-        assert category_1.get("weight") is None
-        category_2 = self.get_model("motion_category/2")
-        assert category_2.get("weight") == 1
-        category_3 = self.get_model("motion_category/3")
-        assert category_3.get("weight") == 2
+        self.assert_model_not_exists("motion_category/1")
+        self.assert_model_exists("motion_category/2", {"weight": 1})
+        self.assert_model_exists("motion_category/3", {"weight": 2})
 
     def test_sort_no_permission(self) -> None:
         self.base_permission_test(

--- a/tests/system/action/motion_category/test_sort_motions_in_categories.py
+++ b/tests/system/action/motion_category/test_sort_motions_in_categories.py
@@ -7,62 +7,63 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCategorySortMotionsInCategoriesActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
+        self.create_meeting()
         self.permission_test_models: dict[str, dict[str, Any]] = {
             "motion_category/222": {
+                "name": "category 222",
                 "meeting_id": 1,
+                "sequential_number": 222,
             },
-            "motion/31": {"category_id": 222, "meeting_id": 1},
-            "motion/32": {"category_id": 222, "meeting_id": 1},
+            "motion/31": {
+                "title": "motion 31",
+                "category_id": 222,
+                "meeting_id": 1,
+                "state_id": 1,
+                "sequential_number": 31,
+            },
+            "motion/32": {
+                "title": "motion 32",
+                "category_id": 222,
+                "meeting_id": 1,
+                "state_id": 1,
+                "sequential_number": 32,
+            },
         }
 
     def test_sort_correct_1(self) -> None:
-        self.create_meeting()
-        self.set_models(
-            {
-                "meeting/1": {
-                    "motion_ids": [31, 32],
-                },
-                "motion_category/222": {"meeting_id": 1},
-                "motion/31": {"category_id": 222, "meeting_id": 1},
-                "motion/32": {"category_id": 222, "meeting_id": 1},
-            }
-        )
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion_category.sort_motions_in_category",
             {"id": 222, "motion_ids": [32, 31]},
         )
         self.assert_status_code(response, 200)
-        model_31 = self.get_model("motion/31")
-        assert model_31.get("category_weight") == 2
-        model_32 = self.get_model("motion/32")
-        assert model_32.get("category_weight") == 1
+        self.assert_model_exists("motion/31", {"category_weight": 2})
+        self.assert_model_exists("motion/32", {"category_weight": 1})
 
     def test_sort_missing_model(self) -> None:
-        self.create_meeting()
-        self.set_models(
-            {
-                "motion_category/222": {"meeting_id": 1},
-                "motion/31": {"category_id": 222, "meeting_id": 1},
-            }
-        )
+        self.permission_test_models.pop("motion/32")
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion_category.sort_motions_in_category",
             {"id": 222, "motion_ids": [32, 31]},
         )
         self.assert_status_code(response, 400)
-        assert (
-            "motion sorting failed, because element motion/32 doesn't exist."
-            in response.json["message"]
+        self.assertEqual(
+            "motion sorting failed, because element motion/32 doesn't exist.",
+            response.json["message"],
         )
 
     def test_sort_another_section_db(self) -> None:
-        self.create_meeting()
+        self.set_models(self.permission_test_models)
         self.set_models(
             {
-                "motion_category/222": {"meeting_id": 1},
-                "motion/31": {"category_id": 222, "meeting_id": 1},
-                "motion/32": {"category_id": 222, "meeting_id": 1},
-                "motion/33": {"category_id": 222, "meeting_id": 1},
+                "motion/33": {
+                    "title": "motion 33",
+                    "category_id": 222,
+                    "meeting_id": 1,
+                    "state_id": 1,
+                    "sequential_number": 33,
+                }
             }
         )
         response = self.request(
@@ -70,9 +71,9 @@ class MotionCategorySortMotionsInCategoriesActionTest(BaseActionTestCase):
             {"id": 222, "motion_ids": [32, 31]},
         )
         self.assert_status_code(response, 400)
-        assert (
-            "motion sorting failed, because some elements were not included in the call."
-            in response.json["message"]
+        self.assertEqual(
+            "motion sorting failed, because some elements were not included in the call.",
+            response.json["message"],
         )
 
     def test_sort_no_permission(self) -> None:

--- a/tests/system/action/motion_category/test_update.py
+++ b/tests/system/action/motion_category/test_update.py
@@ -7,27 +7,24 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCategorySystemTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.create_meeting(222)
+        self.create_meeting()
         self.permission_test_models: dict[str, dict[str, Any]] = {
-            "motion/89": {"meeting_id": 1},
+            "motion/89": {
+                "title": "motion 89",
+                "meeting_id": 1,
+                "state_id": 1,
+                "sequential_number": 89,
+            },
             "motion_category/111": {
                 "name": "name_srtgb123",
                 "prefix": "prefix_JmDHFgvH",
                 "meeting_id": 1,
+                "sequential_number": 111,
             },
         }
 
     def test_update_correct_all_fields(self) -> None:
-        self.set_models(
-            {
-                "motion/89": {"meeting_id": 222},
-                "motion_category/111": {
-                    "name": "name_srtgb123",
-                    "prefix": "prefix_JmDHFgvH",
-                    "meeting_id": 222,
-                },
-            }
-        )
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion_category.update",
             {
@@ -38,12 +35,10 @@ class MotionCategorySystemTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 200)
-
-        self.assert_model_exists("motion_category/111")
-        model = self.get_model("motion_category/111")
-        assert model.get("name") == "name_Xcdfgee"
-        assert model.get("prefix") == "prefix_sthyAKrW"
-        assert model.get("motion_ids") == [89]
+        self.assert_model_exists(
+            "motion_category/111",
+            {"name": "name_Xcdfgee", "prefix": "prefix_sthyAKrW", "motion_ids": [89]},
+        )
 
     def test_update_delete_prefix(self) -> None:
         self.set_models(
@@ -51,20 +46,14 @@ class MotionCategorySystemTest(BaseActionTestCase):
                 "motion_category/111": {
                     "name": "name_srtgb123",
                     "prefix": "prefix_JmDHFgvH",
-                    "meeting_id": 222,
-                },
+                    "meeting_id": 1,
+                    "sequential_number": 111,
+                }
             }
         )
-        response = self.request(
-            "motion_category.update",
-            {
-                "id": 111,
-                "prefix": None,
-            },
-        )
+        response = self.request("motion_category.update", {"id": 111, "prefix": None})
         self.assert_status_code(response, 200)
-        model = self.get_model("motion_category/111")
-        assert "prefix" not in model
+        self.assert_model_exists("motion_category/111", {"prefix": None})
 
     def test_update_wrong_id(self) -> None:
         self.set_models(
@@ -72,16 +61,16 @@ class MotionCategorySystemTest(BaseActionTestCase):
                 "motion_category/111": {
                     "name": "name_srtgb123",
                     "prefix": "prefix_JmDHFgvH",
-                    "meeting_id": 222,
-                },
+                    "meeting_id": 1,
+                    "sequential_number": 111,
+                }
             }
         )
         response = self.request(
             "motion_category.update", {"id": 112, "name": "name_Xcdfgee"}
         )
         self.assert_status_code(response, 400)
-        model = self.get_model("motion_category/111")
-        assert model.get("name") == "name_srtgb123"
+        self.assert_model_exists("motion_category/111", {"name": "name_srtgb123"})
 
     def test_update_non_unique_prefix(self) -> None:
         self.set_models(
@@ -89,29 +78,25 @@ class MotionCategorySystemTest(BaseActionTestCase):
                 "motion_category/111": {
                     "name": "name_srtgb123",
                     "prefix": "bla",
-                    "meeting_id": 222,
+                    "meeting_id": 1,
+                    "sequential_number": 111,
                 },
                 "motion_category/110": {
                     "name": "name_already",
                     "prefix": "test",
-                    "meeting_id": 222,
+                    "meeting_id": 1,
+                    "sequential_number": 110,
                 },
             }
         )
-        response = self.request(
-            "motion_category.update",
-            {
-                "id": 111,
-                "prefix": "test",
-            },
-        )
+        response = self.request("motion_category.update", {"id": 111, "prefix": "test"})
         self.assert_status_code(response, 200)
         self.assert_model_exists(
             "motion_category/111",
             {
                 "name": "name_srtgb123",
                 "prefix": "test",
-                "meeting_id": 222,
+                "meeting_id": 1,
             },
         )
 
@@ -119,20 +104,14 @@ class MotionCategorySystemTest(BaseActionTestCase):
         self.base_permission_test(
             self.permission_test_models,
             "motion_category.update",
-            {
-                "id": 111,
-                "name": "name_Xcdfgee",
-            },
+            {"id": 111, "name": "name_Xcdfgee"},
         )
 
     def test_update_permission(self) -> None:
         self.base_permission_test(
             self.permission_test_models,
             "motion_category.update",
-            {
-                "id": 111,
-                "name": "name_Xcdfgee",
-            },
+            {"id": 111, "name": "name_Xcdfgee"},
             Permissions.Motion.CAN_MANAGE,
         )
 
@@ -140,8 +119,5 @@ class MotionCategorySystemTest(BaseActionTestCase):
         self.base_locked_out_superadmin_permission_test(
             self.permission_test_models,
             "motion_category.update",
-            {
-                "id": 111,
-                "name": "name_Xcdfgee",
-            },
+            {"id": 111, "name": "name_Xcdfgee"},
         )

--- a/tests/system/action/motion_change_recommendation/test_delete.py
+++ b/tests/system/action/motion_change_recommendation/test_delete.py
@@ -1,24 +1,23 @@
-from typing import Any
-
 from tests.system.action.base import BaseActionTestCase
 
 
 class MotionChangeRecommendationActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models: dict[str, dict[str, Any]] = {
-            "motion_change_recommendation/111": {"meeting_id": 1, "motion_id": 1},
-            "motion/1": {"meeting_id": 1, "change_recommendation_ids": [111]},
-        }
-
-    def test_delete_correct(self) -> None:
         self.create_meeting()
         self.set_models(
             {
+                "motion/1": {
+                    "title": "motion 1",
+                    "meeting_id": 1,
+                    "state_id": 1,
+                    "sequential_number": 1,
+                },
                 "motion_change_recommendation/111": {"meeting_id": 1, "motion_id": 1},
-                "motion/1": {"meeting_id": 1, "change_recommendation_ids": [111]},
             }
         )
+
+    def test_delete_correct(self) -> None:
         response = self.request("motion_change_recommendation.delete", {"id": 111})
         self.assert_status_code(response, 200)
         self.assert_model_not_exists("motion_change_recommendation/111")
@@ -27,26 +26,20 @@ class MotionChangeRecommendationActionTest(BaseActionTestCase):
         )
 
     def test_delete_wrong_id(self) -> None:
-        self.create_meeting()
-        self.set_models(
-            {
-                "motion_change_recommendation/112": {"meeting_id": 1},
-            }
-        )
-        response = self.request("motion_change_recommendation.delete", {"id": 111})
+        response = self.request("motion_change_recommendation.delete", {"id": 112})
         self.assert_status_code(response, 400)
-        self.assert_model_exists("motion_change_recommendation/112")
+        self.assertEqual(
+            "Model 'motion_change_recommendation/112' does not exist.",
+            response.json["message"],
+        )
+        self.assert_model_exists("motion_change_recommendation/111")
 
     def test_delete_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
-            "motion_change_recommendation.delete",
-            {"id": 111},
+            {}, "motion_change_recommendation.delete", {"id": 111}
         )
 
     def test_delete_permission_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            self.permission_test_models,
-            "motion_change_recommendation.delete",
-            {"id": 111},
+            {}, "motion_change_recommendation.delete", {"id": 111}
         )

--- a/tests/system/action/motion_change_recommendation/test_update.py
+++ b/tests/system/action/motion_change_recommendation/test_update.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -7,27 +5,14 @@ from tests.system.action.base import BaseActionTestCase
 class MotionChangeRecommendationActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models: dict[str, dict[str, Any]] = {
-            "motion/25": {
-                "title": "title_pheK0Ja3ai",
-                "meeting_id": 1,
-            },
-            "motion_change_recommendation/111": {
-                "line_from": 11,
-                "line_to": 23,
-                "text": "text_LhmrbbwS",
-                "motion_id": 25,
-                "meeting_id": 1,
-            },
-        }
-
-    def test_update_correct(self) -> None:
         self.create_meeting()
         self.set_models(
             {
                 "motion/25": {
                     "title": "title_pheK0Ja3ai",
                     "meeting_id": 1,
+                    "state_id": 1,
+                    "sequential_number": 25,
                 },
                 "motion_change_recommendation/111": {
                     "line_from": 11,
@@ -38,6 +23,8 @@ class MotionChangeRecommendationActionTest(BaseActionTestCase):
                 },
             }
         )
+
+    def test_update_correct(self) -> None:
         response = self.request(
             "motion_change_recommendation.update",
             {
@@ -50,70 +37,48 @@ class MotionChangeRecommendationActionTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 200)
-        model = self.get_model("motion_change_recommendation/111")
-        assert model.get("text") == "text_zzTWoMte"
-        assert model.get("rejected") is False
-        assert model.get("internal") is True
-        assert model.get("type") == "insertion"
-        assert model.get("other_description") == "other_description_IClpabuM"
+        self.assert_model_exists(
+            "motion_change_recommendation/111",
+            {
+                "text": "text_zzTWoMte",
+                "rejected": False,
+                "internal": True,
+                "type": "insertion",
+                "other_description": "other_description_IClpabuM",
+            },
+        )
         self.assert_history_information(
             "motion/25", ["Motion change recommendation updated"]
         )
 
     def test_update_wrong_id(self) -> None:
-        self.create_meeting()
-        self.set_models(
-            {
-                "motion/25": {
-                    "title": "title_pheK0Ja3ai",
-                    "meeting_id": 1,
-                },
-                "motion_change_recommendation/111": {
-                    "line_from": 11,
-                    "line_to": 23,
-                    "text": "text_LhmrbbwS",
-                    "motion_id": 25,
-                    "meeting_id": 1,
-                },
-            }
-        )
         response = self.request(
             "motion_change_recommendation.update", {"id": 112, "text": "text_Xcdfgee"}
         )
         self.assert_status_code(response, 400)
-        model = self.get_model("motion_change_recommendation/111")
-        assert model.get("text") == "text_LhmrbbwS"
-        assert model.get("line_from") == 11
-        assert model.get("line_to") == 23
-        assert model.get("motion_id") == 25
+        self.assert_model_exists(
+            "motion_change_recommendation/111",
+            {"text": "text_LhmrbbwS", "line_from": 11, "line_to": 23, "motion_id": 25},
+        )
 
     def test_update_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
+            {},
             "motion_change_recommendation.update",
-            {
-                "id": 111,
-                "text": "text_zzTWoMte",
-            },
+            {"id": 111, "text": "text_zzTWoMte"},
         )
 
     def test_update_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
+            {},
             "motion_change_recommendation.update",
-            {
-                "id": 111,
-                "text": "text_zzTWoMte",
-            },
+            {"id": 111, "text": "text_zzTWoMte"},
             Permissions.Motion.CAN_MANAGE,
         )
 
     def test_update_permission_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            self.permission_test_models,
+            {},
             "motion_change_recommendation.update",
-            {
-                "id": 111,
-                "text": "text_zzTWoMte",
-            },
+            {"id": 111, "text": "text_zzTWoMte"},
         )

--- a/tests/system/action/motion_comment/test_create.py
+++ b/tests/system/action/motion_comment/test_create.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -7,68 +5,48 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCommentCreateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models: dict[str, dict[str, Any]] = {
-            "motion/357": {"title": "title_YIDYXmKj", "meeting_id": 1},
-            "motion_comment_section/78": {
-                "meeting_id": 1,
-                "write_group_ids": [3],
-                "name": "test",
-            },
-        }
-
-    def test_create(self) -> None:
-        self.create_meeting(111)
+        self.create_meeting()
         self.set_models(
             {
-                "user/1": {"meeting_user_ids": [1]},
-                "meeting_user/1": {
-                    "meeting_id": 111,
-                    "user_id": 1,
-                    "group_ids": [3],
+                "motion/357": {
+                    "title": "title_YIDYXmKj",
+                    "meeting_id": 1,
+                    "state_id": 1,
+                    "sequential_number": 357,
                 },
-                "meeting/111": {
-                    "admin_group_id": 3,
-                    "meeting_user_ids": [1],
+                "motion_comment_section/78": {
+                    "meeting_id": 1,
+                    "name": "test",
+                    "sequential_number": 78,
                 },
-                "group/3": {},
-                "motion/357": {"title": "title_YIDYXmKj", "meeting_id": 111},
-                "motion_comment_section/78": {"meeting_id": 111, "name": "test"},
+                "group/3": {"write_comment_section_ids": [78]},
             }
         )
+
+    def test_create(self) -> None:
+        self.set_user_groups(1, [3])
         response = self.request(
             "motion_comment.create",
             {"comment": "test_Xcdfgee", "motion_id": 357, "section_id": 78},
         )
         self.assert_status_code(response, 200)
-        model = self.get_model("motion_comment/1")
-        assert model.get("comment") == "test_Xcdfgee"
-        assert model.get("motion_id") == 357
-        assert model.get("section_id") == 78
+        self.assert_model_exists(
+            "motion_comment/1",
+            {"comment": "test_Xcdfgee", "motion_id": 357, "section_id": 78},
+        )
         self.assert_history_information(
             "motion/357", ["Comment {} created", "motion_comment_section/78"]
         )
 
     def test_create_not_unique_error(self) -> None:
-        self.create_meeting(111)
+        self.set_user_groups(1, [2])
         self.set_models(
             {
-                "user/1": {"meeting_user_ids": [1]},
-                "meeting_user/1": {
-                    "meeting_id": 111,
-                    "user_id": 1,
-                    "group_ids": [3],
-                },
-                "meeting/111": {
-                    "admin_group_id": 3,
-                },
-                "group/3": {},
-                "motion/357": {"title": "title_YIDYXmKj", "meeting_id": 111},
-                "motion_comment_section/78": {"meeting_id": 111},
                 "motion_comment/4356": {
                     "comment": "test_Xcdfgee",
                     "motion_id": 357,
                     "section_id": 78,
-                    "meeting_id": 111,
+                    "meeting_id": 1,
                 },
             }
         )
@@ -77,7 +55,7 @@ class MotionCommentCreateActionTest(BaseActionTestCase):
             {"comment": "test_Xcdfgee", "motion_id": 357, "section_id": 78},
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
+        self.assertEqual(
             "There already exists a comment for this section, please update it instead.",
             response.json["message"],
         )
@@ -85,19 +63,12 @@ class MotionCommentCreateActionTest(BaseActionTestCase):
     def test_create_empty_data(self) -> None:
         response = self.request("motion_comment.create", {})
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must contain ['comment', 'motion_id', 'section_id'] properties",
+        self.assertEqual(
+            "Action motion_comment.create: data must contain ['comment', 'motion_id', 'section_id'] properties",
             response.json["message"],
         )
 
     def test_create_wrong_field(self) -> None:
-        self.create_meeting(111)
-        self.set_models(
-            {
-                "motion/357": {"title": "title_YIDYXmKj", "meeting_id": 111},
-                "motion_comment_section/78": {},
-            }
-        )
         response = self.request(
             "motion_comment.create",
             {
@@ -108,21 +79,21 @@ class MotionCommentCreateActionTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must not contain {'wrong_field'} properties",
+        self.assertEqual(
+            "Action motion_comment.create: data must not contain {'wrong_field'} properties",
             response.json["message"],
         )
 
     def test_create_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
+            {},
             "motion_comment.create",
             {"comment": "test_Xcdfgee", "motion_id": 357, "section_id": 78},
         )
 
     def test_create_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
+            {},
             "motion_comment.create",
             {"comment": "test_Xcdfgee", "motion_id": 357, "section_id": 78},
             Permissions.Motion.CAN_SEE,
@@ -130,53 +101,39 @@ class MotionCommentCreateActionTest(BaseActionTestCase):
 
     def test_create_permission_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            self.permission_test_models,
+            {},
             "motion_comment.create",
             {"comment": "test_Xcdfgee", "motion_id": 357, "section_id": 78},
         )
 
     def test_create_no_permission_cause_write_group(self) -> None:
-        self.permission_test_models["motion_comment_section/78"]["write_group_ids"] = [
-            2
-        ]
-        self.create_meeting()
-        self.user_id = self.create_user("user")
+        self.user_id = self.create_user("user", [1])
         self.login(self.user_id)
-        self.set_user_groups(self.user_id, [3])
-        self.set_group_permissions(3, [Permissions.Motion.CAN_SEE])
-        self.set_models(self.permission_test_models)
+        self.set_group_permissions(1, [Permissions.Motion.CAN_SEE])
         response = self.request(
             "motion_comment.create",
             {"comment": "test_Xcdfgee", "motion_id": 357, "section_id": 78},
         )
         self.assert_status_code(response, 403)
-        assert (
-            "You are not in the write group of the section or in admin group."
-            in response.json["message"]
+        self.assertEqual(
+            "You are not allowed to perform action motion_comment.create. You are not in the write group of the section or in admin group.",
+            response.json["message"],
         )
 
     def test_create_permission_cause_submitter(self) -> None:
-        self.permission_test_models["motion_comment_section/78"]["write_group_ids"] = [
-            2
-        ]
-        self.permission_test_models["motion_comment_section/78"][
-            "submitter_can_write"
-        ] = True
-        self.create_meeting()
-        self.user_id = self.create_user("user")
+        self.user_id = self.create_user("user", [1])
         self.login(self.user_id)
-        self.set_user_groups(self.user_id, [3])
-        self.set_group_permissions(3, [Permissions.Motion.CAN_SEE])
-        self.permission_test_models["motion_submitter/1234"] = {
-            "meeting_user_id": 1,
-            "motion_id": 357,
-        }
-        self.permission_test_models["meeting_user/1"] = {
-            "meeting_id": 1,
-            "user_id": self.user_id,
-            "motion_submitter_ids": [1234],
-        }
-        self.set_models(self.permission_test_models)
+        self.set_group_permissions(1, [Permissions.Motion.CAN_SEE])
+        self.set_models(
+            {
+                "motion_comment_section/78": {"submitter_can_write": True},
+                "motion_submitter/1234": {
+                    "meeting_user_id": 1,
+                    "motion_id": 357,
+                    "meeting_id": 1,
+                },
+            }
+        )
         response = self.request(
             "motion_comment.create",
             {"comment": "test_Xcdfgee", "motion_id": 357, "section_id": 78},
@@ -189,7 +146,7 @@ class MotionCommentCreateActionTest(BaseActionTestCase):
         self.assert_model_exists(
             "meeting_user/1",
             {
-                "group_ids": [3],
+                "group_ids": [1],
                 "motion_submitter_ids": [1234],
                 "meeting_id": 1,
                 "user_id": 2,

--- a/tests/system/action/motion_comment/test_delete.py
+++ b/tests/system/action/motion_comment/test_delete.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -7,30 +5,10 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCommentDeleteActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models: dict[str, dict[str, Any]] = {
-            "motion/1": {"meeting_id": 1, "comment_ids": [111]},
-            "motion_comment/111": {"meeting_id": 1, "section_id": 78, "motion_id": 1},
-            "motion_comment_section/78": {
-                "meeting_id": 1,
-                "write_group_ids": [3],
-                "name": "test",
-            },
-        }
-
-    def test_delete_correct(self) -> None:
         self.create_meeting()
+        self.create_motion(1, 1)
         self.set_models(
             {
-                "user/1": {"meeting_user_ids": [1]},
-                "meeting_user/1": {
-                    "meeting_id": 1,
-                    "user_id": 1,
-                    "group_ids": [2],
-                },
-                "meeting/1": {"admin_group_id": 2},
-                "group/2": {"meeting_id": 1, "admin_group_for_meeting_id": 1},
-                "group/3": {"meeting_id": 1},
-                "motion/1": {"meeting_id": 1, "comment_ids": [111]},
                 "motion_comment/111": {
                     "meeting_id": 1,
                     "section_id": 78,
@@ -38,11 +16,15 @@ class MotionCommentDeleteActionTest(BaseActionTestCase):
                 },
                 "motion_comment_section/78": {
                     "meeting_id": 1,
-                    "write_group_ids": [3],
                     "name": "test",
+                    "sequential_number": 78,
                 },
+                "group/3": {"write_comment_section_ids": [78]},
             }
         )
+
+    def test_delete_correct(self) -> None:
+        self.set_user_groups(1, [2])
         response = self.request("motion_comment.delete", {"id": 111})
         self.assert_status_code(response, 200)
         self.assert_model_not_exists("motion_comment/111")
@@ -51,80 +33,53 @@ class MotionCommentDeleteActionTest(BaseActionTestCase):
         )
 
     def test_delete_wrong_id(self) -> None:
-        self.create_model("motion_comment/112")
-        response = self.request("motion_comment.delete", {"id": 111})
+        self.set_user_groups(1, [2])
+        response = self.request("motion_comment.delete", {"id": 112})
         self.assert_status_code(response, 400)
-        self.assert_model_exists("motion_comment/112")
+        self.assert_model_exists("motion_comment/111")
+        self.assertEqual(
+            "Model 'motion_comment/112' does not exist.", response.json["message"]
+        )
 
     def test_delete_no_permissions(self) -> None:
-        self.base_permission_test(
-            self.permission_test_models,
-            "motion_comment.delete",
-            {"id": 111},
-        )
+        self.base_permission_test({}, "motion_comment.delete", {"id": 111})
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
-            "motion_comment.delete",
-            {"id": 111},
-            Permissions.Motion.CAN_SEE,
+            {}, "motion_comment.delete", {"id": 111}, Permissions.Motion.CAN_SEE
         )
 
     def test_delete_permissions_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            self.permission_test_models,
-            "motion_comment.delete",
-            {"id": 111},
+            {}, "motion_comment.delete", {"id": 111}
         )
 
     def test_update_no_permission_cause_write_group(self) -> None:
-        self.permission_test_models["motion_comment_section/78"]["write_group_ids"] = [
-            2
-        ]
-        self.create_meeting()
-        self.user_id = self.create_user("user")
+        self.user_id = self.create_user("user", [1])
         self.login(self.user_id)
-        self.set_user_groups(self.user_id, [3])
-        self.set_group_permissions(3, [Permissions.Motion.CAN_SEE])
-        self.set_models(self.permission_test_models)
-        response = self.request(
-            "motion_comment.delete",
-            {"id": 111},
-        )
+        self.set_group_permissions(1, [Permissions.Motion.CAN_SEE])
+        response = self.request("motion_comment.delete", {"id": 111})
         self.assert_status_code(response, 403)
-        assert (
-            "You are not in the write group of the section or in admin group."
-            in response.json["message"]
+        self.assertEqual(
+            "You are not allowed to perform action motion_comment.delete. You are not in the write group of the section or in admin group.",
+            response.json["message"],
         )
 
     def test_update_permission_cause_submitter(self) -> None:
-        self.permission_test_models["motion_comment_section/78"]["write_group_ids"] = [
-            2
-        ]
-        self.create_meeting()
-        self.user_id = self.create_user("user")
+        self.user_id = self.create_user("user", [1])
         self.login(self.user_id)
-        self.set_user_groups(self.user_id, [3])
-        self.set_group_permissions(3, [Permissions.Motion.CAN_SEE])
-        self.set_models(self.permission_test_models)
+        self.set_group_permissions(1, [Permissions.Motion.CAN_SEE])
         self.set_models(
             {
-                "motion/1": {"meeting_id": 1, "comment_ids": [111]},
-                "motion_comment/111": {"motion_id": 1},
-                "motion_submitter/12": {"meeting_user_id": 1, "motion_id": 1},
-                "motion_comment_section/78": {"submitter_can_write": True},
-                "meeting_user/1": {
+                "motion_submitter/12": {
                     "meeting_id": 1,
-                    "user_id": self.user_id,
-                    "motion_submitter_ids": [12],
+                    "meeting_user_id": 1,
+                    "motion_id": 1,
                 },
+                "motion_comment_section/78": {"submitter_can_write": True},
             }
         )
 
-        response = self.request(
-            "motion_comment.delete",
-            {"id": 111},
-        )
+        response = self.request("motion_comment.delete", {"id": 111})
         self.assert_status_code(response, 200)
         self.assert_model_not_exists("motion_comment/111")

--- a/tests/system/action/motion_comment/test_update.py
+++ b/tests/system/action/motion_comment/test_update.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -7,83 +5,52 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCommentUpdateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.test_models: dict[str, dict[str, Any]] = {
-            "motion/111": {"meeting_id": 1, "comment_ids": [111]},
-            "motion_comment/111": {
-                "comment": "comment_srtgb123",
-                "meeting_id": 1,
-                "motion_id": 111,
-                "section_id": 78,
-            },
-            "motion_comment_section/78": {
-                "meeting_id": 1,
-                "write_group_ids": [3],
-                "name": "test",
-            },
-        }
-
-    def test_update_correct(self) -> None:
         self.create_meeting()
+        self.create_motion(1, 111)
         self.set_models(
             {
-                "user/1": {"meeting_user_ids": [1]},
-                "meeting_user/1": {
+                "motion_comment/111": {
+                    "comment": "comment_srtgb123",
                     "meeting_id": 1,
-                    "user_id": 1,
-                    "group_ids": [2],
+                    "motion_id": 111,
+                    "section_id": 78,
                 },
-                "meeting/1": {"admin_group_id": 2},
-                "group/2": {
+                "motion_comment_section/78": {
                     "meeting_id": 1,
-                    "admin_group_for_meeting_id": 1,
-                    "meeting_user_ids": [1],
+                    "name": "test",
+                    "sequential_number": 78,
                 },
-                **self.test_models,
+                "group/3": {"write_comment_section_ids": [78]},
             }
         )
+
+    def test_update_correct(self) -> None:
+        self.set_user_groups(1, [2])
         response = self.request(
             "motion_comment.update", {"id": 111, "comment": "comment_Xcdfgee"}
         )
         self.assert_status_code(response, 200)
-        model = self.get_model("motion_comment/111")
-        assert model.get("comment") == "comment_Xcdfgee"
+        self.assert_model_exists("motion_comment/111", {"comment": "comment_Xcdfgee"})
         self.assert_history_information(
             "motion/111", ["Comment {} updated", "motion_comment_section/78"]
         )
 
     def test_update_wrong_id(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {"is_active_in_organization_id": 1},
-                "motion_comment/111": {
-                    "comment": "comment_srtgb123",
-                    "meeting_id": 1,
-                    "section_id": 78,
-                },
-                "motion_comment_section/78": {"meeting_id": 1, "write_group_ids": [3]},
-            }
-        )
         response = self.request(
             "motion_comment.update", {"id": 112, "comment": "comment_Xcdfgee"}
         )
         self.assert_status_code(response, 400)
-        model = self.get_model("motion_comment/111")
-        assert model.get("comment") == "comment_srtgb123"
+        self.assert_model_exists("motion_comment/111", {"comment": "comment_srtgb123"})
 
     def test_update_no_permission(self) -> None:
         self.base_permission_test(
-            self.test_models,
-            "motion_comment.update",
-            {"id": 111, "comment": "comment_Xcdfgee"},
+            {}, "motion_comment.update", {"id": 111, "comment": "comment_Xcdfgee"}
         )
 
     def test_update_permission(self) -> None:
-        self.create_meeting()
-        self.user_id = self.create_user("user")
+        self.user_id = self.create_user("user", [3])
         self.login(self.user_id)
-        self.set_user_groups(self.user_id, [3])
         self.set_group_permissions(3, [Permissions.Motion.CAN_SEE])
-        self.set_models(self.test_models)
         response = self.request(
             "motion_comment.update",
             {"comment": "test_Xcdfgee", "id": 111},
@@ -91,29 +58,23 @@ class MotionCommentUpdateActionTest(BaseActionTestCase):
         self.assert_status_code(response, 200)
 
     def test_update_no_permission_cause_write_group(self) -> None:
-        self.test_models["motion_comment_section/78"]["write_group_ids"] = [2]
-        self.create_meeting()
-        self.user_id = self.create_user("user")
+        self.user_id = self.create_user("user", [1])
         self.login(self.user_id)
-        self.set_user_groups(self.user_id, [3])
-        self.set_group_permissions(3, [Permissions.Motion.CAN_SEE])
-        self.set_models(self.test_models)
+        self.set_group_permissions(1, [Permissions.Motion.CAN_SEE])
         response = self.request(
             "motion_comment.update",
             {"comment": "test_Xcdfgee", "id": 111},
         )
         self.assert_status_code(response, 403)
-        assert (
-            "You are not in the write group of the section or in admin group."
-            in response.json["message"]
+        self.assertEqual(
+            "You are not allowed to perform action motion_comment.update. You are not in the write group of the section or in admin group.",
+            response.json["message"],
         )
 
     def test_update_permission_in_admin_group(self) -> None:
-        self.create_meeting()
         self.user_id = self.create_user("user")
         self.set_user_groups(self.user_id, [2])
         self.login(self.user_id)
-        self.set_models(self.test_models)
         response = self.request(
             "motion_comment.update",
             {"comment": "test_Xcdfgee", "id": 111},
@@ -121,24 +82,19 @@ class MotionCommentUpdateActionTest(BaseActionTestCase):
         self.assert_status_code(response, 200)
 
     def test_update_permission_cause_submitter(self) -> None:
-        self.test_models["motion_comment_section/78"]["write_group_ids"] = [2]
-        self.create_meeting()
-        self.user_id = self.create_user("user")
+        self.user_id = self.create_user("user", [1])
         self.login(self.user_id)
-        self.set_user_groups(self.user_id, [3])
-        self.set_group_permissions(3, [Permissions.Motion.CAN_SEE])
-        self.test_models["motion_comment_section/78"]["submitter_can_write"] = True
-        self.test_models["motion_submitter/777"] = {
-            "meeting_user_id": 1,
-            "motion_id": 111,
-        }
-        self.test_models["motion/111"]["submitter_ids"] = [self.user_id]
-        self.test_models["meeting_user/1"] = {
-            "meeting_id": 1,
-            "user_id": self.user_id,
-            "motion_submitter_ids": [777],
-        }
-        self.set_models(self.test_models)
+        self.set_group_permissions(1, [Permissions.Motion.CAN_SEE])
+        self.set_models(
+            {
+                "motion_comment_section/78": {"submitter_can_write": True},
+                "motion_submitter/777": {
+                    "meeting_id": 1,
+                    "meeting_user_id": 1,
+                    "motion_id": 111,
+                },
+            }
+        )
         response = self.request(
             "motion_comment.update",
             {"comment": "test_Xcdfgee", "id": 111},

--- a/tests/system/action/motion_comment_section/test_create.py
+++ b/tests/system/action/motion_comment_section/test_create.py
@@ -9,19 +9,19 @@ class MotionCommentSectionActionTest(BaseActionTestCase):
             "motion_comment_section.create", {"name": "test_Xcdfgee", "meeting_id": 222}
         )
         self.assert_status_code(response, 200)
-        model = self.get_model("motion_comment_section/1")
-        assert model.get("name") == "test_Xcdfgee"
-        assert model.get("meeting_id") == 222
-        assert model.get("weight") == 10000
-        assert model.get("sequential_number") == 1
+        self.assert_model_exists(
+            "motion_comment_section/1",
+            {
+                "name": "test_Xcdfgee",
+                "meeting_id": 222,
+                "weight": 10000,
+                "sequential_number": 1,
+            },
+        )
 
     def test_create_good_case_all_fields(self) -> None:
         self.create_meeting(222)
-        self.set_models(
-            {
-                "group/23": {"name": "name_IIwngcUT", "meeting_id": 222},
-            }
-        )
+        self.set_models({"group/23": {"name": "name_IIwngcUT", "meeting_id": 222}})
         response = self.request(
             "motion_comment_section.create",
             {
@@ -33,19 +33,23 @@ class MotionCommentSectionActionTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 200)
-        model = self.get_model("motion_comment_section/1")
-        assert model.get("name") == "test_Xcdfgee"
-        assert model.get("meeting_id") == 222
-        assert model.get("weight") == 10000
-        assert model.get("read_group_ids") == [23]
-        assert model.get("write_group_ids") == [23]
-        assert model.get("submitter_can_write") is True
+        self.assert_model_exists(
+            "motion_comment_section/1",
+            {
+                "name": "test_Xcdfgee",
+                "meeting_id": 222,
+                "weight": 10000,
+                "read_group_ids": [23],
+                "write_group_ids": [23],
+                "submitter_can_write": True,
+            },
+        )
 
     def test_create_empty_data(self) -> None:
         response = self.request("motion_comment_section.create", {})
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must contain ['meeting_id', 'name'] properties",
+        self.assertEqual(
+            "Action motion_comment_section.create: data must contain ['meeting_id', 'name'] properties",
             response.json["message"],
         )
 
@@ -60,8 +64,8 @@ class MotionCommentSectionActionTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must not contain {'wrong_field'} properties",
+        self.assertEqual(
+            "Action motion_comment_section.create: data must not contain {'wrong_field'} properties",
             response.json["message"],
         )
 
@@ -89,11 +93,7 @@ class MotionCommentSectionActionTest(BaseActionTestCase):
 
     def test_create_anonymous_may_read(self) -> None:
         self.create_meeting(222)
-        self.set_models(
-            {
-                "group/23": {"name": "name_IIwngcUT", "meeting_id": 222},
-            }
-        )
+        self.set_models({"group/23": {"name": "name_IIwngcUT", "meeting_id": 222}})
         anonymous_group = self.set_anonymous(meeting_id=222)
         response = self.request(
             "motion_comment_section.create",
@@ -117,11 +117,7 @@ class MotionCommentSectionActionTest(BaseActionTestCase):
 
     def test_create_anonymous_may_not_write(self) -> None:
         self.create_meeting(222)
-        self.set_models(
-            {
-                "group/23": {"name": "name_IIwngcUT", "meeting_id": 222},
-            }
-        )
+        self.set_models({"group/23": {"name": "name_IIwngcUT", "meeting_id": 222}})
         anonymous_group = self.set_anonymous(meeting_id=222)
         response = self.request(
             "motion_comment_section.create",
@@ -133,7 +129,7 @@ class MotionCommentSectionActionTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
+        self.assertEqual(
             "Anonymous group is not allowed in write_group_ids.",
             response.json["message"],
         )

--- a/tests/system/action/motion_comment_section/test_delete.py
+++ b/tests/system/action/motion_comment_section/test_delete.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -7,66 +5,51 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCommentSectionActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.create_meeting(22)
-        self.permission_test_models: dict[str, dict[str, Any]] = {
-            "motion_comment_section/111": {
-                "name": "name_srtgb123",
-                "meeting_id": 1,
-            },
-        }
-
-    def test_delete_correct(self) -> None:
+        self.create_meeting()
         self.set_models(
             {
                 "motion_comment_section/111": {
                     "name": "name_srtgb123",
-                    "meeting_id": 22,
+                    "meeting_id": 1,
+                    "sequential_number": 111,
                 },
             }
         )
+
+    def test_delete_correct(self) -> None:
         response = self.request("motion_comment_section.delete", {"id": 111})
         self.assert_status_code(response, 200)
         self.assert_model_not_exists("motion_comment_section/111")
 
     def test_delete_wrong_id(self) -> None:
-        self.set_models(
-            {
-                "motion_comment_section/112": {
-                    "name": "name_srtgb123",
-                    "meeting_id": 22,
-                },
-            }
-        )
-        response = self.request("motion_comment_section.delete", {"id": 111})
+        response = self.request("motion_comment_section.delete", {"id": 112})
         self.assert_status_code(response, 400)
-        self.assert_model_exists("motion_comment_section/112")
+        self.assert_model_exists("motion_comment_section/111")
+        self.assertEqual(
+            "Model 'motion_comment_section/112' does not exist.",
+            response.json["message"],
+        )
 
     def test_delete_existing_comments(self) -> None:
+        self.create_motion(1, 17)
         self.set_models(
-            {
-                "motion_comment/79": {"motion_id": 17, "meeting_id": 22},
-                "motion_comment_section/1141": {"comment_ids": [79], "meeting_id": 22},
-            }
+            {"motion_comment/79": {"motion_id": 17, "meeting_id": 1, "section_id": 111}}
         )
 
-        response = self.request("motion_comment_section.delete", {"id": 1141})
+        response = self.request("motion_comment_section.delete", {"id": 111})
         self.assert_status_code(response, 400)
-        self.assert_model_exists("motion_comment_section/1141")
-        assert (
-            'This section has still comments in motion "17". Please remove all comments before deletion.'
-            in response.json["message"]
+        self.assert_model_exists("motion_comment_section/111")
+        self.assertEqual(
+            'This section has still comments in motion "17". Please remove all comments before deletion.',
+            response.json["message"],
         )
 
     def test_delete_no_permissions(self) -> None:
-        self.base_permission_test(
-            self.permission_test_models,
-            "motion_comment_section.delete",
-            {"id": 111},
-        )
+        self.base_permission_test({}, "motion_comment_section.delete", {"id": 111})
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
+            {},
             "motion_comment_section.delete",
             {"id": 111},
             Permissions.Motion.CAN_MANAGE,
@@ -74,7 +57,5 @@ class MotionCommentSectionActionTest(BaseActionTestCase):
 
     def test_delete_permissions_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            self.permission_test_models,
-            "motion_comment_section.delete",
-            {"id": 111},
+            {}, "motion_comment_section.delete", {"id": 111}
         )

--- a/tests/system/action/motion_comment_section/test_sort.py
+++ b/tests/system/action/motion_comment_section/test_sort.py
@@ -7,85 +7,78 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCommentSectionSortActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.create_meeting(222)
+        self.create_meeting()
         self.permission_test_models: dict[str, dict[str, Any]] = {
             "motion_comment_section/31": {
                 "meeting_id": 1,
                 "name": "name_loisueb",
+                "sequential_number": 31,
             },
             "motion_comment_section/32": {
                 "meeting_id": 1,
                 "name": "name_blanumop",
+                "sequential_number": 32,
             },
         }
 
     def test_sort_correct_1(self) -> None:
-        self.set_models(
-            {
-                "motion_comment_section/31": {
-                    "meeting_id": 222,
-                    "name": "name_loisueb",
-                },
-                "motion_comment_section/32": {
-                    "meeting_id": 222,
-                    "name": "name_blanumop",
-                },
-            }
-        )
+        self.set_models(self.permission_test_models)
         response = self.request(
             "motion_comment_section.sort",
-            {"meeting_id": 222, "motion_comment_section_ids": [32, 31]},
+            {"meeting_id": 1, "motion_comment_section_ids": [32, 31]},
         )
         self.assert_status_code(response, 200)
-        model_31 = self.get_model("motion_comment_section/31")
-        assert model_31.get("weight") == 2
-        model_32 = self.get_model("motion_comment_section/32")
-        assert model_32.get("weight") == 1
+        self.assert_model_exists("motion_comment_section/31", {"weight": 2})
+        self.assert_model_exists("motion_comment_section/32", {"weight": 1})
 
     def test_sort_missing_model(self) -> None:
         self.set_models(
             {
                 "motion_comment_section/31": {
-                    "meeting_id": 222,
+                    "meeting_id": 1,
                     "name": "name_loisueb",
+                    "sequential_number": 31,
                 },
             }
         )
         response = self.request(
             "motion_comment_section.sort",
-            {"meeting_id": 222, "motion_comment_section_ids": [32, 31]},
+            {"meeting_id": 1, "motion_comment_section_ids": [32, 31]},
         )
         self.assert_status_code(response, 400)
-        assert (
-            "motion_comment_section sorting failed, because element motion_comment_section/32 doesn't exist."
-            in response.json["message"]
+        self.assertEqual(
+            "motion_comment_section sorting failed, because element motion_comment_section/32 doesn't exist.",
+            response.json["message"],
         )
 
     def test_sort_another_section_db(self) -> None:
         self.set_models(
             {
                 "motion_comment_section/31": {
-                    "meeting_id": 222,
+                    "meeting_id": 1,
                     "name": "name_loisueb",
+                    "sequential_number": 31,
                 },
                 "motion_comment_section/32": {
-                    "meeting_id": 222,
+                    "meeting_id": 1,
                     "name": "name_blanumop",
+                    "sequential_number": 32,
                 },
                 "motion_comment_section/33": {
-                    "meeting_id": 222,
+                    "meeting_id": 1,
                     "name": "name_polusiem",
+                    "sequential_number": 33,
                 },
             }
         )
         response = self.request(
             "motion_comment_section.sort",
-            {"meeting_id": 222, "motion_comment_section_ids": [32, 31]},
+            {"meeting_id": 1, "motion_comment_section_ids": [32, 31]},
         )
         self.assert_status_code(response, 400)
-        assert (
-            "motion_comment_section sorting failed, because some elements were not included in the call."
-            in response.json["message"]
+        self.assertEqual(
+            "motion_comment_section sorting failed, because some elements were not included in the call.",
+            response.json["message"],
         )
 
     def test_sort_no_permissions(self) -> None:

--- a/tests/system/action/motion_comment_section/test_update.py
+++ b/tests/system/action/motion_comment_section/test_update.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -7,148 +5,109 @@ from tests.system.action.base import BaseActionTestCase
 class MotionCommentSectionActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models: dict[str, dict[str, Any]] = {
-            "motion_comment_section/111": {
-                "name": "name_srtgb123",
-                "meeting_id": 1,
-            },
-            "group/23": {"meeting_id": 1, "name": "name_asdfetza"},
-        }
-
-    def test_update_correct_all_fields(self) -> None:
-        self.create_meeting(222)
-        self.set_models(
-            {
-                "motion_comment_section/111": {
-                    "name": "name_srtgb123",
-                    "meeting_id": 222,
-                },
-                "group/23": {"meeting_id": 222, "name": "name_asdfetza"},
-            }
-        )
-        response = self.request(
-            "motion_comment_section.update",
-            {
-                "id": 111,
-                "name": "name_iuqAPRuD",
-                "read_group_ids": [23],
-                "write_group_ids": [23],
-                "submitter_can_write": False,
-            },
-        )
-        self.assert_status_code(response, 200)
-        model = self.get_model("motion_comment_section/111")
-        assert model.get("name") == "name_iuqAPRuD"
-        assert model.get("meeting_id") == 222
-        assert model.get("read_group_ids") == [23]
-        assert model.get("write_group_ids") == [23]
-        assert model.get("submitter_can_write") is False
-
-    def test_update_wrong_id(self) -> None:
-        self.create_meeting(222)
-        self.set_models(
-            {
-                "group/23": {"meeting_id": 222, "name": "name_asdfetza"},
-                "group/24": {"meeting_id": 222, "name": "name_faofetza"},
-                "motion_comment_section/111": {
-                    "name": "name_srtgb123",
-                    "meeting_id": 222,
-                    "read_group_ids": [23],
-                },
-            }
-        )
-        response = self.request(
-            "motion_comment_section.update", {"id": 112, "read_group_ids": [24]}
-        )
-        self.assert_status_code(response, 400)
-        model = self.get_model("motion_comment_section/111")
-        assert model.get("read_group_ids") == [23]
-
-    def test_update_no_permissions(self) -> None:
-        self.base_permission_test(
-            self.permission_test_models,
-            "motion_comment_section.update",
-            {
-                "id": 111,
-                "name": "name_iuqAPRuD",
-                "read_group_ids": [23],
-                "write_group_ids": [23],
-            },
-        )
-
-    def test_update_permissions(self) -> None:
-        self.base_permission_test(
-            self.permission_test_models,
-            "motion_comment_section.update",
-            {
-                "id": 111,
-                "name": "name_iuqAPRuD",
-                "read_group_ids": [23],
-                "write_group_ids": [23],
-            },
-            Permissions.Motion.CAN_MANAGE,
-        )
-
-    def test_update_permissions_locked_meeting(self) -> None:
-        self.base_locked_out_superadmin_permission_test(
-            self.permission_test_models,
-            "motion_comment_section.update",
-            {
-                "id": 111,
-                "name": "name_iuqAPRuD",
-                "read_group_ids": [23],
-                "write_group_ids": [23],
-            },
-        )
-
-    def test_update_anonymous_may_read(self) -> None:
         self.create_meeting()
         self.set_models(
             {
-                "meeting/1": {"motion_comment_section_ids": [111]},
                 "motion_comment_section/111": {
                     "name": "name_srtgb123",
                     "meeting_id": 1,
+                    "sequential_number": 111,
                 },
             }
         )
-        anonymous_group = self.set_anonymous()
+
+    def test_update_correct_all_fields(self) -> None:
         response = self.request(
             "motion_comment_section.update",
             {
                 "id": 111,
-                "read_group_ids": [anonymous_group],
+                "name": "name_iuqAPRuD",
+                "read_group_ids": [3],
+                "write_group_ids": [3],
+                "submitter_can_write": False,
             },
         )
         self.assert_status_code(response, 200)
         self.assert_model_exists(
             "motion_comment_section/111",
             {
-                "read_group_ids": [anonymous_group],
+                "name": "name_iuqAPRuD",
+                "meeting_id": 1,
+                "read_group_ids": [3],
+                "write_group_ids": [3],
+                "submitter_can_write": False,
             },
         )
-
-    def test_update_anonymous_may_not_write(self) -> None:
-        self.create_meeting()
-        self.set_models(
-            {
-                "meeting/1": {"motion_comment_section_ids": [111]},
-                "motion_comment_section/111": {
-                    "name": "name_srtgb123",
-                    "meeting_id": 1,
-                },
-            }
+        self.assert_model_exists(
+            "group/3",
+            {"write_comment_section_ids": [111], "read_comment_section_ids": [111]},
         )
-        anonymous_group = self.set_anonymous()
+
+    def test_update_wrong_id(self) -> None:
+        self.set_models({"group/3": {"read_comment_section_ids": [111]}})
         response = self.request(
+            "motion_comment_section.update", {"id": 112, "read_group_ids": [1]}
+        )
+        self.assert_status_code(response, 400)
+        self.assert_model_exists("motion_comment_section/111", {"read_group_ids": [3]})
+
+    def test_update_no_permissions(self) -> None:
+        self.base_permission_test(
+            {},
             "motion_comment_section.update",
             {
                 "id": 111,
-                "write_group_ids": [anonymous_group],
+                "name": "name_iuqAPRuD",
+                "read_group_ids": [3],
+                "write_group_ids": [3],
             },
         )
+
+    def test_update_permissions(self) -> None:
+        self.base_permission_test(
+            {},
+            "motion_comment_section.update",
+            {
+                "id": 111,
+                "name": "name_iuqAPRuD",
+                "read_group_ids": [3],
+                "write_group_ids": [3],
+            },
+            Permissions.Motion.CAN_MANAGE,
+        )
+
+    def test_update_permissions_locked_meeting(self) -> None:
+        self.base_locked_out_superadmin_permission_test(
+            {},
+            "motion_comment_section.update",
+            {
+                "id": 111,
+                "name": "name_iuqAPRuD",
+                "read_group_ids": [3],
+                "write_group_ids": [3],
+            },
+        )
+
+    def test_update_anonymous_may_read(self) -> None:
+        anonymous_group = self.set_anonymous()
+        response = self.request(
+            "motion_comment_section.update",
+            {"id": 111, "read_group_ids": [anonymous_group]},
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "motion_comment_section/111",
+            {"read_group_ids": [anonymous_group]},
+        )
+
+    def test_update_anonymous_may_not_write(self) -> None:
+        anonymous_group = self.set_anonymous()
+        response = self.request(
+            "motion_comment_section.update",
+            {"id": 111, "write_group_ids": [anonymous_group]},
+        )
         self.assert_status_code(response, 400)
-        self.assertIn(
+        self.assertEqual(
             "Anonymous group is not allowed in write_group_ids.",
             response.json["message"],
         )

--- a/tests/system/action/motion_state/test_create.py
+++ b/tests/system/action/motion_state/test_create.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -7,60 +5,34 @@ from tests.system.action.base import BaseActionTestCase
 class MotionStateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models: dict[str, dict[str, Any]] = {
-            "motion_workflow/42": {
-                "name": "test_name_fjwnq8d8tje8",
-                "meeting_id": 1,
-            },
-        }
+        self.create_meeting()
 
     def test_create(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {"is_active_in_organization_id": 1, "committee_id": 1},
-                "motion_workflow/42": {
-                    "name": "test_name_fjwnq8d8tje8",
-                    "meeting_id": 1,
-                },
-            }
-        )
         response = self.request(
             "motion_state.create",
             {
                 "name": "test_Xcdfgee",
-                "workflow_id": 42,
+                "workflow_id": 1,
                 "allow_motion_forwarding": True,
                 "allow_amendment_forwarding": True,
                 "set_workflow_timestamp": True,
             },
         )
         self.assert_status_code(response, 200)
-        self.assert_model_exists("motion_state/1")
-        model = self.get_model("motion_state/1")
-        assert model.get("name") == "test_Xcdfgee"
-        assert model.get("restrictions") == []
-        assert model.get("merge_amendment_into_final") == "undefined"
-        assert model.get("css_class") == "lightblue"
-        assert model.get("allow_motion_forwarding") is True
-        assert model.get("allow_amendment_forwarding") is True
-        assert model.get("set_workflow_timestamp") is True
+        self.assert_model_exists(
+            "motion_state/2",
+            {
+                "name": "test_Xcdfgee",
+                "restrictions": [],
+                "merge_amendment_into_final": "undefined",
+                "css_class": "lightblue",
+                "allow_motion_forwarding": True,
+                "allow_amendment_forwarding": True,
+                "set_workflow_timestamp": True,
+            },
+        )
 
     def test_create_as_new_first_state(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {"is_active_in_organization_id": 1, "committee_id": 1},
-                "motion_workflow/42": {
-                    "name": "test_name_fjwnq8d8tje8",
-                    "meeting_id": 1,
-                    "first_state_id": 1,
-                },
-                "motion_state/1": {
-                    "workflow_id": 42,
-                    "first_state_of_workflow_id": 42,
-                    "name": "first state one",
-                },
-            }
-        )
         response = self.request_json(
             [
                 {
@@ -68,15 +40,15 @@ class MotionStateActionTest(BaseActionTestCase):
                     "data": [
                         {
                             "name": "first state two",
-                            "workflow_id": 42,
-                            "first_state_of_workflow_id": 42,
+                            "workflow_id": 1,
+                            "first_state_of_workflow_id": 1,
                         }
                     ],
                 }
             ]
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
+        self.assertEqual(
             "There is already a first state for this workflow set. You can't change it.",
             response.json["message"],
         )
@@ -84,26 +56,18 @@ class MotionStateActionTest(BaseActionTestCase):
     def test_create_as_new_first_state_of_second_workflow(self) -> None:
         self.set_models(
             {
-                "meeting/1": {"is_active_in_organization_id": 1, "committee_id": 1},
-                "motion_workflow/42": {
-                    "name": "test_name_42",
-                    "meeting_id": 1,
-                    "first_state_id": 1,
-                },
-                "motion_state/1": {
-                    "workflow_id": 42,
-                    "first_state_of_workflow_id": 42,
-                    "name": "first state one",
-                },
                 "motion_workflow/43": {
                     "name": "test_name_43",
                     "meeting_id": 1,
                     "first_state_id": 2,
+                    "sequential_number": 43,
                 },
                 "motion_state/2": {
+                    "meeting_id": 1,
                     "workflow_id": 43,
                     "first_state_of_workflow_id": 43,
                     "name": "first state two",
+                    "weight": 2,
                 },
             }
         )
@@ -114,7 +78,7 @@ class MotionStateActionTest(BaseActionTestCase):
                     "data": [
                         {
                             "name": "first state three",
-                            "workflow_id": 42,
+                            "workflow_id": 1,
                             "first_state_of_workflow_id": 43,
                         }
                     ],
@@ -122,95 +86,63 @@ class MotionStateActionTest(BaseActionTestCase):
             ]
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "This state of workflow 42 cannot be the first state of workflow 43.",
+        self.assertEqual(
+            "This state of workflow 1 cannot be the first state of workflow 43.",
             response.json["message"],
         )
 
     def test_create_enum_fields(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {"is_active_in_organization_id": 1, "committee_id": 1},
-                "motion_workflow/42": {
-                    "name": "test_name_fjwnq8d8tje8",
-                    "meeting_id": 1,
-                },
-            }
-        )
         response = self.request(
             "motion_state.create",
             {
                 "name": "test_Xcdfgee",
-                "workflow_id": 42,
+                "workflow_id": 1,
                 "css_class": "red",
                 "restrictions": ["is_submitter"],
                 "merge_amendment_into_final": "do_not_merge",
             },
         )
         self.assert_status_code(response, 200)
-        self.assert_model_exists("motion_state/1")
-        model = self.get_model("motion_state/1")
-        assert model.get("name") == "test_Xcdfgee"
-        assert model.get("workflow_id") == 42
-        assert model.get("css_class") == "red"
-        assert model.get("restrictions") == ["is_submitter"]
-        assert model.get("merge_amendment_into_final") == "do_not_merge"
+        self.assert_model_exists("motion_state/2")
+        self.assert_model_exists(
+            "motion_state/2",
+            {
+                "name": "test_Xcdfgee",
+                "workflow_id": 1,
+                "css_class": "red",
+                "restrictions": ["is_submitter"],
+                "merge_amendment_into_final": "do_not_merge",
+            },
+        )
 
     def test_create_auto_weight(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {"is_active_in_organization_id": 1, "committee_id": 1},
-                "motion_workflow/42": {
-                    "name": "test_name_fjwnq8d8tje8",
-                    "meeting_id": 1,
-                },
-            }
-        )
         response = self.request(
             "motion_state.create",
-            {
-                "name": "test_Xcdfgee",
-                "workflow_id": 42,
-            },
+            {"name": "test_Xcdfgee", "workflow_id": 1},
         )
         self.assert_status_code(response, 200)
-        self.assert_model_exists("motion_state/1", {"weight": 1})
+        self.assert_model_exists("motion_state/2", {"weight": 37})
+
         response = self.request(
             "motion_state.create",
-            {
-                "name": "test_Xcdfgee",
-                "workflow_id": 42,
-            },
+            {"name": "test_Xcdfgee", "workflow_id": 1},
         )
         self.assert_status_code(response, 200)
-        self.assert_model_exists("motion_state/2", {"weight": 2})
+        self.assert_model_exists("motion_state/3", {"weight": 38})
 
     def test_create_manual_weight(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {"is_active_in_organization_id": 1, "committee_id": 1},
-                "motion_workflow/42": {
-                    "name": "test_name_fjwnq8d8tje8",
-                    "meeting_id": 1,
-                },
-            }
-        )
         response = self.request(
             "motion_state.create",
-            {
-                "name": "test_Xcdfgee",
-                "workflow_id": 42,
-                "weight": 42,
-            },
+            {"name": "test_Xcdfgee", "workflow_id": 1, "weight": 1},
         )
         self.assert_status_code(response, 200)
-        self.assert_model_exists("motion_state/1", {"weight": 42})
+        self.assert_model_exists("motion_state/2", {"weight": 1})
 
     def test_create_empty_data(self) -> None:
         response = self.request("motion_state.create", {})
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must contain ['name', 'workflow_id'] properties",
+        self.assertEqual(
+            "Action motion_state.create: data must contain ['name', 'workflow_id'] properties",
             response.json["message"],
         )
 
@@ -219,19 +151,19 @@ class MotionStateActionTest(BaseActionTestCase):
             "motion_state.create", {"wrong_field": "text_AefohteiF8"}
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must contain ['name', 'workflow_id'] properties",
+        self.assertEqual(
+            "Action motion_state.create: data must contain ['name', 'workflow_id'] properties",
             response.json["message"],
         )
 
     def test_create_forbidden_value_1(self) -> None:
         response = self.request(
             "motion_state.create",
-            {"name": "test_Xcdfgee", "workflow_id": 42, "css_class": "pink"},
+            {"name": "test_Xcdfgee", "workflow_id": 1, "css_class": "pink"},
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data.css_class must be one of ['grey', 'red', 'green', 'lightblue', 'yellow']",
+        self.assertEqual(
+            "Action motion_state.create: data.css_class must be one of ['grey', 'red', 'green', 'lightblue', 'yellow']",
             response.json["message"],
         )
 
@@ -240,34 +172,30 @@ class MotionStateActionTest(BaseActionTestCase):
             "motion_state.create",
             {
                 "name": "test_Xcdfgee",
-                "workflow_id": 42,
+                "workflow_id": 1,
                 "restrictions": ["is__XXXX__submitter"],
             },
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data.restrictions[0] must be one of ['motion.can_see_internal', 'motion.can_manage_metadata', 'motion.can_manage', 'is_submitter']",
+        self.assertEqual(
+            "Action motion_state.create: data.restrictions[0] must be one of ['motion.can_see_internal', 'motion.can_manage_metadata', 'motion.can_manage', 'is_submitter']",
             response.json["message"],
         )
 
     def test_create_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
-            "motion_state.create",
-            {"name": "test_Xcdfgee", "workflow_id": 42},
+            {}, "motion_state.create", {"name": "test_Xcdfgee", "workflow_id": 1}
         )
 
     def test_create_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
+            {},
             "motion_state.create",
-            {"name": "test_Xcdfgee", "workflow_id": 42},
+            {"name": "test_Xcdfgee", "workflow_id": 1},
             Permissions.Motion.CAN_MANAGE,
         )
 
     def test_create_permissions_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            self.permission_test_models,
-            "motion_state.create",
-            {"name": "test_Xcdfgee", "workflow_id": 42},
+            {}, "motion_state.create", {"name": "test_Xcdfgee", "workflow_id": 1}
         )

--- a/tests/system/action/motion_state/test_delete.py
+++ b/tests/system/action/motion_state/test_delete.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -7,80 +5,49 @@ from tests.system.action.base import BaseActionTestCase
 class MotionStateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models: dict[str, dict[str, Any]] = {
-            "motion_state/111": {"name": "name_srtgb123", "meeting_id": 1}
-        }
+        self.create_meeting()
+        self.set_models(
+            {
+                "motion_state/2": {
+                    "name": "deletable state",
+                    "workflow_id": 1,
+                    "meeting_id": 1,
+                    "weight": 2,
+                },
+            }
+        )
 
     def test_delete_correct(self) -> None:
-        self.set_models(
-            {
-                "motion_state/111": {"name": "name_srtgb123", "meeting_id": 1},
-                "meeting/1": {"is_active_in_organization_id": 1, "committee_id": 1},
-            }
-        )
-        response = self.request("motion_state.delete", {"id": 111})
+        response = self.request("motion_state.delete", {"id": 2})
         self.assert_status_code(response, 200)
-        self.assert_model_not_exists("motion_state/111")
+        self.assert_model_not_exists("motion_state/2")
 
     def test_delete_wrong_id(self) -> None:
-        self.set_models(
-            {
-                "motion_state/112": {"name": "name_srtgb123", "meeting_id": 1},
-                "meeting/1": {"is_active_in_organization_id": 1, "committee_id": 1},
-            }
-        )
-        response = self.request("motion_state.delete", {"id": 111})
+        response = self.request("motion_state.delete", {"id": 3})
         self.assert_status_code(response, 400)
-        self.assert_model_exists("motion_state/112")
+        self.assert_model_exists("motion_state/1")
+        self.assert_model_exists("motion_state/2")
+        self.assertEqual(
+            "Model 'motion_state/3' does not exist.", response.json["message"]
+        )
 
     def test_delete_first_state(self) -> None:
-        self.set_models(
-            {
-                "meeting/110": {
-                    "name": "name_meeting110",
-                    "is_active_in_organization_id": 1,
-                    "motion_state_ids": [111],
-                    "committee_id": 1,
-                },
-                "motion_workflow/1112": {
-                    "name": "name_XZwyPWxb",
-                    "first_state_id": 111,
-                    "meeting_id": 110,
-                    "state_ids": [111],
-                },
-                "motion_state/111": {
-                    "name": "name_srtgb123",
-                    "first_state_of_workflow_id": 1112,
-                    "workflow_id": 1112,
-                    "meeting_id": 110,
-                },
-            }
-        )
-        response = self.request("motion_state.delete", {"id": 111})
+        response = self.request("motion_state.delete", {"id": 1})
         self.assert_status_code(response, 400)
-        assert (
-            "You can not delete motion_state/111 because you have to delete the following related models first: ['motion_workflow/1112']"
-            in response.json["message"]
+        self.assertEqual(
+            "You can not delete motion_state/1 because you have to delete the following related models first: ['motion_workflow/1']",
+            response.json["message"],
         )
 
     def test_delete_no_permissions(self) -> None:
-        self.base_permission_test(
-            self.permission_test_models,
-            "motion_state.delete",
-            {"id": 111},
-        )
+        self.base_permission_test({}, "motion_state.delete", {"id": 2})
 
     def test_delete_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
-            "motion_state.delete",
-            {"id": 111},
-            Permissions.Motion.CAN_MANAGE,
+            {}, "motion_state.delete", {"id": 2}, Permissions.Motion.CAN_MANAGE
         )
 
     def test_delete_permissions_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            self.permission_test_models,
-            "motion_state.delete",
-            {"id": 111},
+            {}, "motion_state.delete", {"id": 2}
         )

--- a/tests/system/action/motion_state/test_sort.py
+++ b/tests/system/action/motion_state/test_sort.py
@@ -1,29 +1,29 @@
-from typing import Any
-
 from openslides_backend.permissions.permissions import Permissions
-from openslides_backend.shared.util import ONE_ORGANIZATION_FQID
 from tests.system.action.base import BaseActionTestCase
 
 
 class MotionStateSort(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models: dict[str, dict[str, Any]] = {
-            ONE_ORGANIZATION_FQID: {"active_meeting_ids": [1]},
-            "committee/1": {"meeting_ids": [1]},
-            "meeting/1": {
-                "motion_state_ids": [1, 2, 3],
-                "is_active_in_organization_id": 1,
-                "committee_id": 1,
-            },
-            "motion_workflow/1": {"state_ids": [1, 2, 3], "meeting_id": 1},
-            "motion_state/1": {"workflow_id": 1, "meeting_id": 1},
-            "motion_state/2": {"workflow_id": 1, "meeting_id": 1},
-            "motion_state/3": {"workflow_id": 1, "meeting_id": 1},
-        }
+        self.create_meeting()
+        self.set_models(
+            {
+                "motion_state/2": {
+                    "name": "state 2",
+                    "workflow_id": 1,
+                    "meeting_id": 1,
+                    "weight": 2,
+                },
+                "motion_state/3": {
+                    "name": "state 3",
+                    "workflow_id": 1,
+                    "meeting_id": 1,
+                    "weight": 3,
+                },
+            }
+        )
 
     def test_sort_good(self) -> None:
-        self.set_models(self.permission_test_models)
         response = self.request(
             "motion_state.sort",
             {"workflow_id": 1, "motion_state_ids": [3, 2, 1]},
@@ -34,39 +34,35 @@ class MotionStateSort(BaseActionTestCase):
         self.assert_model_exists("motion_state/3", {"weight": 1})
 
     def test_sort_extra_id_in_payload(self) -> None:
-        self.set_models(self.permission_test_models)
         response = self.request(
             "motion_state.sort",
             {"workflow_id": 1, "motion_state_ids": [3, 2, 4, 1]},
         )
         self.assert_status_code(response, 400)
-        assert (
-            "motion_state sorting failed, because element motion_state/4 doesn't exist."
-            == response.json["message"]
+        self.assertEqual(
+            "motion_state sorting failed, because element motion_state/4 doesn't exist.",
+            response.json["message"],
         )
 
     def test_sort_missing_id_in_payload(self) -> None:
-        self.set_models(self.permission_test_models)
         response = self.request(
             "motion_state.sort",
             {"workflow_id": 1, "motion_state_ids": [3, 1]},
         )
         self.assert_status_code(response, 400)
-        assert (
-            "motion_state sorting failed, because some elements were not included in the call."
-            == response.json["message"]
+        self.assertEqual(
+            "motion_state sorting failed, because some elements were not included in the call.",
+            response.json["message"],
         )
 
     def test_sort_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
-            "motion_state.sort",
-            {"workflow_id": 1, "motion_state_ids": [3, 2, 1]},
+            {}, "motion_state.sort", {"workflow_id": 1, "motion_state_ids": [3, 2, 1]}
         )
 
     def test_sort_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
+            {},
             "motion_state.sort",
             {"workflow_id": 1, "motion_state_ids": [3, 2, 1]},
             Permissions.Motion.CAN_MANAGE,
@@ -74,7 +70,5 @@ class MotionStateSort(BaseActionTestCase):
 
     def test_sort_permissions_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            self.permission_test_models,
-            "motion_state.sort",
-            {"workflow_id": 1, "motion_state_ids": [3, 2, 1]},
+            {}, "motion_state.sort", {"workflow_id": 1, "motion_state_ids": [3, 2, 1]}
         )

--- a/tests/system/action/motion_state/test_update.py
+++ b/tests/system/action/motion_state/test_update.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -8,173 +6,136 @@ class MotionStateActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.create_meeting()
-        self.permission_test_models: dict[str, dict[str, Any]] = {
-            "motion_workflow/110": {
-                "name": "name_Ycefgee",
-                "state_ids": [111],
-                "meeting_id": 1,
-            },
-            "motion_state/111": {
-                "name": "name_srtgb123",
-                "workflow_id": 110,
-                "meeting_id": 1,
-            },
-        }
+        self.set_models(
+            {
+                "motion_workflow/1": {"name": "name_Ycefgee"},
+                "motion_state/1": {"name": "name_srtgb123"},
+            }
+        )
 
     def test_update_correct(self) -> None:
         self.set_models(
             {
-                "motion_workflow/110": {
-                    "name": "name_Ycefgee",
-                    "state_ids": [111, 112],
-                    "meeting_id": 1,
-                },
-                "motion_state/111": {
-                    "name": "name_srtgb123",
-                    "workflow_id": 110,
-                    "meeting_id": 1,
-                },
-                "motion_state/112": {
+                "motion_state/2": {
                     "name": "test",
-                    "workflow_id": 110,
+                    "workflow_id": 1,
                     "meeting_id": 1,
+                    "weight": 2,
                 },
             }
         )
         response = self.request(
             "motion_state.update",
             {
-                "id": 111,
+                "id": 1,
                 "name": "name_Xcdfgee",
                 "is_internal": True,
                 "allow_motion_forwarding": True,
                 "allow_amendment_forwarding": True,
                 "set_workflow_timestamp": True,
-                "submitter_withdraw_state_id": 112,
+                "submitter_withdraw_state_id": 2,
             },
         )
         self.assert_status_code(response, 200)
-        self.assert_model_exists("motion_state/111")
-        model = self.get_model("motion_state/111")
-        assert model.get("name") == "name_Xcdfgee"
-        assert model.get("is_internal") is True
-        assert model.get("allow_motion_forwarding") is True
-        assert model.get("allow_amendment_forwarding") is True
-        assert model.get("set_workflow_timestamp") is True
-        assert model.get("submitter_withdraw_state_id") == 112
+        self.assert_model_exists(
+            "motion_state/1",
+            {
+                "name": "name_Xcdfgee",
+                "is_internal": True,
+                "allow_motion_forwarding": True,
+                "allow_amendment_forwarding": True,
+                "set_workflow_timestamp": True,
+                "submitter_withdraw_state_id": 2,
+            },
+        )
 
     def test_update_correct_plus_next_previous(self) -> None:
         self.set_models(
             {
-                "motion_workflow/110": {
-                    "name": "name_Ycefgee",
-                    "state_ids": [111, 112, 113],
-                    "meeting_id": 1,
-                },
-                "motion_state/111": {
-                    "name": "name_srtgb123",
-                    "workflow_id": 110,
-                    "meeting_id": 1,
-                },
-                "motion_state/112": {
+                "motion_state/2": {
                     "name": "name_srtfg112",
-                    "workflow_id": 110,
+                    "workflow_id": 1,
                     "meeting_id": 1,
+                    "weight": 2,
                 },
-                "motion_state/113": {
+                "motion_state/3": {
                     "name": "name_srtfg113",
-                    "workflow_id": 110,
+                    "workflow_id": 1,
                     "meeting_id": 1,
+                    "weight": 3,
                 },
             }
         )
         response = self.request(
             "motion_state.update",
             {
-                "id": 111,
-                "next_state_ids": [112],
-                "previous_state_ids": [113],
+                "id": 1,
+                "next_state_ids": [2],
+                "previous_state_ids": [3],
             },
         )
         self.assert_status_code(response, 200)
-        model = self.get_model("motion_state/111")
-        assert model.get("next_state_ids") == [112]
-        assert model.get("previous_state_ids") == [113]
+        self.assert_model_exists(
+            "motion_state/1", {"next_state_ids": [2], "previous_state_ids": [3]}
+        )
 
     def test_update_wrong_workflow_mismatch(self) -> None:
         self.set_models(
             {
-                "motion_workflow/110": {
-                    "name": "name_Ycefgee",
-                    "state_ids": [111, 112],
+                "motion_state/2": {
+                    "name": "name_srtfg112",
+                    "workflow_id": 1,
                     "meeting_id": 1,
+                    "weight": 2,
                 },
                 "motion_workflow/90": {
                     "name": "name_Ycefgee",
-                    "state_ids": [113],
                     "meeting_id": 1,
-                },
-                "motion_state/111": {
-                    "name": "name_srtgb123",
-                    "workflow_id": 110,
-                    "meeting_id": 1,
-                },
-                "motion_state/112": {
-                    "name": "name_srtfg112",
-                    "workflow_id": 110,
-                    "meeting_id": 1,
+                    "first_state_id": 113,
+                    "sequential_number": 90,
                 },
                 "motion_state/113": {
                     "name": "name_srtfg113",
                     "workflow_id": 90,
                     "meeting_id": 1,
+                    "weight": 113,
                 },
             }
         )
         response = self.request(
             "motion_state.update",
-            {
-                "id": 111,
-                "next_state_ids": [112],
-                "previous_state_ids": [113],
-            },
+            {"id": 1, "next_state_ids": [2], "previous_state_ids": [113]},
         )
         self.assert_status_code(response, 400)
-        assert "Cannot update: found states from different workflows" in str(
-            response.json["message"]
+        self.assertEqual(
+            "Cannot update: found states from different workflows (1, 90)",
+            response.json["message"],
         )
 
     def test_update_wrong_id(self) -> None:
-        self.set_models(
-            {
-                "motion_state/111": {"name": "name_srtgb123", "meeting_id": 1},
-            }
-        )
         response = self.request(
-            "motion_state.update", {"id": 112, "name": "name_Xcdfgee"}
+            "motion_state.update", {"id": 2, "name": "name_Xcdfgee"}
         )
         self.assert_status_code(response, 400)
-        model = self.get_model("motion_state/111")
-        assert model.get("name") == "name_srtgb123"
+        self.assert_model_exists("motion_state/1", {"name": "name_srtgb123"})
+        self.assertEqual(
+            "Model 'motion_state/2' does not exist.", response.json["message"]
+        )
 
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
-            "motion_state.update",
-            {"id": 111, "name": "name_Xcdfgee"},
+            {}, "motion_state.update", {"id": 1, "name": "name_Xcdfgee"}
         )
 
     def test_update_permissions(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
+            {},
             "motion_state.update",
-            {"id": 111, "name": "name_Xcdfgee"},
+            {"id": 1, "name": "name_Xcdfgee"},
             Permissions.Motion.CAN_MANAGE,
         )
 
     def test_update_permissions_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            self.permission_test_models,
-            "motion_state.update",
-            {"id": 111, "name": "name_Xcdfgee"},
+            {}, "motion_state.update", {"id": 1, "name": "name_Xcdfgee"}
         )

--- a/tests/system/action/motion_workflow/test_create.py
+++ b/tests/system/action/motion_workflow/test_create.py
@@ -4,31 +4,24 @@ from tests.system.action.base import BaseActionTestCase
 
 class MotionWorkflowSystemTest(BaseActionTestCase):
     def test_create(self) -> None:
-        self.create_model(
-            "meeting/42",
-            {
-                "name": "test_name_fsdksjdfhdsfssdf",
-                "is_active_in_organization_id": 1,
-                "committee_id": 1,
-            },
-        )
+        self.create_meeting(42)
         response = self.request(
             "motion_workflow.create", {"name": "test_Xcdfgee", "meeting_id": 42}
         )
         self.assert_status_code(response, 200)
-        workflow = self.get_model("motion_workflow/1")
-        assert workflow.get("name") == "test_Xcdfgee"
-        assert workflow.get("first_state_id") == 1
-        assert workflow.get("sequential_number") == 1
-        state = self.get_model("motion_state/1")
-        assert state.get("workflow_id") == 1
-        assert state.get("first_state_of_workflow_id") == 1
+        self.assert_model_exists(
+            "motion_workflow/43",
+            {"name": "test_Xcdfgee", "first_state_id": 43, "sequential_number": 43},
+        )
+        self.assert_model_exists(
+            "motion_state/43", {"workflow_id": 43, "first_state_of_workflow_id": 43}
+        )
 
     def test_create_empty_data(self) -> None:
         response = self.request("motion_workflow.create", {})
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must contain ['meeting_id', 'name'] properties",
+        self.assertEqual(
+            "Action motion_workflow.create: data must contain ['meeting_id', 'name'] properties",
             response.json["message"],
         )
 
@@ -37,49 +30,42 @@ class MotionWorkflowSystemTest(BaseActionTestCase):
             "motion_workflow.create", {"wrong_field": "text_AefohteiF8"}
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must contain ['meeting_id', 'name'] properties",
+        self.assertEqual(
+            "Action motion_workflow.create: data must contain ['meeting_id', 'name'] properties",
             response.json["message"],
         )
 
     def test_create_simple_workflow(self) -> None:
-        self.create_model(
-            "meeting/42",
-            {
-                "name": "test_meeting1",
-                "is_active_in_organization_id": 1,
-                "committee_id": 1,
-            },
-        )
+        self.create_meeting(42)
         response = self.request(
             "motion_workflow.create_simple_workflow",
             {"name": "test_Xcdfgee", "meeting_id": 42},
         )
         self.assert_status_code(response, 200)
         self.assert_model_exists(
-            "motion_workflow/1", {"name": "test_Xcdfgee", "first_state_id": 1}
+            "motion_workflow/43", {"name": "test_Xcdfgee", "first_state_id": 43}
         )
         self.assert_model_exists(
-            "motion_state/1",
-            {"name": "submitted", "weight": 1, "next_state_ids": [2, 3, 4]},
+            "motion_state/43",
+            {"name": "submitted", "weight": 1, "next_state_ids": [44, 45, 46]},
         )
         self.assert_model_exists(
-            "motion_state/2",
+            "motion_state/44",
             {
                 "name": "accepted",
                 "weight": 2,
-                "previous_state_ids": [1],
+                "previous_state_ids": [43],
                 "meeting_id": 42,
-                "workflow_id": 1,
+                "workflow_id": 43,
             },
         )
         self.assert_model_exists(
-            "motion_state/3",
-            {"name": "rejected", "weight": 3, "previous_state_ids": [1]},
+            "motion_state/45",
+            {"name": "rejected", "weight": 3, "previous_state_ids": [43]},
         )
         self.assert_model_exists(
-            "motion_state/4",
-            {"name": "not decided", "weight": 4, "previous_state_ids": [1]},
+            "motion_state/46",
+            {"name": "not decided", "weight": 4, "previous_state_ids": [43]},
         )
 
     def test_create_no_permissions(self) -> None:

--- a/tests/system/action/motion_workflow/test_delete.py
+++ b/tests/system/action/motion_workflow/test_delete.py
@@ -1,200 +1,75 @@
+from typing import Any
+
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
 
 class MotionWorkflowSystemTest(BaseActionTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.create_meeting()
+        self.workflow2: dict[str, dict[str, Any]] = {
+            "motion_workflow/2": {
+                "name": "workflow 2",
+                "meeting_id": 1,
+                "sequential_number": 2,
+                "first_state_id": 2,
+            },
+            "motion_state/2": {
+                "name": "state of workflow 2",
+                "workflow_id": 2,
+                "meeting_id": 1,
+                "weight": 2,
+            },
+        }
+
     def test_delete_correct(self) -> None:
-        self.set_models(
-            {
-                "meeting/90": {
-                    "name": "name_testtest",
-                    "motions_default_workflow_id": 12,
-                    "motion_workflow_ids": [111, 2],
-                    "is_active_in_organization_id": 1,
-                    "committee_id": 1,
-                },
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 90},
-                "motion_workflow/2": {"meeting_id": 90},
-            }
-        )
-        response = self.request("motion_workflow.delete", {"id": 111})
-        self.assert_status_code(response, 200)
-        self.assert_model_not_exists("motion_workflow/111")
-
-    def test_delete_with_states(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {
-                    "motion_workflow_ids": [2, 100],
-                    "is_active_in_organization_id": 1,
-                    "committee_id": 1,
-                },
-                "motion_workflow/2": {"meeting_id": 1, "state_ids": [3]},
-                "motion_state/3": {"workflow_id": 2, "meeting_id": 1},
-                "motion_workflow/100": {"meeting_id": 1},
-            }
-        )
+        self.set_models(self.workflow2)
         response = self.request("motion_workflow.delete", {"id": 2})
         self.assert_status_code(response, 200)
         self.assert_model_not_exists("motion_workflow/2")
-        self.assert_model_not_exists("motion_state/3")
-
-    def test_delete_with_first_state(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {
-                    "motion_workflow_ids": [2, 100],
-                    "is_active_in_organization_id": 1,
-                    "committee_id": 1,
-                },
-                "motion_workflow/2": {
-                    "meeting_id": 1,
-                    "state_ids": [3],
-                    "first_state_id": 3,
-                },
-                "motion_state/3": {
-                    "workflow_id": 2,
-                    "first_state_of_workflow_id": 2,
-                    "meeting_id": 1,
-                },
-                "motion_workflow/100": {"meeting_id": 1},
-            }
-        )
-        response = self.request("motion_workflow.delete", {"id": 2})
-        self.assert_status_code(response, 200)
-        self.assert_model_not_exists("motion_workflow/2")
-        self.assert_model_not_exists("motion_state/3")
+        self.assert_model_not_exists("motion_state/2")
 
     def test_delete_wrong_id(self) -> None:
-        self.create_model("motion_workflow/112", {"name": "name_srtgb123"})
-        response = self.request("motion_workflow.delete", {"id": 111})
+        response = self.request("motion_workflow.delete", {"id": 2})
         self.assert_status_code(response, 400)
-        self.assert_model_exists("motion_workflow/112")
-
-    def test_delete_fail_case_default_1(self) -> None:
-        self.set_models(
-            {
-                "meeting/90": {
-                    "name": "name_testtest",
-                    "motions_default_workflow_id": 111,
-                    "motion_workflow_ids": [111],
-                    "is_active_in_organization_id": 1,
-                    "committee_id": 1,
-                },
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 90},
-            }
+        self.assertEqual(
+            "Model 'motion_workflow/2' does not exist.", response.json["message"]
         )
-        response = self.request("motion_workflow.delete", {"id": 111})
+
+    def test_delete_fail_default_motion_workflow(self) -> None:
+        self.set_models(self.workflow2)
+        response = self.request("motion_workflow.delete", {"id": 1})
         self.assert_status_code(response, 400)
-        self.assert_model_exists("motion_workflow/111")
+        self.assert_model_exists("motion_workflow/1")
         self.assertIn(
             "You cannot delete the workflow as long as it is selected as default workflow for new motions in the settings.",
             response.json["message"],
         )
 
-    def test_delete_fail_case_default_2(self) -> None:
-        self.set_models(
-            {
-                "meeting/90": {
-                    "name": "name_testtest",
-                    "motions_default_workflow_id": 12,
-                    "motion_workflow_ids": [111],
-                    "is_active_in_organization_id": 1,
-                    "committee_id": 1,
-                },
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 90},
-            }
-        )
-        response = self.request("motion_workflow.delete", {"id": 111})
+    def test_delete_fail_default_amendment_workflow(self) -> None:
+        self.set_models(self.workflow2)
+        self.set_models({"meeting/1": {"motions_default_amendment_workflow_id": 2}})
+        response = self.request("motion_workflow.delete", {"id": 2})
         self.assert_status_code(response, 400)
-        self.assert_model_exists("motion_workflow/111")
-        self.assertIn(
-            "You cannot delete the last workflow of a meeting.",
-            response.json["message"],
-        )
-
-    def test_delete_fail_case_default_3(self) -> None:
-        self.set_models(
-            {
-                "meeting/90": {
-                    "name": "name_testtest",
-                    "motions_default_workflow_id": 12,
-                    "motions_default_amendment_workflow_id": 111,
-                    "motion_workflow_ids": [111],
-                    "is_active_in_organization_id": 1,
-                    "committee_id": 1,
-                },
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 90},
-            }
-        )
-        response = self.request("motion_workflow.delete", {"id": 111})
-        self.assert_status_code(response, 400)
-        self.assert_model_exists("motion_workflow/111")
+        self.assert_model_exists("motion_workflow/2")
         self.assertIn(
             "You cannot delete the workflow as long as it is selected as default workflow for new amendments in the settings.",
             response.json["message"],
         )
 
-    def test_delete_last_workflow(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {
-                    "motion_workflow_ids": [1],
-                    "is_active_in_organization_id": 1,
-                    "committee_id": 1,
-                },
-                "motion_workflow/1": {"meeting_id": 1},
-            }
-        )
-        response = self.request("motion_workflow.delete", {"id": 1})
-        self.assert_status_code(response, 400)
-        self.assert_model_exists("motion_workflow/1")
-
     def test_delete_no_permissions(self) -> None:
-        self.base_permission_test(
-            {
-                "meeting/1": {
-                    "name": "name_testtest",
-                    "motions_default_workflow_id": 12,
-                    "motion_workflow_ids": [111, 2],
-                    "is_active_in_organization_id": 1,
-                },
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 1},
-                "motion_workflow/2": {"meeting_id": 1},
-            },
-            "motion_workflow.delete",
-            {"id": 111},
-        )
+        self.set_models(self.workflow2)
+        self.base_permission_test({}, "motion_workflow.delete", {"id": 2})
 
     def test_delete_permissions(self) -> None:
+        self.set_models(self.workflow2)
         self.base_permission_test(
-            {
-                "meeting/1": {
-                    "name": "name_testtest",
-                    "motions_default_workflow_id": 12,
-                    "motion_workflow_ids": [111, 2],
-                    "is_active_in_organization_id": 1,
-                },
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 1},
-                "motion_workflow/2": {"meeting_id": 1},
-            },
-            "motion_workflow.delete",
-            {"id": 111},
-            Permissions.Motion.CAN_MANAGE,
+            {}, "motion_workflow.delete", {"id": 2}, Permissions.Motion.CAN_MANAGE
         )
 
     def test_delete_permissions_locked_meeting(self) -> None:
+        self.set_models(self.workflow2)
         self.base_locked_out_superadmin_permission_test(
-            {
-                "meeting/1": {
-                    "name": "name_testtest",
-                    "motions_default_workflow_id": 12,
-                    "motion_workflow_ids": [111, 2],
-                    "is_active_in_organization_id": 1,
-                },
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 1},
-                "motion_workflow/2": {"meeting_id": 1},
-            },
-            "motion_workflow.delete",
-            {"id": 111},
+            {}, "motion_workflow.delete", {"id": 2}
         )

--- a/tests/system/action/motion_workflow/test_import.py
+++ b/tests/system/action/motion_workflow/test_import.py
@@ -4,6 +4,10 @@ from tests.system.action.base import BaseActionTestCase
 
 
 class MotionWorkflowImport(BaseActionTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.create_meeting(42)
+
     def get_state(
         self,
         name: str,
@@ -32,14 +36,6 @@ class MotionWorkflowImport(BaseActionTestCase):
         }
 
     def test_import_simple_case(self) -> None:
-        self.create_model(
-            "meeting/42",
-            {
-                "name": "test_name_fsdksjdfhdsfssdf",
-                "is_active_in_organization_id": 1,
-                "committee_id": 1,
-            },
-        )
         response = self.request(
             "motion_workflow.import",
             {
@@ -53,19 +49,19 @@ class MotionWorkflowImport(BaseActionTestCase):
         )
         self.assert_status_code(response, 200)
         self.assert_model_exists(
-            "motion_workflow/1",
+            "motion_workflow/43",
             {
                 "name": "test_Xcdfgee",
-                "first_state_id": 1,
-                "sequential_number": 1,
+                "first_state_id": 43,
+                "sequential_number": 43,
             },
         )
         self.assert_model_exists(
-            "motion_state/1",
+            "motion_state/43",
             {
-                "workflow_id": 1,
+                "workflow_id": 43,
                 "name": "begin",
-                "first_state_of_workflow_id": 1,
+                "first_state_of_workflow_id": 43,
                 "weight": 1,
                 "set_workflow_timestamp": True,
                 "allow_motion_forwarding": True,
@@ -74,14 +70,6 @@ class MotionWorkflowImport(BaseActionTestCase):
         )
 
     def test_import_one_state_no_first_state_name(self) -> None:
-        self.create_model(
-            "meeting/42",
-            {
-                "name": "test_name_fsdksjdfhdsfssdf",
-                "is_active_in_organization_id": 1,
-                "committee_id": 1,
-            },
-        )
         response = self.request(
             "motion_workflow.import",
             {
@@ -93,26 +81,15 @@ class MotionWorkflowImport(BaseActionTestCase):
         )
         self.assert_status_code(response, 200)
         self.assert_model_exists(
-            "motion_workflow/1",
-            {
-                "name": "test_Xcdfgee",
-                "first_state_id": 1,
-            },
+            "motion_workflow/43",
+            {"name": "test_Xcdfgee", "first_state_id": 43},
         )
         self.assert_model_exists(
-            "motion_state/1",
-            {"workflow_id": 1, "name": "begin", "first_state_of_workflow_id": 1},
+            "motion_state/43",
+            {"workflow_id": 43, "name": "begin", "first_state_of_workflow_id": 43},
         )
 
     def test_import_missing_state(self) -> None:
-        self.create_model(
-            "meeting/42",
-            {
-                "name": "test_name_fsdksjdfhdsfssdf",
-                "is_active_in_organization_id": 1,
-                "committee_id": 1,
-            },
-        )
         response = self.request(
             "motion_workflow.import",
             {
@@ -123,20 +100,12 @@ class MotionWorkflowImport(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 400)
-        assert (
-            "Some state names in first_state_name or next_state_names or previous_state_names are not found in the state list."
-            in response.json["message"]
+        self.assertEqual(
+            "Some state names in first_state_name or next_state_names or previous_state_names are not found in the state list.",
+            response.json["message"],
         )
 
     def test_import_missing_state_next(self) -> None:
-        self.create_model(
-            "meeting/42",
-            {
-                "name": "test_name_fsdksjdfhdsfssdf",
-                "is_active_in_organization_id": 1,
-                "committee_id": 1,
-            },
-        )
         response = self.request(
             "motion_workflow.import",
             {
@@ -147,20 +116,12 @@ class MotionWorkflowImport(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 400)
-        assert (
-            "Some state names in first_state_name or next_state_names or previous_state_names are not found in the state list."
-            in response.json["message"]
+        self.assertEqual(
+            "Some state names in first_state_name or next_state_names or previous_state_names are not found in the state list.",
+            response.json["message"],
         )
 
     def test_import_missing_state_previous(self) -> None:
-        self.create_model(
-            "meeting/42",
-            {
-                "name": "test_name_fsdksjdfhdsfssdf",
-                "is_active_in_organization_id": 1,
-                "committee_id": 1,
-            },
-        )
         response = self.request(
             "motion_workflow.import",
             {
@@ -171,20 +132,12 @@ class MotionWorkflowImport(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 400)
-        assert (
-            "Some state names in first_state_name or next_state_names or previous_state_names are not found in the state list."
-            in response.json["message"]
+        self.assertEqual(
+            "Some state names in first_state_name or next_state_names or previous_state_names are not found in the state list.",
+            response.json["message"],
         )
 
     def test_import_next_previous_states(self) -> None:
-        self.create_model(
-            "meeting/42",
-            {
-                "name": "test_name_fsdksjdfhdsfssdf",
-                "is_active_in_organization_id": 1,
-                "committee_id": 1,
-            },
-        )
         response = self.request(
             "motion_workflow.import",
             {
@@ -201,62 +154,54 @@ class MotionWorkflowImport(BaseActionTestCase):
         )
         self.assert_status_code(response, 200)
         self.assert_model_exists(
-            "motion_workflow/1",
+            "motion_workflow/43",
             {
                 "name": "test_Xcdfgee",
-                "first_state_id": 1,
+                "first_state_id": 43,
             },
         )
         self.assert_model_exists(
-            "motion_state/1",
+            "motion_state/43",
             {
-                "workflow_id": 1,
+                "workflow_id": 43,
                 "name": "begin",
-                "first_state_of_workflow_id": 1,
-                "next_state_ids": [2, 3],
+                "first_state_of_workflow_id": 43,
+                "next_state_ids": [44, 45],
                 "weight": 10,
             },
         )
         self.assert_model_exists(
-            "motion_state/2",
+            "motion_state/44",
             {
-                "workflow_id": 1,
+                "workflow_id": 43,
                 "name": "edit",
-                "next_state_ids": [4],
-                "previous_state_ids": [1],
+                "next_state_ids": [46],
+                "previous_state_ids": [43],
                 "weight": 11,
             },
         )
         self.assert_model_exists(
-            "motion_state/3",
+            "motion_state/45",
             {
-                "workflow_id": 1,
+                "workflow_id": 43,
                 "name": "read",
-                "next_state_ids": [],
-                "previous_state_ids": [1],
+                "next_state_ids": None,
+                "previous_state_ids": [43],
                 "weight": 12,
             },
         )
         self.assert_model_exists(
-            "motion_state/4",
+            "motion_state/46",
             {
-                "workflow_id": 1,
+                "workflow_id": 43,
                 "name": "end",
-                "next_state_ids": [],
-                "previous_state_ids": [2],
+                "next_state_ids": None,
+                "previous_state_ids": [44],
                 "weight": 13,
             },
         )
 
     def test_import_wrong_prev_state(self) -> None:
-        self.create_model(
-            "meeting/42",
-            {
-                "name": "test_name_fsdksjdfhdsfssdf",
-                "is_active_in_organization_id": 1,
-                "committee_id": 1,
-            },
-        )
         response = self.request(
             "motion_workflow.import",
             {
@@ -272,17 +217,11 @@ class MotionWorkflowImport(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 400)
-        assert "State begin is not in previous of edit." in response.json["message"]
+        self.assertEqual(
+            "State begin is not in previous of edit.", response.json["message"]
+        )
 
     def test_import_wrong_next_state(self) -> None:
-        self.create_model(
-            "meeting/42",
-            {
-                "name": "test_name_fsdksjdfhdsfssdf",
-                "is_active_in_organization_id": 1,
-                "committee_id": 1,
-            },
-        )
         response = self.request(
             "motion_workflow.import",
             {
@@ -298,4 +237,6 @@ class MotionWorkflowImport(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 400)
-        assert "State edit is not in next of begin." in response.json["message"]
+        self.assertEqual(
+            "State edit is not in next of begin.", response.json["message"]
+        )

--- a/tests/system/action/motion_workflow/test_update.py
+++ b/tests/system/action/motion_workflow/test_update.py
@@ -3,59 +3,42 @@ from tests.system.action.base import BaseActionTestCase
 
 
 class MotionWorkflowSystemTest(BaseActionTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.create_meeting()
+        self.set_models({"motion_workflow/1": {"name": "name_srtgb123"}})
+
     def test_update_correct(self) -> None:
-        self.set_models(
-            {
-                "meeting/10": {"is_active_in_organization_id": 1, "committee_id": 1},
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 10},
-            }
-        )
         response = self.request(
-            "motion_workflow.update", {"id": 111, "name": "name_Xcdfgee"}
+            "motion_workflow.update", {"id": 1, "name": "name_Xcdfgee"}
         )
         self.assert_status_code(response, 200)
-        self.assert_model_exists("motion_workflow/111")
-        model = self.get_model("motion_workflow/111")
-        assert model.get("name") == "name_Xcdfgee"
+        self.assert_model_exists("motion_workflow/1", {"name": "name_Xcdfgee"})
 
     def test_update_wrong_id(self) -> None:
-        self.set_models(
-            {
-                "meeting/10": {"is_active_in_organization_id": 1, "committee_id": 1},
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 10},
-            }
-        )
         response = self.request(
-            "motion_workflow.update", {"id": 112, "name": "name_Xcdfgee"}
+            "motion_workflow.update", {"id": 2, "name": "name_Xcdfgee"}
         )
         self.assert_status_code(response, 400)
-        model = self.get_model("motion_workflow/111")
-        assert model.get("name") == "name_srtgb123"
+        self.assert_model_exists("motion_workflow/1", {"name": "name_srtgb123"})
+        self.assertEqual(
+            "Model 'motion_workflow/2' does not exist.", response.json["message"]
+        )
 
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(
-            {
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 1},
-            },
-            "motion_workflow.update",
-            {"id": 111, "name": "name_Xcdfgee"},
+            {}, "motion_workflow.update", {"id": 1, "name": "name_Xcdfgee"}
         )
 
     def test_update_permissions(self) -> None:
         self.base_permission_test(
-            {
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 1},
-            },
+            {},
             "motion_workflow.update",
-            {"id": 111, "name": "name_Xcdfgee"},
+            {"id": 1, "name": "name_Xcdfgee"},
             Permissions.Motion.CAN_MANAGE,
         )
 
     def test_update_permissions_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            {
-                "motion_workflow/111": {"name": "name_srtgb123", "meeting_id": 1},
-            },
-            "motion_workflow.update",
-            {"id": 111, "name": "name_Xcdfgee"},
+            {}, "motion_workflow.update", {"id": 1, "name": "name_Xcdfgee"}
         )


### PR DESCRIPTION
**Deleted tests:**
* motion_workflow.test_delete:
    * `test_delete_with_states`, `test_delete_with_first_state`: after fixing test_data inconsistencies they became the duplicates of `test_delete_correct`, since `first_state_id` is a required unique field of `motion_workflow`
    * `test_delete_fail_case_default_2`: `motions_default_workflow_id` is a required field of the meeting, so described validation is unreachable in the db with consistent data. Also deleted the corresponding check in the action code
    * `test_delete_last_workflow`: looks like it was the duplicate of `test_delete_fail_case_default_2` and describes the case not possible in consistent db

**Renamed** `test_delete_fail_case_default_1` and `test_delete_fail_case_default_3` to make the names more descriptive.

**TODO** (together with similarly failing meeting and motion tests): `motion_change_recommendation.delete test_delete_correct`. Fails on self.events.extend(events) (updating history step).

3 more collections (`motion_editor`, `motion_submitter`, `motion_working_group_speaker`) will be handled in a separate PR, since their test classes extend not BaseActionTestCase directly but it's extended version. It would make sence to handle them together separately from the other collections.