### PR TITLE
Handle health route outside of threads

### DIFF
--- a/openslides_backend/http/thread_worker.py
+++ b/openslides_backend/http/thread_worker.py
@@ -8,7 +8,12 @@ class OpenSlidesThreadWorker(ThreadWorker):
         # Peek into the sockets content to be able to read out the path part of the header (which ought to be the part after the first whitespace).
         peek = str(conn.sock.recv(4096, MSG_PEEK)).split()
 
-        if len(peek) >= 2 and "system/action/health" in peek[1]:
+        if (
+            len(peek) >= 2
+            and (stripped_path := peek[1].strip("/")).startswith("system/")
+            and stripped_path.endswith("/health")
+            and len(stripped_path.split("/")) == 3
+        ):
             # If the health route is recognized, set data_ready to True to stop handle from returning _DEFER and force it into working instead.
             # Since the message could be read, the data is probably there already,
             # the health route doesn't take a payload to begin with.

--- a/openslides_backend/http/thread_worker.py
+++ b/openslides_backend/http/thread_worker.py
@@ -1,0 +1,14 @@
+from socket import MSG_PEEK
+
+from gunicorn.workers.gthread import TConn, ThreadWorker
+
+
+class OpenSlidesThreadWorker(ThreadWorker):
+    def enqueue_req(self, conn: TConn) -> None:
+        peek = str(conn.sock.recv(4096, MSG_PEEK)).split()
+        if len(peek) >= 2 and "system/action/health" in peek[1]:
+            conn.data_ready = True
+            res = self.handle(conn)
+            self.finish_request(conn, res)
+        else:
+            super().enqueue_req(conn)

--- a/openslides_backend/http/thread_worker.py
+++ b/openslides_backend/http/thread_worker.py
@@ -5,9 +5,15 @@ from gunicorn.workers.gthread import TConn, ThreadWorker
 
 class OpenSlidesThreadWorker(ThreadWorker):
     def enqueue_req(self, conn: TConn) -> None:
+        # Peek into the sockets content to be able to read out the path part of the header (which ought to be the part after the first whitespace).
         peek = str(conn.sock.recv(4096, MSG_PEEK)).split()
+
         if len(peek) >= 2 and "system/action/health" in peek[1]:
+            # If the health route is recognized, set data_ready to True to stop handle from returning _DEFER and force it into working instead.
+            # Since the message could be read, the data is probably there already,
+            # the health route doesn't take a payload to begin with.
             conn.data_ready = True
+            # Call the base class methods used in the base method in order, don't enthread them.
             res = self.handle(conn)
             self.finish_request(conn, res)
         else:

--- a/openslides_backend/main.py
+++ b/openslides_backend/main.py
@@ -54,7 +54,7 @@ class OpenSlidesBackendGunicornApplication(BaseApplication):  # pragma: no cover
             "loglevel": self.env.get_loglevel().lower(),
             "reload": self.env.is_dev_mode(),
             "reload_engine": "auto",  # This is the default however.
-            "worker_class": "gthread",  # async gthread with unlimited prolongation possibility
+            "worker_class": "openslides_backend.http.thread_worker.OpenSlidesThreadWorker",  # async gthread with unlimited prolongation possibility
             "threads": int(
                 self.env.OPENSLIDES_BACKEND_NUM_THREADS
             ),  # Threads per Worker(process)


### PR DESCRIPTION
Closes #3619 

Establishes custom thread worker that handles the health route outside the threads.

From my manual testing it does handle the requests separately and the instance is functional, however I haven't tested it on a large scale prod setup or a long running instance and I don't know what will happen if the connection has high latency (my theory is some health requests may be missed and fed into the regular process instead, nothing that can be done about it though), so @rrenkert could you try out your experiment with this version?

Also, since the base method and class that was overridden can be further changed by the gunicorn devs, this might break at some point later on.
The code changes _are_ pretty minimal, and, except for the most recent change 5 months ago, this method that was changed did not have any substantial changes for 12 years, but I still thought this ought to be mentioned at least.

@hjanott if you want to know what the original code looks like before reviewing: https://github.com/benoitc/gunicorn/blob/master/gunicorn/workers/gthread.py#L241