### PR TITLE
Remove mediafiles unqiue together check

### DIFF
--- a/openslides_backend/action/actions/mediafile/mixins.py
+++ b/openslides_backend/action/actions/mediafile/mixins.py
@@ -4,7 +4,7 @@ from ....permissions.management_levels import OrganizationManagementLevel
 from ....permissions.permission_helper import has_organization_management_level
 from ....services.database.commands import GetManyRequest
 from ....shared.exceptions import ActionException, DatabaseException, MissingPermission
-from ....shared.filters import And, FilterOperator, Not
+from ....shared.filters import FilterOperator
 from ....shared.patterns import KEYSEPARATOR, fqid_from_collection_and_id
 from ....shared.util import ONE_ORGANIZATION_ID
 from ...action import Action
@@ -39,12 +39,6 @@ class MediafileMixin(Action):
                 parent_id = mediafile.get("parent_id")
             except DatabaseException:
                 pass
-        self.check_title_unique_if_in_root(
-            instance.get("title"),
-            parent_id,
-            instance.get("id"),
-            fqid_from_collection_and_id(collection, id_),
-        )
 
         if collection == "organization":
             if "access_group_ids" in instance and (
@@ -157,27 +151,6 @@ class MediafileMixin(Action):
             for group in groups:
                 if group.get("meeting_id") != meeting_id:
                     raise ActionException("Owner and access groups don't match.")
-
-    def check_title_unique_if_in_root(
-        self,
-        title: str | None,
-        parent_id: int | None,
-        id_: int | None,
-        owner_id: str,
-    ) -> None:
-        if parent_id is None and title is not None:
-            filter_ = And(
-                FilterOperator("title", "=", title),
-                FilterOperator("parent_id", "=", parent_id),
-                FilterOperator("owner_id", "=", owner_id),
-            )
-            if id_:
-                filter_ = And(filter_, Not(FilterOperator("id", "=", id_)))
-            results = self.datastore.filter(self.model.collection, filter_, ["id"])
-            if results:
-                raise ActionException(
-                    f"File '{title}' already exists in the root folder."
-                )
 
 
 class MediafileCreateMixin(MediafileMixin):

--- a/openslides_backend/models/models.py
+++ b/openslides_backend/models/models.py
@@ -651,7 +651,8 @@ class Mediafile(Model):
 
     id = fields.IntegerField(required=True, constant=True)
     title = fields.CharField(
-        constraints={"description": "Title and parent_id must be unique."}
+        required=True,
+        constraints={"description": "Title and parent_id must be unique."},
     )
     is_directory = fields.BooleanField()
     filesize = fields.IntegerField(

--- a/openslides_backend/shared/export_helper.py
+++ b/openslides_backend/shared/export_helper.py
@@ -98,6 +98,7 @@ def export_meeting(
                                     "published_to_meetings_in_organization_id",
                                     "parent_id",
                                     "child_ids",
+                                    "title",
                                 ],
                             ),
                         ],

--- a/tests/system/action/assignment/test_create.py
+++ b/tests/system/action/assignment/test_create.py
@@ -143,7 +143,12 @@ class AssignmentCreateActionTest(BaseActionTestCase):
         self.set_models(
             {
                 "meeting/110": {"agenda_item_creation": "default_yes"},
-                "mediafile/1": {"owner_id": ONE_ORGANIZATION_FQID},
+                "mediafile/1": {
+                    "owner_id": ONE_ORGANIZATION_FQID,
+                    "mimetype": "text/plain",
+                    "title": "orga notes",
+                    "filename": "list_of_easter_eggs.txt",
+                },
             }
         )
         response = self.request(

--- a/tests/system/action/mediafile/test_delete.py
+++ b/tests/system/action/mediafile/test_delete.py
@@ -11,7 +11,7 @@ class MediafileDeleteActionTest(BaseActionTestCase):
         super().setUp()
         self.permission_test_models: dict[str, dict[str, Any]] = {
             "meeting/1": {"logo_web_header_id": 222},
-            "mediafile/222": {"owner_id": "meeting/1"},
+            "mediafile/222": {"owner_id": "meeting/1", "title": "file_222"},
             "meeting_mediafile/222": {
                 "mediafile_id": 222,
                 "is_public": True,

--- a/tests/system/action/mediafile/test_move.py
+++ b/tests/system/action/mediafile/test_move.py
@@ -10,8 +10,16 @@ class MediafileMoveActionTest(BaseActionTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.permission_test_models: dict[str, dict[str, Any]] = {
-            "mediafile/7": {"owner_id": "meeting/1", "is_directory": True},
-            "mediafile/8": {"owner_id": "meeting/1", "is_directory": True},
+            "mediafile/7": {
+                "owner_id": "meeting/1",
+                "is_directory": True,
+                "title": "file_7",
+            },
+            "mediafile/8": {
+                "owner_id": "meeting/1",
+                "is_directory": True,
+                "title": "file_8",
+            },
             "meeting_mediafile/7": {
                 "mediafile_id": 7,
                 "is_public": True,
@@ -24,8 +32,16 @@ class MediafileMoveActionTest(BaseActionTestCase):
             },
         }
         self.orga_permission_test_models: dict[str, dict[str, Any]] = {
-            "mediafile/7": {"owner_id": ONE_ORGANIZATION_FQID, "is_directory": True},
-            "mediafile/8": {"owner_id": ONE_ORGANIZATION_FQID, "is_directory": True},
+            "mediafile/7": {
+                "owner_id": ONE_ORGANIZATION_FQID,
+                "is_directory": True,
+                "title": "directory_7",
+            },
+            "mediafile/8": {
+                "owner_id": ONE_ORGANIZATION_FQID,
+                "is_directory": True,
+                "title": "directory_8",
+            },
         }
 
     def test_move_parent_none(self) -> None:
@@ -254,7 +270,13 @@ class MediafileMoveActionTest(BaseActionTestCase):
 
     def test_move_explicitly_published_file_error(self) -> None:
         self.set_models(
-            {"mediafile/1": {"owner_id": ONE_ORGANIZATION_FQID, "is_directory": True}}
+            {
+                "mediafile/1": {
+                    "owner_id": ONE_ORGANIZATION_FQID,
+                    "is_directory": True,
+                    "title": "directory_1",
+                }
+            }
         )
         self.create_mediafile(2, is_directory=True)
         response = self.request(
@@ -282,7 +304,13 @@ class MediafileMoveActionTest(BaseActionTestCase):
 
     def test_move_to_explicitly_published_directory(self) -> None:
         self.set_models(
-            {"mediafile/1": {"owner_id": ONE_ORGANIZATION_FQID, "is_directory": True}}
+            {
+                "mediafile/1": {
+                    "owner_id": ONE_ORGANIZATION_FQID,
+                    "is_directory": True,
+                    "title": "directory_1",
+                }
+            }
         )
         self.create_mediafile(2, is_directory=True)
         response = self.request(
@@ -317,11 +345,13 @@ class MediafileMoveActionTest(BaseActionTestCase):
                 "mediafile/2": {
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "is_directory": True,
+                    "title": "directory_2",
                 },
                 "mediafile/3": {
                     "parent_id": 2,
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "is_directory": True,
+                    "title": "directory_3",
                 },
             }
         )
@@ -581,12 +611,14 @@ class MediafileMoveActionTest(BaseActionTestCase):
                 "mediafile/1": {
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "is_directory": True,
+                    "title": "directory_1",
                 },
                 "mediafile/2": {
                     "parent_id": 4,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "is_directory": True,
+                    "title": "directory_2",
                 },
                 "meeting_mediafile/2": {
                     "meeting_id": 1,
@@ -603,6 +635,7 @@ class MediafileMoveActionTest(BaseActionTestCase):
                     "parent_id": 2,
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "is_directory": True,
+                    "title": "directory_3",
                 },
                 "meeting_mediafile/3": {
                     "meeting_id": 1,
@@ -623,6 +656,7 @@ class MediafileMoveActionTest(BaseActionTestCase):
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "is_directory": True,
+                    "title": "directory_4",
                 },
             }
         )

--- a/tests/system/action/mediafile/test_update.py
+++ b/tests/system/action/mediafile/test_update.py
@@ -832,7 +832,13 @@ class MediafileUpdateActionTest(BaseActionTestCase):
 
     def test_update_token_payload_old_token(self) -> None:
         self.set_models(
-            {"mediafile/7": {"token": "token_1", "owner_id": ONE_ORGANIZATION_FQID}}
+            {
+                "mediafile/7": {
+                    "token": "token_1",
+                    "owner_id": ONE_ORGANIZATION_FQID,
+                    "title": "file_7",
+                }
+            }
         )
         response = self.request("mediafile.update", {"id": 7, "token": "token_1"})
         self.assert_status_code(response, 200)

--- a/tests/system/action/mediafile/test_update.py
+++ b/tests/system/action/mediafile/test_update.py
@@ -927,55 +927,16 @@ class MediafileUpdateActionTest(BaseActionTestCase):
             response.json["message"],
         )
 
-    def test_update_title_empty_parent_id_unique(self) -> None:
-        self.create_mediafile(6, 1, is_directory=True)
-        self.create_mediafile(7, 1, parent_id=6)
-        self.create_mediafile(8, 1, parent_id=6)
-        self.set_models(
-            {
-                "mediafile/7": {"title": ""},
-                "meeting_mediafile/16": {
-                    "mediafile_id": 6,
-                    "is_public": True,
-                    "meeting_id": 1,
-                },
-                "meeting_mediafile/17": {
-                    "mediafile_id": 7,
-                    "is_public": True,
-                    "meeting_id": 1,
-                },
-                "meeting_mediafile/18": {
-                    "mediafile_id": 8,
-                    "is_public": True,
-                    "meeting_id": 1,
-                },
-            }
-        )
-        response = self.request("mediafile.update", {"id": 8, "title": ""})
-        self.assert_status_code(response, 400)
-        self.assertIn(
-            'mediafile/8: duplicate key value violates unique constraint "unique_mediafile_title_parent_id_owner_id"\n'
-            + "DETAIL:  Key (title, parent_id, owner_id)=(, 6, meeting/1) already exists.",
-            response.json["message"],
-        )
-
     def test_update_title_owner_id_root_unique(self) -> None:
         self.create_mediafile(7, 1)
         self.create_mediafile(8, 1)
         response = self.request("mediafile.update", {"id": 8, "title": "file_7"})
         self.assert_status_code(response, 400)
-        assert (
-            "File 'file_7' already exists in the root folder."
-            in response.json["message"]
+        self.assertIn(
+            'mediafile/8: duplicate key value violates unique constraint "unique_mediafile_title_parent_id_owner_id"\n'
+            + "DETAIL:  Key (title, parent_id, owner_id)=(file_7, null, meeting/1) already exists.",
+            response.json["message"],
         )
-
-    def test_update_title_empty_owner_id_root_unique(self) -> None:
-        self.create_mediafile(7, 1)
-        self.create_mediafile(8, 1)
-        self.set_models({"mediafile/7": {"title": ""}})
-        response = self.request("mediafile.update", {"id": 8, "title": ""})
-        self.assert_status_code(response, 400)
-        assert "File '' already exists in the root folder." in response.json["message"]
 
     def test_update_no_permissions(self) -> None:
         self.base_permission_test(

--- a/tests/system/action/mediafile/test_upload.py
+++ b/tests/system/action/mediafile/test_upload.py
@@ -599,29 +599,6 @@ l,m,n,"""
             response.json["message"],
         )
 
-    def test_create_directory_empty_title_parent_id_unique(self) -> None:
-        self.create_meeting()
-        self.create_mediafile(6, 1, is_directory=True)
-        self.create_mediafile(7, 1, parent_id=6)
-        file_content = base64.b64encode(b"testtesttest").decode()
-        self.set_models({"mediafile/7": {"title": ""}})
-        response = self.request(
-            "mediafile.upload",
-            {
-                "owner_id": "meeting/1",
-                "title": "",
-                "parent_id": 6,
-                "file": file_content,
-                "filename": "test.txt",
-            },
-        )
-        self.assert_status_code(response, 400)
-        self.assertIn(
-            'mediafile/8: duplicate key value violates unique constraint "unique_mediafile_title_parent_id_owner_id"\n'
-            + "DETAIL:  Key (title, parent_id, owner_id)=(, 6, meeting/1) already exists.",
-            response.json["message"],
-        )
-
     def test_create_root_title_owner_id_unique(self) -> None:
         self.create_meeting()
         self.create_mediafile(7, 1)
@@ -636,27 +613,11 @@ l,m,n,"""
             },
         )
         self.assert_status_code(response, 400)
-        assert (
-            "File 'file_7' already exists in the root folder."
-            in response.json["message"]
+        self.assertIn(
+            'mediafile/8: duplicate key value violates unique constraint "unique_mediafile_title_parent_id_owner_id"\n'
+            + "DETAIL:  Key (title, parent_id, owner_id)=(file_7, null, meeting/1) already exists.",
+            response.json["message"],
         )
-
-    def test_create_root_title_empty_owner_id_unique(self) -> None:
-        self.create_meeting()
-        self.create_mediafile(7, 1)
-        file_content = base64.b64encode(b"testtesttest").decode()
-        self.set_models({"mediafile/7": {"title": ""}})
-        response = self.request(
-            "mediafile.upload",
-            {
-                "owner_id": "meeting/1",
-                "title": "",
-                "file": file_content,
-                "filename": "test.txt",
-            },
-        )
-        self.assert_status_code(response, 400)
-        assert "File '' already exists in the root folder." in response.json["message"]
 
     def test_create_directory_owner_access_groups_dont_match(self) -> None:
         self.create_meeting()

--- a/tests/system/action/meeting/test_clone.py
+++ b/tests/system/action/meeting/test_clone.py
@@ -672,11 +672,17 @@ class MeetingClone(BaseActionTestCase):
                 },
                 "mediafile/1": {
                     "owner_id": "meeting/1",
-                    "mimetype": "text/plain",
+                    "mimetype": "image/png",
+                    "owner_id": "meeting/1",
+                    "title": "logo (new)",
+                    "filename": "logo_2026.png",
                 },
                 "mediafile/2": {
                     "owner_id": "meeting/1",
-                    "mimetype": "text/plain",
+                    "mimetype": "font/woff",
+                    "owner_id": "meeting/1",
+                    "title": "fancy font",
+                    "filename": "font-fancy.woff",
                 },
                 "meeting_mediafile/10": {
                     "meeting_id": 1,
@@ -1066,18 +1072,21 @@ class MeetingClone(BaseActionTestCase):
                     "is_directory": True,
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
+                    "title": "public",
                 },
                 "mediafile/15": {
                     "is_directory": True,
                     "parent_id": 14,
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
+                    "title": "fonts",
                 },
                 "mediafile/16": {
                     "is_directory": True,
                     "parent_id": 15,
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
+                    "title": "published",
                 },
                 "mediafile/17": {
                     "parent_id": 16,
@@ -1085,6 +1094,8 @@ class MeetingClone(BaseActionTestCase):
                     "mimetype": "font/woff",
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
+                    "filename": "font-galactic.woff",
+                    "title": "fonts for special highlighted headers",
                 },
                 "meeting_mediafile/11": {
                     "is_public": False,

--- a/tests/system/action/meeting/test_set_font.py
+++ b/tests/system/action/meeting/test_set_font.py
@@ -14,6 +14,8 @@ class MeetingSetFontActionTest(BaseActionTestCase):
                 "is_directory": False,
                 "mimetype": "font/woff",
                 "owner_id": "meeting/1",
+                "filename": "font-fancy.woff",
+                "title": "fancy font",
             },
             "meeting_mediafile/7": {
                 "meeting_id": 1,
@@ -48,6 +50,7 @@ class MeetingSetFontActionTest(BaseActionTestCase):
         self.test_models["mediafile/17"] = {
             "owner_id": "meeting/1",
             "is_directory": True,
+            "title": "fonts",
         }
         self.set_models(self.test_models)
         response = self.request(
@@ -75,6 +78,8 @@ class MeetingSetFontActionTest(BaseActionTestCase):
                     "is_directory": False,
                     "mimetype": "font/woff",
                     "owner_id": ONE_ORGANIZATION_FQID,
+                    "filename": "font-fancy.woff",
+                    "title": "fancy font",
                 },
             }
         )
@@ -112,6 +117,8 @@ class MeetingSetFontActionTest(BaseActionTestCase):
                     "mimetype": "font/woff",
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
+                    "filename": "font-fancy.woff",
+                    "title": "fancy font",
                 },
             }
         )
@@ -140,6 +147,7 @@ class MeetingSetFontActionTest(BaseActionTestCase):
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
                     "child_ids": [17],
+                    "title": "fonts",
                 },
                 "mediafile/17": {
                     "parent_id": 16,
@@ -147,6 +155,8 @@ class MeetingSetFontActionTest(BaseActionTestCase):
                     "mimetype": "font/woff",
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
+                    "filename": "font-fancy.woff",
+                    "title": "fancy font",
                 },
             }
         )

--- a/tests/system/action/meeting/test_set_logo.py
+++ b/tests/system/action/meeting/test_set_logo.py
@@ -14,6 +14,8 @@ class MeetingSetLogoActionTest(BaseActionTestCase):
                 "is_directory": False,
                 "mimetype": "image/png",
                 "owner_id": "meeting/1",
+                "filename": "new_final_finalest_final_for_sure_1_1.png",
+                "title": "approved logo",
             },
             "meeting_mediafile/7": {
                 "meeting_id": 1,
@@ -60,6 +62,7 @@ class MeetingSetLogoActionTest(BaseActionTestCase):
         self.permission_test_models["mediafile/17"] = {
             "owner_id": "meeting/1",
             "is_directory": True,
+            "title": "logos",
         }
         self.set_models(self.permission_test_models)
         response = self.request(
@@ -87,6 +90,8 @@ class MeetingSetLogoActionTest(BaseActionTestCase):
                     "is_directory": False,
                     "mimetype": "image/png",
                     "owner_id": ONE_ORGANIZATION_FQID,
+                    "filename": "DRAFT_NOT_PUBLISH.png",
+                    "title": "logo_2026",
                 },
             }
         )
@@ -124,6 +129,8 @@ class MeetingSetLogoActionTest(BaseActionTestCase):
                     "mimetype": "image/png",
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
+                    "filename": "logo_monochrome.png",
+                    "title": "logo-bw",
                 },
             }
         )
@@ -152,6 +159,7 @@ class MeetingSetLogoActionTest(BaseActionTestCase):
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
                     "child_ids": [17],
+                    "title": "logos",
                 },
                 "mediafile/17": {
                     "parent_id": 16,
@@ -159,6 +167,8 @@ class MeetingSetLogoActionTest(BaseActionTestCase):
                     "mimetype": "image/png",
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
+                    "filename": "logo_2026.png",
+                    "title": "logo (new)",
                 },
             }
         )

--- a/tests/system/action/meeting/test_unset_font.py
+++ b/tests/system/action/meeting/test_unset_font.py
@@ -11,8 +11,10 @@ class MediafileUnsetFontActionTest(BaseActionTestCase):
                 "meeting/1": {"font_projector_h1_id": 7, "font_projector_h2_id": 7},
                 "mediafile/17": {
                     "is_directory": False,
-                    "mimetype": "image/png",
+                    "mimetype": "font/woff",
                     "owner_id": "meeting/1",
+                    "filename": "font-basic.woff",
+                    "title": "boring font",
                 },
                 "meeting_mediafile/7": {
                     "meeting_id": 1,

--- a/tests/system/action/meeting/test_unset_logo.py
+++ b/tests/system/action/meeting/test_unset_logo.py
@@ -17,6 +17,8 @@ class MediafileUnsetLogoActionTest(BaseActionTestCase):
                 "is_directory": False,
                 "mimetype": "image/png",
                 "owner_id": "meeting/1",
+                "filename": "logo_2002.png",
+                "title": "logo (old)",
             },
             "meeting_mediafile/7": {
                 "meeting_id": 1,

--- a/tests/system/action/projector/test_add_to_preview.py
+++ b/tests/system/action/projector/test_add_to_preview.py
@@ -283,7 +283,9 @@ class ProjectorAddToPreview(BaseActionTestCase):
         )
 
     def test_unpublished_mediafile_as_content_object(self) -> None:
-        self.set_models({"mediafile/1": {"owner_id": ONE_ORGANIZATION_FQID}})
+        self.set_models(
+            {"mediafile/1": {"owner_id": ONE_ORGANIZATION_FQID, "title": "private"}}
+        )
         response = self.request(
             "projector.add_to_preview",
             {"ids": [2], "content_object_id": "mediafile/1", "meeting_id": 1},

--- a/tests/system/action/projector/test_project.py
+++ b/tests/system/action/projector/test_project.py
@@ -510,7 +510,9 @@ class ProjectorProject(BaseActionTestCase):
         )
 
     def test_unpublished_mediafile_as_content_object(self) -> None:
-        self.set_models({"mediafile/1": {"owner_id": ONE_ORGANIZATION_FQID}})
+        self.set_models(
+            {"mediafile/1": {"owner_id": ONE_ORGANIZATION_FQID, "title": "private"}}
+        )
         response = self.request(
             "projector.project",
             {"ids": [75], "content_object_id": "mediafile/1", "meeting_id": 1},

--- a/tests/system/action/topic/test_create.py
+++ b/tests/system/action/topic/test_create.py
@@ -1,6 +1,5 @@
 from openslides_backend.models.models import AgendaItem
 from openslides_backend.permissions.permissions import Permissions
-from openslides_backend.shared.util import ONE_ORGANIZATION_FQID, ONE_ORGANIZATION_ID
 from tests.system.action.base import BaseActionTestCase
 
 
@@ -105,29 +104,16 @@ class TopicCreateSystemTest(BaseActionTestCase):
 
     def test_create_more_fields(self) -> None:
         self.create_meeting()
+        self.create_mediafile(1)
+        self.create_mediafile(2, is_directory=True)
+        self.create_mediafile(3, parent_id=2)
+        self.create_mediafile(4)
         self.set_models(
             {
-                "mediafile/1": {
-                    "owner_id": ONE_ORGANIZATION_FQID,
-                    "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
-                },
                 "meeting_mediafile/11": {
                     "is_public": False,
                     "mediafile_id": 1,
                     "meeting_id": 1,
-                },
-                "mediafile/2": {
-                    "owner_id": ONE_ORGANIZATION_FQID,
-                    "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
-                },
-                "mediafile/3": {
-                    "parent_id": 2,
-                    "owner_id": ONE_ORGANIZATION_FQID,
-                    "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
-                },
-                "mediafile/4": {
-                    "owner_id": ONE_ORGANIZATION_FQID,
-                    "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
                 },
                 "meeting_mediafile/14": {
                     "is_public": False,

--- a/tests/system/presenter/test_check_database.py
+++ b/tests/system/presenter/test_check_database.py
@@ -445,19 +445,29 @@ class TestCheckDatabase(BasePresenterTestCase):
                     "show_clock": True,
                     **{field: 1 for field in Meeting.reverse_default_projectors()},
                 },
-                "mediafile/1": {"owner_id": "meeting/1", "meeting_mediafile_ids": [1]},
-                "mediafile/2": {"owner_id": "meeting/1", "meeting_mediafile_ids": [2]},
+                "mediafile/1": {
+                    "owner_id": "meeting/1",
+                    "meeting_mediafile_ids": [1],
+                    "title": "first",
+                },
+                "mediafile/2": {
+                    "owner_id": "meeting/1",
+                    "meeting_mediafile_ids": [2],
+                    "title": "second",
+                },
                 "mediafile/3": {
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
                     "is_directory": True,
                     "child_ids": [4],
+                    "title": "third",
                 },
                 "mediafile/4": {
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
                     "parent_id": 3,
                     "meeting_mediafile_ids": [4],
+                    "title": "zero",
                 },
                 "meeting_mediafile/1": {
                     "meeting_id": 1,

--- a/tests/system/presenter/test_check_database_all.py
+++ b/tests/system/presenter/test_check_database_all.py
@@ -331,12 +331,16 @@ class TestCheckDatabaseAll(BasePresenterTestCase):
                     "child_ids": [4],
                     "is_directory": True,
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
+                    "title": "notes",
                 },
                 "mediafile/4": {
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "parent_id": 3,
                     "meeting_mediafile_ids": [4],
                     "published_to_meetings_in_organization_id": ONE_ORGANIZATION_ID,
+                    "mimetype": "text/plain",
+                    "title": "birthdays (Saturday)",
+                    "filename": "birthdays-07-18.txt",
                 },
                 "meeting_mediafile/4": {
                     "meeting_id": 1,
@@ -532,8 +536,16 @@ class TestCheckDatabaseAll(BasePresenterTestCase):
                     "show_clock": True,
                     **{field: 1 for field in Meeting.reverse_default_projectors()},
                 },
-                "mediafile/1": {"owner_id": "meeting/1", "meeting_mediafile_ids": [1]},
-                "mediafile/2": {"owner_id": "meeting/1", "meeting_mediafile_ids": [2]},
+                "mediafile/1": {
+                    "owner_id": "meeting/1",
+                    "meeting_mediafile_ids": [1],
+                    "title": "first",
+                },
+                "mediafile/2": {
+                    "owner_id": "meeting/1",
+                    "meeting_mediafile_ids": [2],
+                    "title": "second",
+                },
                 "meeting_mediafile/1": {
                     "meeting_id": 1,
                     "mediafile_id": 1,

--- a/tests/system/presenter/test_get_mediafile_context.py
+++ b/tests/system/presenter/test_get_mediafile_context.py
@@ -7,7 +7,14 @@ from .base import BasePresenterTestCase
 
 class TestGetUserRelatedModels(BasePresenterTestCase):
     def test_get_mediafile_context_simple(self) -> None:
-        self.set_models({"mediafile/1": {"owner_id": ONE_ORGANIZATION_FQID}})
+        self.set_models(
+            {
+                "mediafile/1": {
+                    "owner_id": ONE_ORGANIZATION_FQID,
+                    "title": "the one and only",
+                }
+            }
+        )
         status_code, data = self.request(
             "get_mediafile_context", {"mediafile_ids": [1]}
         )

--- a/tests/unit/test_checker.py
+++ b/tests/unit/test_checker.py
@@ -684,7 +684,11 @@ class TestCheckerCheckData(TestCase):
         for collection in ["theme", "committee", "organization"]:
             del self.meeting_data[collection]
         self.meeting_data.update(
-            {"mediafile": {"1": {"id": 1, "owner_id": ONE_ORGANIZATION_FQID}}}
+            {
+                "mediafile": {
+                    "1": {"id": 1, "owner_id": ONE_ORGANIZATION_FQID, "title": "1"}
+                }
+            }
         )
         self.check_data(
             data=self.meeting_data,
@@ -728,24 +732,28 @@ class TestCheckerCheckData(TestCase):
             "mediafile": {
                 "1": {
                     "id": 1,
+                    "title": "1",
                     "owner_id": "meeting/1",
                     "child_ids": [2],
                     "meeting_mediafile_ids": [11],
                 },
                 "2": {
                     "id": 2,
+                    "title": "2",
                     "owner_id": "meeting/1",
                     "parent_id": 1,
                     "meeting_mediafile_ids": [12],
                 },
                 "3": {
                     "id": 3,
+                    "title": "3",
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "is_directory": True,
                     "child_ids": [4],
                 },
                 "4": {
                     "id": 4,
+                    "title": "4",
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "is_directory": True,
                     "parent_id": 3,
@@ -753,6 +761,7 @@ class TestCheckerCheckData(TestCase):
                 },
                 "5": {
                     "id": 5,
+                    "title": "5",
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "parent_id": 4,
                     "meeting_mediafile_ids": [15],
@@ -818,11 +827,13 @@ class TestCheckerCheckData(TestCase):
             "mediafile": {
                 "1": {
                     "id": 1,
+                    "title": "1",
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "child_ids": [2],
                 },
                 "2": {
                     "id": 2,
+                    "title": "2",
                     "owner_id": ONE_ORGANIZATION_FQID,
                     "parent_id": 1,
                     "meeting_mediafile_ids": [12],


### PR DESCRIPTION
Needs https://github.com/OpenSlides/openslides-meta/pull/462

- Removed backend-check for unique files in root, updates error messages in tests;
- Added missing `title` in the tests. For some files also added missing `filename`, updated `mimetype` etc. (will become relevant after introducing custom constraints);
- Updated checker (was throwing error message because of the missing required title).