### PR TITLE
SAML meeting mapping always allow create if `meeting_user` not meeting member

### DIFF
--- a/docs/actions/user.save_saml_account.md
+++ b/docs/actions/user.save_saml_account.md
@@ -37,7 +37,7 @@ Extras to do on creation:
 - The saml attribute mapping can have a list of 'meeting_mappers' that can be used to assign users meeting related data. (See example below. A full example can be found in the [organization.update.md](organization.update.md))
     - A mapper can be given a 'name' for debugging purposes.
     - The 'external_id' maps to the meeting and is required (logged as warning if meeting does not exist). Multiple mappers can map to the same meeting.
-    - If 'allow_update' is set to false, the mapper is only used if the user does not already exist. If it is not given it defaults to true.
+    - If 'allow_update' is set to false, the mapper is only used if the user does not already exist in the meeting. If it is not given it defaults to true. This option should only be used if you are sure that users aren't deleted from meetings. Alternatively they can be locked out from the meeting.
     - Mappers are only used if every condition in the list of 'conditions' resolves to true. For this 
         - the value for 'attribute' in the payload data has to match the string or regex given in 'condition'. 
         - if no condition is given this defaults to true. 

--- a/docs/actions/user.save_saml_account.md
+++ b/docs/actions/user.save_saml_account.md
@@ -37,7 +37,7 @@ Extras to do on creation:
 - The saml attribute mapping can have a list of 'meeting_mappers' that can be used to assign users meeting related data. (See example below. A full example can be found in the [organization.update.md](organization.update.md))
     - A mapper can be given a 'name' for debugging purposes.
     - The 'external_id' maps to the meeting and is required (logged as warning if meeting does not exist). Multiple mappers can map to the same meeting.
-    - If 'allow_update' is set to false, the mapper is only used if the user does not already exist in the meeting. If it is not given it defaults to true. This option should only be used if you are sure that users aren't deleted from meetings. Alternatively they can be locked out from the meeting.
+    - If 'allow_update' is set to false, the mapper is only used to create a new participant if the user does not already exist in the meeting. If it is not given it defaults to true. This option should only be used if you are sure that users aren't deleted from meetings. Alternatively they can be locked out from the meeting.
     - Mappers are only used if every condition in the list of 'conditions' resolves to true. For this 
         - the value for 'attribute' in the payload data has to match the string or regex given in 'condition'. 
         - if no condition is given this defaults to true. 
@@ -50,7 +50,7 @@ Extras to do on creation:
 - On conflict of multiple mappers mappings on a same meetings field the last given mappers data for that field is used. Exception to this are groups and structure levels. Their data is combined. 
 - Values for groups and structure levels can additionally be given in comma separated lists composed as a single string.
 - Values for groups are interpreted as their external ID and structure levels as their name within that meeting.
-- If no group exists for a meeting and no default is given, the meetings default group is used. (Logged as warning)
+- If no group exists for a newly created participant and no default is given, the meetings default group is used. (Logged as warning)
 - If a structure level does not exist, it is created.
 - Vote weights need to be given as 6 digit decimal strings.
 

--- a/docs/actions/user.save_saml_account.md
+++ b/docs/actions/user.save_saml_account.md
@@ -51,6 +51,7 @@ Extras to do on creation:
 - Values for groups and structure levels can additionally be given in comma separated lists composed as a single string.
 - Values for groups are interpreted as their external ID and structure levels as their name within that meeting.
 - If no group exists for a newly created participant and no default is given, the meetings default group is used. (Logged as warning)
+- For consistency with client behavior the meetings default group is removed from meeting_user if more than one group would be in the final result.
 - If a structure level does not exist, it is created.
 - Vote weights need to be given as 6 digit decimal strings.
 

--- a/openslides_backend/action/actions/user/save_saml_account.py
+++ b/openslides_backend/action/actions/user/save_saml_account.py
@@ -421,6 +421,10 @@ class UserSaveSamlAccount(
                             if _id not in old_ids:
                                 old_ids.append(_id)
                         meeting_user[field_name] = old_ids
+                    
+                default_group_id = self.datastore.get(f"meeting/{meeting_id}", ["default_group_id"])["default_group_id"]
+                if len(meeting_user["group_ids"]) > 1 and default_group_id in meeting_user["group_ids"]:
+                    meeting_user["group_ids"].remove(default_group_id)
 
     def get_field_data(
         self,
@@ -519,15 +523,15 @@ class UserSaveSamlAccount(
             )
             if len(groups) > 0:
                 return sorted(groups)
-        if default_group_id := meeting["default_group_id"]:
-            if db_meeting_user_exists:
-                return []
-            else:
-                external_meeting_id = meeting["external_id"]
-                self.logger.warning(
-                    f"save_saml_account found no group in meeting '{external_meeting_id}' for {group_names}, but used default_group of meeting"
-                )
-                return [default_group_id]
+        # Because we don't know the db instance here, we can't determine if the meeting_user has no groups which leads to remaining without any group.
+        if db_meeting_user_exists:
+            return []
+        elif default_group_id := meeting["default_group_id"]:
+            external_meeting_id = meeting["external_id"]
+            self.logger.warning(
+                f"save_saml_account found no group in meeting '{external_meeting_id}' for {group_names}, but used default_group of meeting"
+            )
+            return [default_group_id]
         else:
             raise ActionException(
                 "Invalid data state: mapped meeting does not have default group."

--- a/openslides_backend/action/actions/user/save_saml_account.py
+++ b/openslides_backend/action/actions/user/save_saml_account.py
@@ -362,12 +362,15 @@ class UserSaveSamlAccount(
                 )
             ):
                 continue
-            if is_update and get_meeting_user(
-                self.datastore,
-                meeting_id,
-                user_id,
-                ["id"],
-            ):
+            db_meeting_user_exists = bool(
+                get_meeting_user(
+                    self.datastore,
+                    meeting_id,
+                    user_id,
+                    ["id"],
+                )
+            )
+            if is_update and db_meeting_user_exists:
                 instance_meeting_user = instance_meeting_user_data.get("for_update")
             else:
                 instance_meeting_user = instance_meeting_user_data.get("for_create")
@@ -378,10 +381,13 @@ class UserSaveSamlAccount(
                     names = sorted(
                         instance_meeting_user.pop(saml_meeting_user_field, [])
                     )
-                    if saml_meeting_user_field == "groups":
-                        ids = self.get_group_ids(names, meeting)
-                    elif saml_meeting_user_field == "structure_levels":
-                        ids = self.get_structure_level_ids(names, meeting)
+                    match saml_meeting_user_field:
+                        case "groups":
+                            ids = self.get_group_ids(
+                                names, meeting, db_meeting_user_exists
+                            )
+                        case "structure_levels":
+                            ids = self.get_structure_level_ids(names, meeting)
                     if ids:
                         instance_meeting_user[
                             f"{saml_meeting_user_field.rstrip('s')}_ids"
@@ -408,11 +414,13 @@ class UserSaveSamlAccount(
                 ["id", "group_ids", "structure_level_ids"],
             ):
                 for field_name in ["group_ids", "structure_level_ids"]:
+                    # TODO use sets
                     if old_ids := meeting_user_db.get(field_name):
                         ids = meeting_user.get(field_name, [])
                         for _id in ids:
                             if _id not in old_ids:
-                                meeting_user[field_name] = old_ids + [_id]
+                                old_ids.append(_id)
+                        meeting_user[field_name] = old_ids
 
     def get_field_data(
         self,
@@ -490,7 +498,9 @@ class UserSaveSamlAccount(
                 f"Meeting mapper: {mapper_name} could not find value in idp data for fields: {fields}. Using default if available."
             )
 
-    def get_group_ids(self, group_names: list[str], meeting: dict) -> list[int]:
+    def get_group_ids(
+        self, group_names: list[str], meeting: dict, db_meeting_user_exists: bool
+    ) -> list[int]:
         """
         Gets the group ids from given group names in that meeting.
         If none of the groups exists in the meeting, the meetings default group is returned.
@@ -510,13 +520,18 @@ class UserSaveSamlAccount(
             if len(groups) > 0:
                 return sorted(groups)
         if default_group_id := meeting["default_group_id"]:
-            external_meeting_id = meeting["external_id"]
-            self.logger.warning(
-                f"save_saml_account found no group in meeting '{external_meeting_id}' for {group_names}, but used default_group of meeting"
-            )
-            return [default_group_id]
+            if db_meeting_user_exists:
+                return []
+            else:
+                external_meeting_id = meeting["external_id"]
+                self.logger.warning(
+                    f"save_saml_account found no group in meeting '{external_meeting_id}' for {group_names}, but used default_group of meeting"
+                )
+                return [default_group_id]
         else:
-            assert False
+            raise ActionException(
+                "Invalid data state: mapped meeting does not have default group."
+            )
 
     def get_structure_level_ids(
         self, structure_level_names: list[str], meeting: dict[str, Any]

--- a/openslides_backend/action/actions/user/save_saml_account.py
+++ b/openslides_backend/action/actions/user/save_saml_account.py
@@ -363,12 +363,15 @@ class UserSaveSamlAccount(
             ):
                 continue
             db_meeting_user_exists = bool(
-                get_meeting_user(
-                    self.datastore,
-                    meeting_id,
-                    user_id,
-                    ["id"],
-                )
+                (
+                    get_meeting_user(
+                        self.datastore,
+                        meeting_id,
+                        user_id,
+                        ["group_ids"],
+                    )
+                    or {}
+                ).get("group_ids")
             )
             if is_update and db_meeting_user_exists:
                 instance_meeting_user = instance_meeting_user_data.get("for_update")
@@ -421,9 +424,14 @@ class UserSaveSamlAccount(
                             if _id not in old_ids:
                                 old_ids.append(_id)
                         meeting_user[field_name] = old_ids
-                    
-                default_group_id = self.datastore.get(f"meeting/{meeting_id}", ["default_group_id"])["default_group_id"]
-                if len(meeting_user["group_ids"]) > 1 and default_group_id in meeting_user["group_ids"]:
+
+                default_group_id = self.datastore.get(
+                    f"meeting/{meeting_id}", ["default_group_id"]
+                )["default_group_id"]
+                if (
+                    len(meeting_user["group_ids"]) > 1
+                    and default_group_id in meeting_user["group_ids"]
+                ):
                     meeting_user["group_ids"].remove(default_group_id)
 
     def get_field_data(

--- a/openslides_backend/action/actions/user/save_saml_account.py
+++ b/openslides_backend/action/actions/user/save_saml_account.py
@@ -362,7 +362,12 @@ class UserSaveSamlAccount(
                 )
             ):
                 continue
-            if is_update:
+            if is_update and get_meeting_user(
+                self.datastore,
+                meeting_id,
+                user_id,
+                ["id"],
+            ):
                 instance_meeting_user = instance_meeting_user_data.get("for_update")
             else:
                 instance_meeting_user = instance_meeting_user_data.get("for_create")

--- a/tests/system/action/user/test_save_saml_account.py
+++ b/tests/system/action/user/test_save_saml_account.py
@@ -1221,6 +1221,83 @@ class UserAddToGroup(UserBaseSamlAccount):
         )
         self.assert_model_not_exists("structure_level/4")
 
+    def test_update_user_participant_already_in_not_mapped_meeting(self) -> None:
+        """
+        Shows:
+            * user stays in group 2
+            * second mapper is used in spite of allow_update being false since Kreistag meeting is a create
+        """
+        del self.meeting_mappers[0]
+        self.meeting_mappers[0]["allow_update"] = "false"
+        self.set_user_groups(1, [2, 5])
+        self.set_models(
+            {
+                "organization/1": self.organization,
+                "structure_level/1": {
+                    "name": "structure1",
+                    "meeting_user_ids": [1],
+                    "meeting_id": 1,
+                },
+                "meeting_user/1": {"structure_level_ids": [1]},
+                "group/5": {"meeting_user_ids": []},
+                "meeting_user/2": {"group_ids": []},
+            }
+        )
+        response = self.request(
+            "user.save_saml_account",
+            {
+                "username": ["admin_saml"],
+                "email": "holzi@holz.de",
+                "kv_member_number": "KV_Könighols",
+                "kv_email": "hols@holz.de",
+                "participant_kv_number": "MG_1254",
+                "kv_group_attribute": "Delegates",
+                "kv_structure": "structure2",
+            },
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "user/1",
+            {
+                "saml_id": "admin_saml",
+                "username": "admin",
+                "meeting_user_ids": [1, 2],
+                "meeting_ids": [1, 4],
+            },
+        )
+        self.assert_model_exists(
+            "meeting_user/1",
+            {
+                "user_id": 1,
+                "group_ids": [2],
+                "meeting_id": 1,
+                "structure_level_ids": [1],
+            },
+        )
+        self.assert_model_exists(
+            "meeting_user/2",
+            {
+                "user_id": 1,
+                "group_ids": [5],
+                "meeting_id": 4,
+                "structure_level_ids": [2],
+            },
+        )
+        self.assert_model_not_exists("meeting_user/3")
+        self.assert_model_exists(
+            "group/2", {"meeting_user_ids": [1], "external_id": "Delegates"}
+        )
+        self.assert_model_exists(
+            "group/5", {"meeting_user_ids": [2], "external_id": "Delegates"}
+        )
+        self.assert_model_exists(
+            "structure_level/1", {"name": "structure1", "meeting_user_ids": [1]}
+        )
+        self.assert_model_exists(
+            "structure_level/2", {"name": "structure2", "meeting_user_ids": [2]}
+        )
+        self.assert_model_not_exists("structure_level/3")
+
     def test_update_user_participant_already_in_group_no_idp_group(self) -> None:
         """
         Shows when no idp group is send or mapping set:

--- a/tests/system/action/user/test_save_saml_account.py
+++ b/tests/system/action/user/test_save_saml_account.py
@@ -1139,26 +1139,26 @@ class UserAddToGroup(UserBaseSamlAccount):
             "group/5", {"meeting_user_ids": [2], "external_id": "Delegates"}
         )
 
-    def test_update_user_participant_already_in_group(self) -> None:
+    def test_update_user_participant_already_in_another_meeting(self) -> None:
         """
         Shows:
             * user stays in group 2
             * structure_level/1 left untouched structure_level/2 added
-            * second mapper is ignored due to being an update and allow_update being false
+            * second mapper is used in spite of allow_update being false since Kreistag meeting is a create
         """
         self.meeting_mappers[1]["allow_update"] = "False"
-        self.set_models({"organization/1": self.organization})
         self.set_user_groups(1, [2])
         self.set_models(
             {
+                "organization/1": self.organization,
                 "structure_level/1": {
                     "name": "structure1",
                     "meeting_user_ids": [1],
                     "meeting_id": 1,
-                }
+                },
+                "meeting_user/1": {"structure_level_ids": [1]},
             }
         )
-        self.update_model("meeting_user/1", {"structure_level_ids": [1]})
         response = self.request(
             "user.save_saml_account",
             {
@@ -1181,6 +1181,82 @@ class UserAddToGroup(UserBaseSamlAccount):
             {
                 "saml_id": "admin_saml",
                 "username": "admin",
+                "meeting_user_ids": [1, 2],
+                "meeting_ids": [1, 4],
+            },
+        )
+        self.assert_model_exists(
+            "meeting_user/1",
+            {
+                "user_id": 1,
+                "group_ids": [2],
+                "meeting_id": 1,
+                "structure_level_ids": [1, 2],
+            },
+        )
+        self.assert_model_exists(
+            "meeting_user/2",
+            {
+                "user_id": 1,
+                "group_ids": [5],
+                "meeting_id": 4,
+                "structure_level_ids": [3],
+            },
+        )
+        self.assert_model_not_exists("meeting_user/3")
+        self.assert_model_exists(
+            "group/2", {"meeting_user_ids": [1], "external_id": "Delegates"}
+        )
+        self.assert_model_exists(
+            "group/5", {"meeting_user_ids": [2], "external_id": "Delegates"}
+        )
+        self.assert_model_exists(
+            "structure_level/1", {"name": "structure1", "meeting_user_ids": [1]}
+        )
+        self.assert_model_exists(
+            "structure_level/2", {"name": "structure2", "meeting_user_ids": [1]}
+        )
+        self.assert_model_exists(
+            "structure_level/3", {"name": "structure2", "meeting_user_ids": [2]}
+        )
+        self.assert_model_not_exists("structure_level/4")
+
+    def test_update_user_participant_already_in_group_no_idp_group(self) -> None:
+        """
+        Shows when no idp group is send or mapping set:
+            * user stays in group 2
+            * structure_level/1 left untouched structure_level/2 added
+        """
+        # self.meeting_mappers[0]["groups"] = [{"default": "Default"}]
+        self.set_user_groups(1, [2])
+        self.set_models(
+            {
+                "organization/1": self.organization,
+                "structure_level/1": {
+                    "name": "structure1",
+                    "meeting_user_ids": [1],
+                    "meeting_id": 1,
+                },
+                "meeting_user/1": {"structure_level_ids": [1]},
+            }
+        )
+        response = self.request(
+            "user.save_saml_account",
+            {
+                "username": ["admin_saml"],
+                "member_number": "LV_Königholz",
+                "email": "holzi@holz.de",
+                "participant_number": "MG_1254",
+                "idp_group_attribute": "",
+                "structure": "structure2",
+            },
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "user/1",
+            {
+                "saml_id": "admin_saml",
+                "username": "admin",
                 "meeting_user_ids": [1],
                 "meeting_ids": [1],
             },
@@ -1189,7 +1265,7 @@ class UserAddToGroup(UserBaseSamlAccount):
             "meeting_user/1",
             {
                 "user_id": 1,
-                "group_ids": [2],
+                "group_ids": [2, 1],
                 "meeting_id": 1,
                 "structure_level_ids": [1, 2],
             },

--- a/tests/system/action/user/test_save_saml_account.py
+++ b/tests/system/action/user/test_save_saml_account.py
@@ -1227,7 +1227,9 @@ class UserAddToGroup(UserBaseSamlAccount):
             * user stays in group 2
             * structure_level/1 left untouched structure_level/2 added
         """
-        # self.meeting_mappers[0]["groups"] = [{"default": "Default"}]
+        self.meeting_mappers[0]["mappings"]["groups"] = [  # type: ignore
+            {"default": "Staff"}
+        ]
         self.set_user_groups(1, [2])
         self.set_models(
             {
@@ -1237,6 +1239,7 @@ class UserAddToGroup(UserBaseSamlAccount):
                     "meeting_user_ids": [1],
                     "meeting_id": 1,
                 },
+                "group/42": {"name": "Staff", "external_id": "Staff"},
                 "meeting_user/1": {"structure_level_ids": [1]},
             }
         )
@@ -1247,7 +1250,7 @@ class UserAddToGroup(UserBaseSamlAccount):
                 "member_number": "LV_Königholz",
                 "email": "holzi@holz.de",
                 "participant_number": "MG_1254",
-                "idp_group_attribute": "",
+                "groups": "Admin",  # should be ignored
                 "structure": "structure2",
             },
         )
@@ -1265,7 +1268,7 @@ class UserAddToGroup(UserBaseSamlAccount):
             "meeting_user/1",
             {
                 "user_id": 1,
-                "group_ids": [2, 1],
+                "group_ids": [2],
                 "meeting_id": 1,
                 "structure_level_ids": [1, 2],
             },
@@ -1281,6 +1284,49 @@ class UserAddToGroup(UserBaseSamlAccount):
             "structure_level/2", {"name": "structure2", "meeting_user_ids": [1]}
         )
         self.assert_model_not_exists("structure_level/3")
+
+    def test_update_user_participant_already_in_group_updates_default(self) -> None:
+        """
+        Shows when no idp group is send but mapping with inexistent group set:
+            * user stays in group 2 and shouldn't get a default group
+        """
+        self.set_user_groups(1, [2])
+        self.set_models({"organization/1": self.organization})
+        response = self.request(
+            "user.save_saml_account",
+            {
+                "username": ["admin_saml"],
+                "member_number": "LV_Königholz",
+                "email": "holzi@holz.de",
+                "participant_number": "MG_1254",
+                "groups": "Admin",  # should be ignored
+            },
+        )
+        self.assert_status_code(response, 200)
+        self.assert_model_exists(
+            "user/1",
+            {
+                "saml_id": "admin_saml",
+                "username": "admin",
+                "meeting_user_ids": [1],
+                "meeting_ids": [1],
+            },
+        )
+        self.assert_model_exists(
+            "meeting_user/1",
+            {
+                "user_id": 1,
+                "group_ids": [2],
+                "meeting_id": 1,
+            },
+        )
+        self.assert_model_not_exists("meeting_user/2")
+        self.assert_model_exists(
+            "group/1", {"meeting_user_ids": None, "external_id": "Default"}
+        )
+        self.assert_model_exists(
+            "group/2", {"meeting_user_ids": [1], "external_id": "Delegates"}
+        )
 
     def test_update_user_add_group_to_existing_groups(self) -> None:
         """group added, user created and logged in"""

--- a/tests/system/action/user/test_save_saml_account.py
+++ b/tests/system/action/user/test_save_saml_account.py
@@ -1329,7 +1329,12 @@ class UserAddToGroup(UserBaseSamlAccount):
         )
 
     def test_update_user_add_group_to_existing_groups(self) -> None:
-        """group added, user created and logged in"""
+        """
+        Shows:
+            * group added
+            * user created and logged in
+            * default group removed as it's not legal next to other groups
+        """
         self.set_user_groups(1, [1, 3])
         response = self.request(
             "user.save_saml_account",
@@ -1354,7 +1359,7 @@ class UserAddToGroup(UserBaseSamlAccount):
             },
         )
         self.assert_model_exists(
-            "meeting_user/1", {"user_id": 1, "group_ids": [1, 3, 2], "meeting_id": 1}
+            "meeting_user/1", {"user_id": 1, "group_ids": [3, 2], "meeting_id": 1}
         )
         self.assert_model_exists(
             "meeting_user/2", {"user_id": 1, "group_ids": [5], "meeting_id": 4}

--- a/tests/util.py
+++ b/tests/util.py
@@ -61,7 +61,9 @@ class Client(WerkzeugClient):
             )
         except AuthenticateException as e:
             raise AuthenticationException(str(e))
-        assert response.status_code == 200
+        assert (
+            response.status_code == 200
+        ), f"Auth Service: {response.status_code} {response.reason} {response.content.decode()}"
         # save access token and refresh id for subsequent requests
         self.update_auth_data(
             {


### PR DESCRIPTION
resolves #3496 
Fix groups being removed with update.
Allow `meeting_user` creation if user is not member of meeting.
I added the group rule that the default group is only used when there no other is.