### PR TITLE
Set tz=UTC when converting integer timestamps

### DIFF
--- a/openslides_backend/action/actions/committee/import_.py
+++ b/openslides_backend/action/actions/committee/import_.py
@@ -192,7 +192,9 @@ class CommitteeImport(BaseImportAction, CommitteeImportMixin):
                     if (value := action_data.get(field_name)) and isinstance(
                         value, int
                     ):
-                        action_data[field_name] = datetime.fromtimestamp(value, tz=timezone.utc)
+                        action_data[field_name] = datetime.fromtimestamp(
+                            value, tz=timezone.utc
+                        )
                 if template_id := entry.get("meeting_template"):
                     action_data["meeting_id"] = template_id
                     clone_meeting_data.append(action_data)

--- a/openslides_backend/action/actions/committee/import_.py
+++ b/openslides_backend/action/actions/committee/import_.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from openslides_backend.action.actions.meeting.clone import MeetingClone
@@ -192,7 +192,7 @@ class CommitteeImport(BaseImportAction, CommitteeImportMixin):
                     if (value := action_data.get(field_name)) and isinstance(
                         value, int
                     ):
-                        action_data[field_name] = datetime.fromtimestamp(value)
+                        action_data[field_name] = datetime.fromtimestamp(value, tz=timezone.utc)
                 if template_id := entry.get("meeting_template"):
                     action_data["meeting_id"] = template_id
                     clone_meeting_data.append(action_data)

--- a/openslides_backend/action/actions/meeting/clone.py
+++ b/openslides_backend/action/actions/meeting/clone.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, cast
 
@@ -130,7 +130,7 @@ class MeetingClone(MeetingImport):
         # Set proper types for TimestampFields
         for field_name in ["start_time", "end_time"]:
             if (value := instance.get(field_name)) and isinstance(value, int):
-                instance[field_name] = datetime.fromtimestamp(value)
+                instance[field_name] = datetime.fromtimestamp(value, tz=timezone.utc)
 
         meeting.pop("external_id", "")
         for field in updatable_fields:

--- a/openslides_backend/action/actions/meeting/create.py
+++ b/openslides_backend/action/actions/meeting/create.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime,timezone
 from typing import Any
 
 from openslides_backend.models.models import Meeting
@@ -227,7 +227,7 @@ class MeetingCreate(
         # Set proper types for TimestampFields
         for field_name in ["start_time", "end_time"]:
             if (value := instance.get(field_name)) and isinstance(value, int):
-                instance[field_name] = datetime.fromtimestamp(value)
+                instance[field_name] = datetime.fromtimestamp(value, tz=timezone.utc)
         return instance
 
     def get_dependent_action_data(

--- a/openslides_backend/action/actions/meeting/create.py
+++ b/openslides_backend/action/actions/meeting/create.py
@@ -1,4 +1,4 @@
-from datetime import datetime,timezone
+from datetime import datetime, timezone
 from typing import Any
 
 from openslides_backend.models.models import Meeting

--- a/openslides_backend/action/actions/meeting/update.py
+++ b/openslides_backend/action/actions/meeting/update.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, cast
 
 from psycopg.types.json import Jsonb
@@ -329,7 +329,7 @@ class MeetingUpdate(
         for field in ["start_time", "end_time"]:
             raw_value = instance.get(field)
             if isinstance(raw_value, int):
-                instance[field] = datetime.fromtimestamp(raw_value)
+                instance[field] = datetime.fromtimestamp(raw_value, tz=timezone.utc)
 
         if (translations := instance.get("custom_translations")) is not None:
             instance["custom_translations"] = Jsonb(translations)

--- a/openslides_backend/action/actions/motion/update.py
+++ b/openslides_backend/action/actions/motion/update.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
-from zoneinfo import ZoneInfo
 
 from psycopg.types.json import Jsonb
 
@@ -109,7 +108,7 @@ class MotionUpdate(
 
     def update_instance(self, instance: dict[str, Any]) -> dict[str, Any]:
         instance = super().update_instance(instance)
-        timestamp = datetime.now(ZoneInfo("UTC"))
+        timestamp = datetime.now(tz=timezone.utc)
         instance["last_modified"] = timestamp
         motion = self.datastore.get(
             fqid_from_collection_and_id(self.model.collection, instance["id"]),
@@ -128,7 +127,7 @@ class MotionUpdate(
             raw_timestamp = instance.get(field_name)
             if isinstance(raw_timestamp, int):
                 instance[field_name] = datetime.fromtimestamp(
-                    raw_timestamp, ZoneInfo("UTC")
+                    raw_timestamp, tz=timezone.utc
                 )
 
         if instance.get("workflow_id"):

--- a/openslides_backend/action/actions/structure_level_list_of_speakers/update.py
+++ b/openslides_backend/action/actions/structure_level_list_of_speakers/update.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from openslides_backend.action.generics.update import UpdateAction
@@ -48,7 +48,7 @@ class StructureLevelListOfSpeakersUpdateAction(UpdateAction):
             )
 
         if (t := instance.get("current_start_time")) and isinstance(t, int):
-            instance["current_start_time"] = datetime.fromtimestamp(t)
+            instance["current_start_time"] = datetime.fromtimestamp(t, tz=timezone.utc)
 
         if spoken_time := instance.pop("spoken_time", None):
             db_instance = self.datastore.get(


### PR DESCRIPTION
Fixes #3632


Seems in the action implementation integer timestamps are converted using `datetime.fromtimestamp(value)` without specifying timezone information. This will correctly assume UTC for the value. However as stated in the [docs](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp):

    If optional argument tz is None or not specified, [...] the returned datetime object is naive.

This leads to shifts in the value, if the timezone in the postgres's users locale differs from UTC. This is not the case is the compose based dev setup but was observed in other environments.