### PR TITLE
Set prepare_threshold to DB connection kwargs to no prepared statements

### DIFF
--- a/openslides_backend/services/postgresql/db_connection_handling.py
+++ b/openslides_backend/services/postgresql/db_connection_handling.py
@@ -55,6 +55,7 @@ def create_os_conn_pool(open: bool = True) -> ConnectionPool[Connection[rows.Dic
         kwargs={
             "autocommit": True,
             "row_factory": rows.dict_row,
+            "prepare_threshold": None,
         },
         min_size=int(env.DB_POOL_MIN_SIZE),
         max_size=int(env.DB_POOL_MAX_SIZE),


### PR DESCRIPTION
Removing prepared statements again to prevent errors with libpq version 15. Once on debian trixie or using psycopg[binary] we could allow them again. Those would provide libpq 17.