### PR TITLE
[rel-db] cleanup fix base action test case

### DIFF
--- a/tests/system/action/base.py
+++ b/tests/system/action/base.py
@@ -182,19 +182,14 @@ class BaseActionTestCase(BaseSystemTestCase):
             parent_fqid = f"committee/{parent_id}"
             parent = self.datastore.get(
                 parent_fqid,
-                ["all_parent_ids", "all_child_ids", "child_ids"],
+                ["all_parent_ids", "all_child_ids"],
                 lock_result=False,
                 use_changed_models=False,
             )
             data[parent_fqid] = {
-                "child_ids": [*parent.get("child_ids", []), committee_id],
                 "all_child_ids": [*parent.get("all_child_ids", []), committee_id],
             }
             data[committee_fqid]["parent_id"] = parent_id
-            data[committee_fqid]["all_parent_ids"] = [
-                *parent.get("all_parent_ids", []),
-                parent_id,
-            ]
             if grandparent_ids := parent.get("all_parent_ids", []):
                 grandparents = self.datastore.get_many(
                     [GetManyRequest("committee", grandparent_ids, ["all_child_ids"])],
@@ -292,18 +287,15 @@ class BaseActionTestCase(BaseSystemTestCase):
     ) -> int:
         """Also creates an anonymous group at the next-highest free group_id"""
         next_group_id = self.datastore.reserve_id("group")
-        group_ids = self.get_model(f"meeting/{meeting_id}").get("group_ids", [])
         self.set_models(
             {
                 f"meeting/{meeting_id}": {
                     "enable_anonymous": enable,
-                    "group_ids": [*group_ids, next_group_id],
                     "anonymous_group_id": next_group_id,
                 },
                 f"group/{next_group_id}": {
                     "name": "Anonymous",
                     "meeting_id": meeting_id,
-                    "anonymous_group_for_meeting_id": meeting_id,
                     "permissions": permissions,
                 },
             }
@@ -403,16 +395,9 @@ class BaseActionTestCase(BaseSystemTestCase):
         return id
 
     def set_home_committee(self, user_id: int, home_committee_id: int) -> None:
-        home_fqid = f"committee/{home_committee_id}"
-        committee = self.datastore.get(
-            home_fqid, ["native_user_ids"], lock_result=False
-        )
         self.set_models(
             {
                 f"user/{user_id}": {"home_committee_id": home_committee_id},
-                home_fqid: {
-                    "native_user_ids": [*committee.get("native_user_ids", []), user_id]
-                },
             }
         )
 
@@ -431,21 +416,6 @@ class BaseActionTestCase(BaseSystemTestCase):
 
     def create_user_for_meeting(self, meeting_id: int) -> int:
         meeting = self.get_model(f"meeting/{meeting_id}")
-        if not meeting.get("default_group_id"):
-            id = self.datastore.reserve_id("group")
-            self.set_models(
-                {
-                    f"meeting/{meeting_id}": {
-                        "group_ids": meeting.get("group_ids", []) + [id],
-                        "default_group_id": id,
-                    },
-                    f"group/{id}": {
-                        "meeting_id": meeting_id,
-                        "default_group_for_meeting_id": meeting_id,
-                    },
-                }
-            )
-            meeting["default_group_id"] = id
         user_id = self.create_user("user_" + get_random_string(6))
         self.set_user_groups(user_id, [meeting["default_group_id"]])
         return user_id
@@ -453,32 +423,48 @@ class BaseActionTestCase(BaseSystemTestCase):
     # @with_database_context
     def set_user_groups(self, user_id: int, group_ids: list[int]) -> list[int]:
         """
-        Sets the users groups and corresponding meeting_users and meeting_ids.
+        Sets the groups in corresponding meeting_users and creates new ones if not existent.
         Returns the meeting_user_ids.
         """
         assert isinstance(group_ids, list)
+        current_meeting_users = self.datastore.filter(
+            "meeting_user",
+            FilterOperator("user_id", "=", user_id),
+            ["id", "user_id", "meeting_id", "group_ids"],
+            lock_result=False,
+        )
+        request_group_ids = set(group_ids)
+        for mu in current_meeting_users.values():
+            if mu_group_ids := mu["group_ids"]:
+                request_group_ids.update(mu_group_ids)
         groups = self.datastore.get_many(
             [
                 GetManyRequest(
                     "group",
-                    group_ids,
+                    list(request_group_ids),
                     ["id", "meeting_id", "meeting_user_ids"],
                 )
             ],
             lock_result=False,
         )["group"]
-        meeting_ids: list[int] = list({v["meeting_id"] for v in groups.values()})
-        filtered_result = self.datastore.filter(
-            "meeting_user",
-            FilterOperator("user_id", "=", user_id),
-            ["id", "user_id", "meeting_id"],
-            lock_result=False,
+        meeting_ids: list[int] = list(
+            {v["meeting_id"] for v in groups.values() if v["id"] in group_ids}
         )
         meeting_users: dict[int, dict[str, Any]] = {
-            data["meeting_id"]: dict(data)
-            for data in filtered_result.values()
+            data["meeting_id"]: data
+            for data in current_meeting_users.values()
             if data["meeting_id"] in meeting_ids
         }
+        # reset meeting_users that aren't part of any by group_ids related meetings.
+        for group in groups.values():
+            # find difference with meetings
+            if group["meeting_id"] not in meeting_users and (
+                meeting_user_ids := group.get("meeting_user_ids")
+            ):
+                for meeting_user_id in meeting_user_ids:
+                    # remove intersection with user
+                    if meeting_user_id in current_meeting_users:
+                        meeting_user_ids.remove(meeting_user_id)
         last_meeting_user_id = max(
             [
                 int(k[1])
@@ -487,7 +473,7 @@ class BaseActionTestCase(BaseSystemTestCase):
             ]
             or [0]
         )
-        meeting_users_new = {
+        if meeting_users_new := {
             meeting_id: {
                 "id": (last_meeting_user_id := last_meeting_user_id + 1),  # noqa: F841
                 "user_id": user_id,
@@ -495,47 +481,29 @@ class BaseActionTestCase(BaseSystemTestCase):
             }
             for meeting_id in meeting_ids
             if meeting_id not in meeting_users
-        }
-        meeting_users.update(meeting_users_new)
-        meetings = self.datastore.get_many(
-            [
-                GetManyRequest(
-                    "meeting",
-                    meeting_ids,
-                    ["id", "meeting_user_ids"],
-                )
-            ],
-            lock_result=False,
-        )["meeting"]
-        user = self.datastore.get(
-            f"user/{user_id}",
-            # TODO here was a wrong field 'user_meeting_ids' check if there can be performance improvements by now using 'meeting_user_ids'
-            ["meeting_user_ids"],
-            lock_result=False,
-            use_changed_models=False,
-        )
+        }:
+            meeting_users.update(meeting_users_new)
 
-        def add_to_list(where: dict[str, Any], key: str, what: int) -> None:
-            if key in where and where[key]:
-                if what not in where[key]:
-                    where[key].append(what)
-            else:
-                where[key] = [what]
-
-        for group in groups.values():
+        # fill relevant meeting_user relations
+        for group_id in group_ids:
+            group = groups[group_id]
             meeting_id = group["meeting_id"]
             meeting_user_id = meeting_users[meeting_id]["id"]
-            add_to_list(group, "meeting_user_ids", meeting_user_id)
-        self.set_models(
-            {
-                f"user/{user_id}": user,
-                **{f"meeting_user/{mu['id']}": mu for mu in meeting_users_new.values()},
-                **{f"group/{group['id']}": group for group in groups.values()},
-                **{
-                    f"meeting/{meeting['id']}": meeting for meeting in meetings.values()
-                },
-            }
-        )
+            if meeting_user_ids := group.get("meeting_user_ids"):
+                if meeting_user_id not in meeting_user_ids:
+                    meeting_user_ids.append(meeting_user_id)
+            else:
+                group["meeting_user_ids"] = [meeting_user_id]
+        if meeting_users_new or groups:
+            self.set_models(
+                {
+                    **{
+                        f"meeting_user/{mu['id']}": mu
+                        for mu in meeting_users_new.values()
+                    },
+                    **{f"group/{group['id']}": group for group in groups.values()},
+                }
+            )
         return [mu["id"] for mu in meeting_users.values()]
 
     def create_mediafile(


### PR DESCRIPTION
Adapts to rel-db changes. Makes `set_user_groups` respect existing group relations.