### PR TITLE
Fix forget_password email translation bug

### DIFF
--- a/docs/actions/user.forget_password.md
+++ b/docs/actions/user.forget_password.md
@@ -9,7 +9,9 @@
 
 ## Action 
 
-A user can change their password by this action without being authenticated. To perform a changing of their password the user enters their email-address (case insensitive). The client then sends a hard-coded reset email to the given email-address (as `email`). TODO: translations
+A user can change their password by this action without being authenticated. To perform a changing of their password the user enters their email-address (case insensitive). The client then sends a hard-coded reset email to the given email-address (as `email`). 
+
+The email text is translated based on the `Accept-Languages` column of the request header. The highest-priority language that is supported by OpenSlides is used. If none of them are supported, orga default language is used.
 
 Regardless if the email-address is used by a user, the client shows the user a successful message (for example "An email was successfully sent to the given email-address"). This is necessary to avoid filtering which email-address is used by an OpenSlides-user.
 

--- a/openslides_backend/http/views/action_view.py
+++ b/openslides_backend/http/views/action_view.py
@@ -35,6 +35,8 @@ class ActionView(BaseView):
         with get_new_os_conn() as conn:
             with conn.cursor() as curs:
                 MigrationHelper.assert_migration_index(curs)
+                curs.execute("SELECT default_language FROM organization_t WHERE id = 1")
+                lang:str = curs.fetchone().get("default_language")
         # Get user id.
         user_id, access_token = self.get_user_id_from_headers(
             request.headers, request.cookies
@@ -47,7 +49,7 @@ class ActionView(BaseView):
 
         # Handle request.
         handler = ActionHandler(self.env, self.services, self.logging)
-        Translator.set_translation_language(request.headers.get("Accept-Language"))
+        Translator.set_translation_language(request.headers.get("Accept-Language"), lang)
         is_atomic = not request.environ["RAW_URI"].endswith("handle_separately")
         response = handle_action_in_worker_thread(
             request.json, user_id, is_atomic, handler

--- a/openslides_backend/http/views/action_view.py
+++ b/openslides_backend/http/views/action_view.py
@@ -36,7 +36,7 @@ class ActionView(BaseView):
             with conn.cursor() as curs:
                 MigrationHelper.assert_migration_index(curs)
                 curs.execute("SELECT default_language FROM organization_t WHERE id = 1")
-                lang:str = curs.fetchone().get("default_language")
+                lang: str | None = (curs.fetchone() or {}).get("default_language")
         # Get user id.
         user_id, access_token = self.get_user_id_from_headers(
             request.headers, request.cookies
@@ -49,7 +49,9 @@ class ActionView(BaseView):
 
         # Handle request.
         handler = ActionHandler(self.env, self.services, self.logging)
-        Translator.set_translation_language(request.headers.get("Accept-Language"), lang)
+        Translator.set_translation_language(
+            request.headers.get("Accept-Language"), lang
+        )
         is_atomic = not request.environ["RAW_URI"].endswith("handle_separately")
         response = handle_action_in_worker_thread(
             request.json, user_id, is_atomic, handler

--- a/openslides_backend/i18n/translator.py
+++ b/openslides_backend/i18n/translator.py
@@ -29,7 +29,7 @@ class _Translator:
         else:
             return msg
 
-    def set_translation_language(self, lang_header: str | None) -> None:
+    def set_translation_language(self, lang_header: str | None, default_language: str | None = None) -> None:
         langs = []
         if lang_header is not None:
             langs = self.parse_language_header(lang_header)
@@ -38,7 +38,7 @@ class _Translator:
                 self.current_language = lang
                 break
         else:
-            self.current_language = DEFAULT_LANGUAGE
+            self.current_language = default_language or DEFAULT_LANGUAGE
 
     def parse_language_header(self, lang_header: str) -> list[str]:
         # each language is separated by a comma

--- a/openslides_backend/i18n/translator.py
+++ b/openslides_backend/i18n/translator.py
@@ -29,7 +29,9 @@ class _Translator:
         else:
             return msg
 
-    def set_translation_language(self, lang_header: str | None, default_language: str | None = None) -> None:
+    def set_translation_language(
+        self, lang_header: str | None, default_language: str | None = None
+    ) -> None:
         langs = []
         if lang_header is not None:
             langs = self.parse_language_header(lang_header)
@@ -58,7 +60,7 @@ class _Translator:
             code = code.split("-")[0]
             result.append((q, code))
         # sort by quality value and return only the codes
-        return [t[1] for t in sorted(result, key=lambda tup: tup[0])]
+        return [t[1] for t in sorted(result, key=lambda tup: tup[0], reverse=True)]
 
 
 Translator = _Translator()

--- a/tests/system/action/user/test_forget_password.py
+++ b/tests/system/action/user/test_forget_password.py
@@ -53,7 +53,10 @@ class UserForgetPassword(BaseActionTestCase):
 
     def test_forget_password_send_mail_correct_translated_to_orga_default(self) -> None:
         self.set_models(
-            {ONE_ORGANIZATION_FQID: {"url": None, "default_language": "de"}, "user/1": {"email": "test@ntvtn.de"}}
+            {
+                ONE_ORGANIZATION_FQID: {"url": None, "default_language": "de"},
+                "user/1": {"email": "test@ntvtn.de"},
+            }
         )
         start_time = datetime.now(ZoneInfo("UTC"))
         handler = AIOHandler()
@@ -70,9 +73,56 @@ class UserForgetPassword(BaseActionTestCase):
         assert handler.emails[0]["from"] == EmailSettings.default_from_email
         assert "Ihres OpenSlides-Passworts" in handler.emails[0]["data"]
 
-    def test_forget_password_send_mail_correct_translated_to_orga_default_2(self) -> None:
+    def test_forget_password_send_mail_can_handle_us_english(self) -> None:
         self.set_models(
-            {ONE_ORGANIZATION_FQID: {"url": None, "default_language": "en"}, "user/1": {"email": "test@ntvtn.de"}}
+            {
+                ONE_ORGANIZATION_FQID: {"url": None, "default_language": "de"},
+                "user/1": {"email": "test@ntvtn.de"},
+            }
+        )
+        start_time = datetime.now(ZoneInfo("UTC"))
+        handler = AIOHandler()
+        with AiosmtpdServerManager(handler):
+            response = self.request(
+                "user.forget_password",
+                {"email": "test@ntvtn.de"},
+                anonymous=True,
+                lang="en-US",
+            )
+        self.assert_status_code(response, 200)
+        user = self.get_model("user/1")
+        assert user.get("last_email_sent", 0) >= start_time
+        assert handler.emails[0]["from"] == EmailSettings.default_from_email
+        assert "You are receiving this email" in handler.emails[0]["data"]
+
+    def test_forget_password_language_priority_interpreted_right(self) -> None:
+        self.set_models(
+            {ONE_ORGANIZATION_FQID: {"url": None}, "user/1": {"email": "test@ntvtn.de"}}
+        )
+        start_time = datetime.now(ZoneInfo("UTC"))
+        handler = AIOHandler()
+        with AiosmtpdServerManager(handler):
+            response = self.request(
+                "user.forget_password",
+                {"email": "test@ntvtn.de"},
+                anonymous=True,
+                lang="de,en-US;q=0.9,en;q=0.8,es;q=0.7,cs;q=0.6",
+            )
+        self.assert_status_code(response, 200)
+        user = self.get_model("user/1")
+        assert user.get("last_email_sent", 0) >= start_time
+        assert handler.emails[0]["from"] == EmailSettings.default_from_email
+        assert "Ihres OpenSlides-Passworts: admin" in handler.emails[0]["data"]
+        assert "Ihres OpenSlides-Passworts" in handler.emails[0]["data"]
+
+    def test_forget_password_send_mail_correct_translated_to_orga_default_2(
+        self,
+    ) -> None:
+        self.set_models(
+            {
+                ONE_ORGANIZATION_FQID: {"url": None, "default_language": "en"},
+                "user/1": {"email": "test@ntvtn.de"},
+            }
         )
         start_time = datetime.now(ZoneInfo("UTC"))
         handler = AIOHandler()

--- a/tests/system/action/user/test_forget_password.py
+++ b/tests/system/action/user/test_forget_password.py
@@ -51,6 +51,44 @@ class UserForgetPassword(BaseActionTestCase):
         assert handler.emails[0]["from"] == EmailSettings.default_from_email
         assert "Ihres OpenSlides-Passworts" in handler.emails[0]["data"]
 
+    def test_forget_password_send_mail_correct_translated_to_orga_default(self) -> None:
+        self.set_models(
+            {ONE_ORGANIZATION_FQID: {"url": None, "default_language": "de"}, "user/1": {"email": "test@ntvtn.de"}}
+        )
+        start_time = datetime.now(ZoneInfo("UTC"))
+        handler = AIOHandler()
+        with AiosmtpdServerManager(handler):
+            response = self.request(
+                "user.forget_password",
+                {"email": "test@ntvtn.de"},
+                anonymous=True,
+                lang="mars",
+            )
+        self.assert_status_code(response, 200)
+        user = self.get_model("user/1")
+        assert user.get("last_email_sent", 0) >= start_time
+        assert handler.emails[0]["from"] == EmailSettings.default_from_email
+        assert "Ihres OpenSlides-Passworts" in handler.emails[0]["data"]
+
+    def test_forget_password_send_mail_correct_translated_to_orga_default_2(self) -> None:
+        self.set_models(
+            {ONE_ORGANIZATION_FQID: {"url": None, "default_language": "en"}, "user/1": {"email": "test@ntvtn.de"}}
+        )
+        start_time = datetime.now(ZoneInfo("UTC"))
+        handler = AIOHandler()
+        with AiosmtpdServerManager(handler):
+            response = self.request(
+                "user.forget_password",
+                {"email": "test@ntvtn.de"},
+                anonymous=True,
+                lang="mars",
+            )
+        self.assert_status_code(response, 200)
+        user = self.get_model("user/1")
+        assert user.get("last_email_sent", 0) >= start_time
+        assert handler.emails[0]["from"] == EmailSettings.default_from_email
+        assert "You are receiving this email" in handler.emails[0]["data"]
+
     def test_forget_password_saml_sso_user_error(self) -> None:
         self.set_models(
             {

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -55,16 +55,16 @@ class TranslatorTest(TestCase):
 
     def test_translate_weight_sorted_header_asc(self) -> None:
         self.translator.set_translation_language("en;q=0.5,de;q=0.8")
-        assert self.translator.translate("c") == "c"
+        assert self.translator.translate("c") == "d"
 
     def test_translate_weight_sorted_header_desc(self) -> None:
         self.translator.set_translation_language("en;q=0.8,de;q=0.5")
-        assert self.translator.translate("c") == "d"
+        assert self.translator.translate("c") == "c"
 
     def test_translate_half_weight_sorted_header_asc(self) -> None:
         self.translator.set_translation_language("en;q=0.5,de")
-        assert self.translator.translate("c") == "c"
+        assert self.translator.translate("c") == "d"
 
     def test_translate_half_weight_sorted_header_desc(self) -> None:
         self.translator.set_translation_language("en,de;q=0.5")
-        assert self.translator.translate("c") == "d"
+        assert self.translator.translate("c") == "c"


### PR DESCRIPTION
Closes #3649 

The translator was parsing language priority in the wrong order -> Fixed that.
The action view didn't use the orga language as a default when setting translation -> Changed that.
The documentation didn't include the translation functionality yet -> Added that.