### PR TITLE
Temporarily deactivate inital data creation.

### DIFF
--- a/openslides_backend/http/application.py
+++ b/openslides_backend/http/application.py
@@ -45,8 +45,8 @@ class OpenSlidesBackendWSGIApplication(WSGIApplication):
         self.logger.debug("Initialize OpenSlides Backend WSGI application.")
         self.view = view
         self.services = services
-        if issubclass(view, ActionView):
-            self.create_initial_data()
+        #         if issubclass(view, ActionView):
+        #    self.create_initial_data()
 
     def create_initial_data(self) -> None:
         if is_truthy(self.env.OPENSLIDES_BACKEND_CREATE_INITIAL_DATA):


### PR DESCRIPTION
Until we implement https://github.com/OpenSlides/openslides-backend/issues/3131 the initial data creation is commented out. The import of initial data avoids starting the backend with the new database schema.