### PR TITLE
[rel-DB] Fix different tests

### DIFF
--- a/tests/system/action/base.py
+++ b/tests/system/action/base.py
@@ -557,6 +557,29 @@ class BaseActionTestCase(BaseSystemTestCase):
 
         self.set_models({f"mediafile/{base}": model_data})
 
+    def create_topic(
+        self, base: int, meeting_id: int, topic_data: PartialModel = {}
+    ) -> None:
+        self.set_models(
+            {
+                f"topic/{base}": {
+                    "title": "test",
+                    "sequential_number": base,
+                    "meeting_id": meeting_id,
+                    **topic_data,
+                },
+                f"agenda_item/{base}": {
+                    "meeting_id": meeting_id,
+                    "content_object_id": f"topic/{base}",
+                },
+                f"list_of_speakers/{base}": {
+                    "content_object_id": f"topic/{base}",
+                    "sequential_number": 1,
+                    "meeting_id": meeting_id,
+                },
+            }
+        )
+
     def base_permission_test(
         self,
         models: dict[str, dict[str, Any]],

--- a/tests/system/action/poll_candidate/test_create.py
+++ b/tests/system/action/poll_candidate/test_create.py
@@ -3,14 +3,14 @@ from tests.system.action.base import BaseActionTestCase
 
 class PollCandidateTest(BaseActionTestCase):
     def test_create(self) -> None:
+        self.create_meeting()
         self.set_models(
             {
-                "meeting/1": {
-                    "name": "meeting_1",
-                    "is_active_in_organization_id": 1,
-                    "poll_candidate_list_ids": [2],
-                },
                 "poll_candidate_list/2": {"meeting_id": 1},
+                "option/1": {
+                    "meeting_id": 1,
+                    "content_object_id": "poll_candidate_list/2",
+                },
             }
         )
         response = self.request(

--- a/tests/system/action/poll_candidate/test_delete.py
+++ b/tests/system/action/poll_candidate/test_delete.py
@@ -3,16 +3,14 @@ from tests.system.action.base import BaseActionTestCase
 
 class PollCandidateDeleteTest(BaseActionTestCase):
     def test_delete_correct(self) -> None:
+        self.create_meeting()
         self.set_models(
             {
-                "meeting/1": {
-                    "name": "meeting_1",
-                    "poll_candidate_list_ids": [2],
-                    "poll_candidate_ids": [3],
-                    "is_active_in_organization_id": 1,
+                "poll_candidate_list/2": {"meeting_id": 1},
+                "option/1": {
+                    "meeting_id": 1,
+                    "content_object_id": "poll_candidate_list/2",
                 },
-                "user/1": {"poll_candidate_ids": [3]},
-                "poll_candidate_list/2": {"meeting_id": 1, "poll_candidate_ids": [3]},
                 "poll_candidate/3": {
                     "meeting_id": 1,
                     "poll_candidate_list_id": 2,
@@ -24,6 +22,6 @@ class PollCandidateDeleteTest(BaseActionTestCase):
         response = self.request("poll_candidate.delete", {"id": 3})
         self.assert_status_code(response, 200)
         self.assert_model_not_exists("poll_candidate/3")
-        self.assert_model_exists("user/1", {"poll_candidate_ids": []})
-        self.assert_model_exists("poll_candidate_list/2", {"poll_candidate_ids": []})
-        self.assert_model_exists("meeting/1", {"poll_candidate_ids": []})
+        self.assert_model_exists("user/1", {"poll_candidate_ids": None})
+        self.assert_model_exists("poll_candidate_list/2", {"poll_candidate_ids": None})
+        self.assert_model_exists("meeting/1", {"poll_candidate_ids": None})

--- a/tests/system/action/poll_candidate_list/test_create.py
+++ b/tests/system/action/poll_candidate_list/test_create.py
@@ -3,23 +3,10 @@ from tests.system.action.base import BaseActionTestCase
 
 class PollCandidateList(BaseActionTestCase):
     def test_create_correct(self) -> None:
-        self.set_models(
-            {
-                "meeting/1": {
-                    "name": "meeting_1",
-                    "is_active_in_organization_id": 1,
-                },
-                "user/2": {
-                    "username": "test1",
-                },
-                "user/3": {
-                    "username": "test2",
-                },
-                "option/4": {
-                    "meeting_id": 1,
-                },
-            },
-        )
+        self.create_meeting()
+        self.create_user("test1")
+        self.create_user("test2")
+        self.set_models({"option/4": {"meeting_id": 1}})
         response = self.request(
             "poll_candidate_list.create",
             {

--- a/tests/system/action/poll_candidate_list/test_delete.py
+++ b/tests/system/action/poll_candidate_list/test_delete.py
@@ -3,20 +3,15 @@ from tests.system.action.base import BaseActionTestCase
 
 class PollCandidateListDeleteTest(BaseActionTestCase):
     def test_delete_correct(self) -> None:
+        self.create_meeting()
+        self.create_user("test1")
+        self.create_user("test2")
         self.set_models(
             {
-                "meeting/1": {
-                    "name": "meeting_1",
-                    "poll_candidate_list_ids": [2],
-                    "poll_candidate_ids": [3, 4, 5],
-                    "is_active_in_organization_id": 1,
-                },
-                "user/1": {"poll_candidate_ids": [3]},
-                "user/2": {"username": "test1", "poll_candidate_ids": [4]},
-                "user/3": {"username": "test2", "poll_candidate_ids": [5]},
-                "poll_candidate_list/2": {
+                "poll_candidate_list/2": {"meeting_id": 1},
+                "option/1": {
                     "meeting_id": 1,
-                    "poll_candidate_ids": [3, 4, 5],
+                    "content_object_id": "poll_candidate_list/2",
                 },
                 "poll_candidate/3": {
                     "meeting_id": 1,
@@ -44,7 +39,7 @@ class PollCandidateListDeleteTest(BaseActionTestCase):
         for poll_candidate_id in range(3, 6):
             self.assert_model_not_exists(f"poll_candidate/{poll_candidate_id}")
         for user_id in range(1, 4):
-            self.assert_model_exists(f"user/{user_id}", {"poll_candidate_ids": []})
+            self.assert_model_exists(f"user/{user_id}", {"poll_candidate_ids": None})
         self.assert_model_exists(
-            "meeting/1", {"poll_candidate_list_ids": [], "poll_candidate_ids": []}
+            "meeting/1", {"poll_candidate_list_ids": None, "poll_candidate_ids": None}
         )

--- a/tests/system/action/topic/test_create.py
+++ b/tests/system/action/topic/test_create.py
@@ -7,24 +7,23 @@ from tests.system.action.base import BaseActionTestCase
 class TopicCreateSystemTest(BaseActionTestCase):
     def test_create(self) -> None:
         self.create_meeting()
-        self.set_models(
-            {
-                "topic/41": {"title": "0", "sequential_number": 1, "meeting_id": 1},
-            }
-        )
+        self.create_topic(41, 1, {"sequential_number": 1})
         response = self.request("topic.create", {"meeting_id": 1, "title": "test"})
         self.assert_status_code(response, 200)
         self.assert_model_exists(
-            "topic/42", {"meeting_id": 1, "agenda_item_id": 1, "sequential_number": 2}
+            "topic/42",
+            {
+                "meeting_id": 1,
+                "agenda_item_id": 42,
+                "sequential_number": 2,
+                "list_of_speakers_id": 42,
+            },
         )
         self.assert_model_exists(
-            "agenda_item/1", {"meeting_id": 1, "content_object_id": "topic/42"}
+            "agenda_item/42", {"meeting_id": 1, "content_object_id": "topic/42"}
         )
         self.assert_model_exists(
-            "list_of_speakers/1", {"content_object_id": "topic/42"}
-        )
-        self.assert_model_exists(
-            "list_of_speakers/1", {"content_object_id": "topic/42"}
+            "list_of_speakers/42", {"content_object_id": "topic/42"}
         )
         self.assertTrue(response.json["success"])
         self.assertEqual(response.json["message"], "Actions handled successfully")
@@ -190,11 +189,7 @@ class TopicCreateSystemTest(BaseActionTestCase):
 
     def test_create_multiple_with_existing_sequential_number(self) -> None:
         self.create_meeting()
-        self.set_models(
-            {
-                "topic/1": {"title": "0", "meeting_id": 1, "sequential_number": 42},
-            }
-        )
+        self.create_topic(1, 1, {"sequential_number": 42})
         response = self.request_multi(
             "topic.create",
             [
@@ -203,10 +198,8 @@ class TopicCreateSystemTest(BaseActionTestCase):
             ],
         )
         self.assert_status_code(response, 200)
-        topic = self.get_model("topic/2")
-        self.assertEqual(topic.get("sequential_number"), 43)
-        topic = self.get_model("topic/3")
-        self.assertEqual(topic.get("sequential_number"), 44)
+        self.assert_model_exists("topic/2", {"sequential_number": 43})
+        self.assert_model_exists("topic/3", {"sequential_number": 44})
 
     def test_create_meeting_id_agenda_tag_ids_mismatch(self) -> None:
         """Tag 8 is from meeting 8 and a topic for meeting 1 should be created.

--- a/tests/system/action/topic/test_import.py
+++ b/tests/system/action/topic/test_import.py
@@ -75,9 +75,9 @@ class TopicJsonImport(BaseActionTestCase):
         self.assert_model_exists("import_preview/2")
 
     def test_import_found_id_and_text_field(self) -> None:
+        self.create_topic(1, 22)
         self.set_models(
             {
-                "topic/1": {"sequential_number": 1, "title": "test", "meeting_id": 22},
                 "import_preview/2": {
                     "state": ImportState.DONE,
                     "name": "topic",
@@ -114,19 +114,10 @@ class TopicJsonImport(BaseActionTestCase):
         )
 
     def test_import_found_id_and_agenda_fields(self) -> None:
+        self.create_topic(1, 22)
         self.set_models(
             {
-                "topic/1": {
-                    "sequential_number": 1,
-                    "title": "test",
-                    "meeting_id": 22,
-                    "agenda_item_id": 7,
-                },
-                "agenda_item/7": {
-                    "content_object_id": "topic/1",
-                    "meeting_id": 22,
-                    "duration": 20,
-                },
+                "agenda_item/1": {"duration": 20},
                 "import_preview/2": {
                     "state": ImportState.DONE,
                     "name": "topic",
@@ -161,10 +152,10 @@ class TopicJsonImport(BaseActionTestCase):
         self.assert_status_code(response, 200)
         self.assert_model_exists(
             "topic/1",
-            {"title": "test", "meeting_id": 22, "agenda_item_id": 7},
+            {"title": "test", "meeting_id": 22, "agenda_item_id": 1},
         )
         self.assert_model_exists(
-            "agenda_item/7",
+            "agenda_item/1",
             {
                 "content_object_id": "topic/1",
                 "comment": "test",
@@ -174,12 +165,7 @@ class TopicJsonImport(BaseActionTestCase):
         )
 
     def test_import_duplicate_and_topic_deleted(self) -> None:
-        self.set_models(
-            {
-                "topic/1": {"sequential_number": 1, "title": "test", "meeting_id": 22},
-                "meeting/22": {"topic_ids": [1]},
-            }
-        )
+        self.create_topic(1, 22)
         response = self.request(
             "topic.json_upload", {"meeting_id": 22, "data": [{"title": "test"}]}
         )
@@ -245,9 +231,7 @@ class TopicImportWithIncludedJsonUpload(TopicJsonUploadForUseInImport):
         self.json_upload_duplicate_in_db()
         self.request("topic.delete", {"id": 3})
         self.assert_model_not_exists("topic/3")
-        self.create_model(
-            "topic/4", {"sequential_number": 2, "title": "test", "meeting_id": 22}
-        )
+        self.create_topic(4, 22)
         response = self.request("topic.import", {"id": 1, "import": True})
         self.assert_status_code(response, 200)
         result = response.json["results"][0][0]
@@ -259,9 +243,7 @@ class TopicImportWithIncludedJsonUpload(TopicJsonUploadForUseInImport):
 
     def test_import_topic_duplicate_id(self) -> None:
         self.json_upload_duplicate_in_db()
-        self.create_model(
-            "topic/4", {"sequential_number": 2, "title": "test", "meeting_id": 22}
-        )
+        self.create_topic(4, 22)
         response = self.request("topic.import", {"id": 1, "import": True})
         self.assert_status_code(response, 200)
         result = response.json["results"][0][0]

--- a/tests/system/action/topic/test_json_upload.py
+++ b/tests/system/action/topic/test_json_upload.py
@@ -144,9 +144,7 @@ class TopicJsonUpload(BaseActionTestCase):
         )
 
     def test_json_upload_duplicate_in_existing_topic(self) -> None:
-        self.set_models(
-            {"topic/10": {"sequential_number": 5, "title": "test", "meeting_id": 22}}
-        )
+        self.create_topic(10, 22)
         response = self.request(
             "topic.json_upload",
             {
@@ -226,16 +224,7 @@ class TopicJsonUploadForUseInImport(BaseActionTestCase):
         assert start_time <= worker.get("created", -1) <= end_time
 
     def json_upload_duplicate_in_db(self) -> None:
-        self.set_models(
-            {
-                "topic/3": {
-                    "sequential_number": 2,
-                    "title": "test",
-                    "text": "old one",
-                    "meeting_id": 22,
-                },
-            }
-        )
+        self.create_topic(3, 22, {"text": "old one"})
         response = self.request(
             "topic.json_upload",
             {"meeting_id": 22, "data": [{"title": "test", "text": "new one"}]},

--- a/tests/system/action/topic/test_update.py
+++ b/tests/system/action/topic/test_update.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from openslides_backend.permissions.permissions import Permissions
 from tests.system.action.base import BaseActionTestCase
 
@@ -7,18 +5,10 @@ from tests.system.action.base import BaseActionTestCase
 class TopicUpdateTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.permission_test_models: dict[str, dict[str, Any]] = {
-            "meeting/1": {"name": "test", "is_active_in_organization_id": 1},
-            "topic/1": {"sequential_number": 1, "title": "test", "meeting_id": 1},
-        }
+        self.create_meeting()
+        self.create_topic(1, 1)
 
     def test_update_simple(self) -> None:
-        self.create_meeting()
-        self.set_models(
-            {
-                "topic/1": {"sequential_number": 1, "title": "test", "meeting_id": 1},
-            }
-        )
         response = self.request(
             "topic.update", {"id": 1, "title": "test2", "text": "text"}
         )
@@ -28,11 +18,9 @@ class TopicUpdateTest(BaseActionTestCase):
         self.assertEqual(topic.get("text"), "text")
 
     def test_update_with_attachment(self) -> None:
-        self.create_meeting()
+        self.create_mediafile(1, 1)
         self.set_models(
             {
-                "topic/1": {"sequential_number": 1, "title": "test", "meeting_id": 1},
-                "mediafile/1": {"owner_id": "meeting/1", "meeting_mediafile_ids": [11]},
                 "meeting_mediafile/11": {
                     "is_public": False,
                     "meeting_id": 1,
@@ -60,12 +48,6 @@ class TopicUpdateTest(BaseActionTestCase):
         )
 
     def test_update_text_with_iframe(self) -> None:
-        self.create_meeting()
-        self.set_models(
-            {
-                "topic/1": {"sequential_number": 1, "title": "test", "meeting_id": 1},
-            }
-        )
         response = self.request(
             "topic.update", {"id": 1, "text": "<IFRAME>text</IFRAME>"}
         )
@@ -79,14 +61,14 @@ class TopicUpdateTest(BaseActionTestCase):
 
     def test_update_no_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
+            {},
             "topic.update",
             {"id": 1, "title": "test2", "text": "text"},
         )
 
     def test_update_permission(self) -> None:
         self.base_permission_test(
-            self.permission_test_models,
+            {},
             "topic.update",
             {"id": 1, "title": "test2", "text": "text"},
             Permissions.AgendaItem.CAN_MANAGE,
@@ -94,7 +76,7 @@ class TopicUpdateTest(BaseActionTestCase):
 
     def test_update_permission_locked_meeting(self) -> None:
         self.base_locked_out_superadmin_permission_test(
-            self.permission_test_models,
+            {},
             "topic.update",
             {"id": 1, "title": "test2", "text": "text"},
         )

--- a/tests/system/action/user/test_update.py
+++ b/tests/system/action/user/test_update.py
@@ -2979,6 +2979,7 @@ class UserUpdateActionTest(BaseActionTestCase):
     def test_group_removal_with_speaker(self) -> None:
         self.create_meeting(4)
         self.create_meeting(7)
+        self.create_topic(1, 4)
         self.set_models(
             {
                 "user/1234": {
@@ -3003,12 +3004,6 @@ class UserUpdateActionTest(BaseActionTestCase):
                 "meeting/7": {
                     "committee_id": 63,
                     "present_user_ids": [1234],
-                },
-                "topic/1": {"title": "tropic", "sequential_number": 1, "meeting_id": 4},
-                "list_of_speakers/1": {
-                    "meeting_id": 4,
-                    "sequential_number": 1,
-                    "content_object_id": "topic/1",
                 },
                 "speaker/14": {
                     "list_of_speakers_id": 1,
@@ -3073,6 +3068,7 @@ class UserUpdateActionTest(BaseActionTestCase):
 
     def test_partial_group_removal_with_speaker(self) -> None:
         self.create_meeting(4)
+        self.create_topic(1, 4)
         self.set_models(
             {
                 "user/1234": {
@@ -3082,12 +3078,6 @@ class UserUpdateActionTest(BaseActionTestCase):
                     "meeting_id": 4,
                     "user_id": 1234,
                     "speaker_ids": [14, 24],
-                },
-                "topic/1": {"title": "tropic", "sequential_number": 1, "meeting_id": 4},
-                "list_of_speakers/1": {
-                    "meeting_id": 4,
-                    "sequential_number": 1,
-                    "content_object_id": "topic/1",
                 },
                 "speaker/14": {
                     "list_of_speakers_id": 1,
@@ -3131,6 +3121,7 @@ class UserUpdateActionTest(BaseActionTestCase):
         self.create_meeting()
         self.create_user("dummy2", [1])
         self.create_user("dummy3", [1])
+        self.create_topic(1, 1)
         self.set_models(
             {
                 "user/1": {
@@ -3147,7 +3138,6 @@ class UserUpdateActionTest(BaseActionTestCase):
                     "poll_candidate_ids": [1],
                     "vote_ids": [1, 2],
                 },
-                "topic/1": {"title": "tropic", "sequential_number": 1, "meeting_id": 1},
                 "poll/1": {
                     "title": "pull",
                     "type": "analog",


### PR DESCRIPTION
- Commits 1-3: fixed tests that were failing because of the 1-to-1 not_null trigger.
- Commit 4: while fixing these tests in the `user.test_merge_together.py` file, I've spot quite a bunch of back relations that were set manually. Cleaned up some of them but there are still a lot of them left. Do we want to remove them all too? Probably from the whole directory and in a separate PR? If that's the case, I'll move this commit to a new branch.