### PR TITLE
[rel-db] Complete tag and theme tests

### DIFF
--- a/tests/system/action/tag/test_create.py
+++ b/tests/system/action/tag/test_create.py
@@ -8,15 +8,13 @@ class TagActionTest(BaseActionTestCase):
             "tag.create", {"name": "test_Xcdfgee", "meeting_id": 577}
         )
         self.assert_status_code(response, 200)
-        model = self.get_model("tag/1")
-        self.assertEqual(model.get("name"), "test_Xcdfgee")
-        self.assertEqual(model.get("meeting_id"), 577)
+        self.assert_model_exists("tag/1", {"name": "test_Xcdfgee", "meeting_id": 577})
 
     def test_create_empty_data(self) -> None:
         response = self.request("tag.create", {})
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must contain ['meeting_id', 'name'] properties",
+        self.assertEqual(
+            "Action tag.create: data must contain ['meeting_id', 'name'] properties",
             response.json["message"],
         )
 
@@ -31,8 +29,8 @@ class TagActionTest(BaseActionTestCase):
             },
         )
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must not contain {'wrong_field'} properties",
+        self.assertEqual(
+            "Action tag.create: data must not contain {'wrong_field'} properties",
             response.json["message"],
         )
 
@@ -44,7 +42,7 @@ class TagActionTest(BaseActionTestCase):
         )
         self.assert_status_code(response, 403)
         self.assert_model_not_exists("tag/1")
-        self.assertIn(
+        self.assertEqual(
             "You are not allowed to perform action tag.create. Missing Permission: tag.can_manage",
             response.json["message"],
         )

--- a/tests/system/action/tag/test_delete.py
+++ b/tests/system/action/tag/test_delete.py
@@ -2,44 +2,30 @@ from tests.system.action.base import BaseActionTestCase
 
 
 class TagDeleteTest(BaseActionTestCase):
-    def test_delete_correct(self) -> None:
+    def setUp(self) -> None:
+        super().setUp()
         self.create_meeting()
-        self.set_models(
-            {
-                "meeting/1": {"tag_ids": [111]},
-                "tag/111": {"name": "name_srtgb123", "meeting_id": 1},
-            }
-        )
+        self.set_models({"tag/111": {"name": "name_srtgb123", "meeting_id": 1}})
+
+    def test_delete_correct(self) -> None:
         response = self.request("tag.delete", {"id": 111})
         self.assert_status_code(response, 200)
-        self.assert_model_not_exists("tag/112")
+        self.assert_model_not_exists("tag/111")
 
     def test_delete_wrong_id(self) -> None:
-        self.create_meeting()
-        self.set_models(
-            {
-                "meeting/1": {"tag_ids": [112]},
-                "tag/112": {"name": "name_srtgb123", "meeting_id": 1},
-            }
-        )
-        response = self.request("tag.delete", {"id": 111})
+        response = self.request("tag.delete", {"id": 112})
         self.assert_status_code(response, 400)
-        self.assert_model_exists("tag/112")
+        self.assert_model_exists("tag/111")
 
     def test_delete_correct_2(self) -> None:
-        self.create_meeting()
+        self.create_motion(1)
         self.set_models(
             {
-                "meeting/1": {"tag_ids": [111]},
-                "tag/111": {
-                    "name": "name_srtgb123",
-                    "meeting_id": 1,
-                    "tagged_ids": ["agenda_item/222"],
-                },
                 "agenda_item/222": {
                     "comment": "test_comment_ertgd590854398",
                     "tag_ids": [111],
                     "meeting_id": 1,
+                    "content_object_id": "motion/1",
                 },
             }
         )
@@ -50,8 +36,8 @@ class TagDeleteTest(BaseActionTestCase):
             "agenda_item/222",
             {
                 "id": 222,
-                "meta_deleted": False,
                 "comment": "test_comment_ertgd590854398",
-                "tag_ids": [],
+                "tag_ids": None,
+                "content_object_id": "motion/1",
             },
         )

--- a/tests/system/action/tag/test_update.py
+++ b/tests/system/action/tag/test_update.py
@@ -2,28 +2,17 @@ from tests.system.action.base import BaseActionTestCase
 
 
 class TagActionTest(BaseActionTestCase):
-    def test_update_correct(self) -> None:
+    def setUp(self) -> None:
+        super().setUp()
         self.create_meeting()
-        self.set_models(
-            {
-                "meeting/1": {"tag_ids": [111]},
-                "tag/111": {"name": "name_srtgb123", "meeting_id": 1},
-            }
-        )
+        self.set_models({"tag/111": {"name": "name_srtgb123", "meeting_id": 1}})
+
+    def test_update_correct(self) -> None:
         response = self.request("tag.update", {"id": 111, "name": "name_Xcdfgee"})
         self.assert_status_code(response, 200)
-        model = self.get_model("tag/111")
-        self.assertEqual(model.get("name"), "name_Xcdfgee")
+        self.assert_model_exists("tag/111", {"name": "name_Xcdfgee"})
 
     def test_update_wrong_id(self) -> None:
-        self.create_meeting()
-        self.set_models(
-            {
-                "meeting/1": {"tag_ids": [111]},
-                "tag/111": {"name": "name_srtgb123", "meeting_id": 1},
-            }
-        )
         response = self.request("tag.update", {"id": 112, "name": "name_Xcdfgee"})
         self.assert_status_code(response, 400)
-        model = self.get_model("tag/111")
-        self.assertEqual(model.get("name"), "name_srtgb123")
+        self.assert_model_exists("tag/111", {"name": "name_srtgb123"})

--- a/tests/system/action/theme/test_create.py
+++ b/tests/system/action/theme/test_create.py
@@ -15,7 +15,7 @@ class ThemeCreateActionTest(BaseActionTestCase):
         )
         self.assert_status_code(response, 200)
         self.assert_model_exists(
-            "theme/1",
+            "theme/2",
             {
                 "name": "test_Xcdfgee",
                 "primary_500": "#111222",
@@ -41,7 +41,7 @@ class ThemeCreateActionTest(BaseActionTestCase):
         )
         self.assert_status_code(response, 200)
         self.assert_model_exists(
-            "theme/1",
+            "theme/2",
             {
                 "name": "test_Xcdfgee",
                 "primary_500": "#111222",
@@ -58,8 +58,8 @@ class ThemeCreateActionTest(BaseActionTestCase):
     def test_create_empty_data(self) -> None:
         response = self.request("theme.create", {})
         self.assert_status_code(response, 400)
-        self.assertIn(
-            "data must contain ['accent_500', 'name', 'primary_500', 'warn_500'] properties",
+        self.assertEqual(
+            "Action theme.create: data must contain ['accent_500', 'name', 'primary_500', 'warn_500'] properties",
             response.json["message"],
         )
 

--- a/tests/system/action/theme/test_delete.py
+++ b/tests/system/action/theme/test_delete.py
@@ -1,71 +1,39 @@
-from openslides_backend.shared.util import ONE_ORGANIZATION_FQID
+from openslides_backend.permissions.management_levels import OrganizationManagementLevel
 from tests.system.action.base import BaseActionTestCase
 
 
 class ThemeDeleteActionTest(BaseActionTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.theme_2 = {"theme/2": {"name": "OpenSlides Test", "organization_id": 1}}
+
     def test_delete_correct(self) -> None:
-        self.set_models(
-            {
-                ONE_ORGANIZATION_FQID: {
-                    "theme_id": 2,
-                    "theme_ids": [1, 2],
-                },
-                "theme/1": {
-                    "name": "test",
-                    "primary_500": "#000000",
-                    "organization_id": 1,
-                    "theme_for_organization_id": None,
-                },
-                "theme/2": {
-                    "name": "OpenSlides Test",
-                    "organization_id": 1,
-                    "theme_for_organization_id": 1,
-                },
-            },
-        )
-        response = self.request("theme.delete", {"id": 1})
+        self.set_models(self.theme_2)
+        response = self.request("theme.delete", {"id": 2})
         self.assert_status_code(response, 200)
-        self.assert_model_not_exists("theme/1")
+        self.assert_model_not_exists("theme/2")
 
     def test_delete_fail_to_delete_theme_from_orga(self) -> None:
-        self.set_models(
-            {
-                ONE_ORGANIZATION_FQID: {"theme_ids": [1], "theme_id": 1},
-                "theme/1": {
-                    "name": "test",
-                    "organization_id": 1,
-                    "theme_for_organization_id": 1,
-                },
-            }
-        )
         response = self.request("theme.delete", {"id": 1})
         self.assert_status_code(response, 400)
-        assert (
-            "Update of organization/1: You try to set following required fields to an empty value: ['theme_id']"
-            in response.json["message"]
+        self.assertEqual(
+            "Update of organization/1: You try to set following required fields to an empty value: ['theme_id']",
+            response.json["message"],
         )
 
     def test_no_permission(self) -> None:
-        self.set_models(
-            {
-                "user/1": {"organization_management_level": "can_manage_users"},
-                "theme/1": {"name": "test", "primary_500": "#000000"},
-            }
-        )
-        response = self.request("theme.delete", {"id": 1})
-        self.assert_status_code(response, 403)
-        assert (
-            "You are not allowed to perform action theme.delete. Missing OrganizationManagementLevel: can_manage_organization"
-            in response.json["message"]
+        self.base_permission_test(
+            self.theme_2,
+            "theme.delete",
+            {"id": 2},
+            OrganizationManagementLevel.CAN_MANAGE_USERS,
+            fail=True,
         )
 
     def test_permission(self) -> None:
-        self.set_models(
-            {
-                "user/1": {"organization_management_level": "can_manage_organization"},
-                "theme/1": {"name": "test", "primary_500": "#000000"},
-            }
+        self.base_permission_test(
+            self.theme_2,
+            "theme.delete",
+            {"id": 2},
+            OrganizationManagementLevel.CAN_MANAGE_ORGANIZATION,
         )
-        response = self.request("theme.delete", {"id": 1})
-        self.assert_status_code(response, 200)
-        self.assert_model_not_exists("theme/1")

--- a/tests/system/action/theme/test_update.py
+++ b/tests/system/action/theme/test_update.py
@@ -1,9 +1,9 @@
+from openslides_backend.permissions.management_levels import OrganizationManagementLevel
 from tests.system.action.base import BaseActionTestCase
 
 
 class ThemeUpdateActionTest(BaseActionTestCase):
     def test_update_correct(self) -> None:
-        self.set_models({"theme/1": {"name": "old"}})
         response = self.request(
             "theme.update", {"id": 1, "name": "test", "primary_500": "#121212"}
         )
@@ -11,7 +11,6 @@ class ThemeUpdateActionTest(BaseActionTestCase):
         self.assert_model_exists("theme/1", {"name": "test", "primary_500": "#121212"})
 
     def test_update_opt_fields_correct(self) -> None:
-        self.set_models({"theme/1": {"name": "old"}})
         response = self.request(
             "theme.update",
             {
@@ -36,30 +35,18 @@ class ThemeUpdateActionTest(BaseActionTestCase):
         )
 
     def test_no_permission(self) -> None:
-        self.set_models(
-            {
-                "user/1": {"organization_management_level": "can_manage_users"},
-                "theme/1": {"name": "test", "primary_500": "#000000"},
-            }
-        )
-        response = self.request(
-            "theme.update", {"id": 1, "name": "test", "primary_500": "#121212"}
-        )
-        self.assert_status_code(response, 403)
-        assert (
-            "You are not allowed to perform action theme.update. Missing OrganizationManagementLevel: can_manage_organization"
-            in response.json["message"]
+        self.base_permission_test(
+            {},
+            "theme.update",
+            {"id": 1, "name": "test"},
+            OrganizationManagementLevel.CAN_MANAGE_USERS,
+            fail=True,
         )
 
     def test_permission(self) -> None:
-        self.set_models(
-            {
-                "user/1": {"organization_management_level": "can_manage_organization"},
-                "theme/1": {"name": "old", "primary_500": "#000000"},
-            }
+        self.base_permission_test(
+            {},
+            "theme.update",
+            {"id": 1, "name": "test"},
+            OrganizationManagementLevel.CAN_MANAGE_ORGANIZATION,
         )
-        response = self.request(
-            "theme.update", {"id": 1, "name": "test", "primary_500": "#121212"}
-        )
-        self.assert_status_code(response, 200)
-        self.assert_model_exists("theme/1", {"name": "test", "primary_500": "#121212"})


### PR DESCRIPTION
Since `theme/1` is set in `BaseSystemTestCase.setUp`, I was able to remove any `set_models` calls for this model.