### PR TITLE
[dammi] Handle remove

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,9 @@ create-database:
 generate-schema:
 	make -C meta/dev generate-relational-schema
 
+replace-previous-models:
+	cp -r meta/collections/ openslides_backend/migrations/previous_models/ && cp meta/collection-meta.yml openslides_backend/migrations/previous_models/
+
 generate-migration-diff:
 	python openslides_backend/migrations/sql_diff_generator.py $(ARGS)
 
@@ -181,7 +184,7 @@ run-psql:
 
 # General
 
-generate-files: | generate-permissions generate-models generate-schema generate-migration-diff 
+generate-files: | generate-permissions generate-models generate-schema generate-migration-diff
 
 # Build and run production docker container (not usable inside the docker container)
 

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -312,7 +312,9 @@ def handle_remove_tree(
     for collection_name, field_lists in remove_tree_dict.items():
         fields = field_lists[1]["fields"]
         for field_name in fields[0]:
-            result += f"ALTER TABLE {collection_name}_t DROP COLUMN {field_name};\n"
+            result += (
+                f"ALTER TABLE {collection_name}_t DROP COLUMN {field_name} CASCADE;\n"
+            )
 
             dc_remove_tree_dict[collection_name][1]["fields"][0].remove(field_name)
             # TODO fields[1]

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -79,7 +79,7 @@ def main() -> int:
 
 
 def remove_empty(dictionary: dict[str, Any], key: str) -> None:
-    if not any(dictionary[key]):
+    if dictionary[key] is None or not any(dictionary[key]):
         del dictionary[key]
 
 

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -358,6 +358,32 @@ def handle_remove_tree(
                                             collection_name, field_name, "DEFAULT"
                                         )
                                     )
+                                case "required":
+                                    result += (
+                                        Helper.get_drop_column_attribute_statement(
+                                            collection_name, field_name, "NOT NULL"
+                                        )
+                                    )
+                                case "minimum" | "maximum" | "minLength" | "unique":
+                                    constraint_name_func = getattr(
+                                        HelperGetNames,
+                                        f"get_{attr.lower()}_constraint_name",
+                                    )
+                                    constraint_name = constraint_name_func(
+                                        collection_name,
+                                        (
+                                            [field_name]
+                                            if attr == "unique"
+                                            else field_name
+                                        ),
+                                    )
+                                    result += (
+                                        Helper.get_drop_table_constraint_statement(
+                                            collection_name, constraint_name
+                                        )
+                                    )
+                                case _:
+                                    continue
                             dc_remove_tree_dict[collection_name][1]["fields"][1][
                                 field_name
                             ][0].remove(attr)

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -339,26 +339,51 @@ def handle_remove_tree(
 ) -> str:
     result = ""
     for collection_name, collection_data in remove_tree_dict.items():
-        fields_data = collection_data[1]["fields"]
-        for field_name in fields_data[0]:
-            result += Helper.get_drop_column_statement(collection_name, field_name)
-            dc_remove_tree_dict[collection_name][1]["fields"][0].remove(field_name)
-            remove_empty(dc_remove_tree_dict[collection_name][1], "fields")
-        for field_name, attrs in fields_data[1].items():
-            for attr in attrs[0]:
-                match attr:
-                    case "default":
-                        result += Helper.get_drop_column_attribute_statement(
-                            collection_name, field_name, "DEFAULT"
+        for key, data in collection_data[1].items():
+            match key:
+                case "fields":
+                    for field_name in data[0]:
+                        result += Helper.get_drop_column_statement(
+                            collection_name, field_name
                         )
-                dc_remove_tree_dict[collection_name][1]["fields"][1][field_name][
-                    0
-                ].remove(attr)
-                remove_empty(
-                    dc_remove_tree_dict[collection_name][1]["fields"][1], field_name
-                )
-            remove_empty(dc_remove_tree_dict[collection_name][1], "fields")
-        remove_empty(dc_remove_tree_dict, collection_name)
+                        dc_remove_tree_dict[collection_name][1]["fields"][0].remove(
+                            field_name
+                        )
+                    for field_name, attrs in data[1].items():
+                        for attr in attrs[0]:
+                            match attr:
+                                case "default":
+                                    result += (
+                                        Helper.get_drop_column_attribute_statement(
+                                            collection_name, field_name, "DEFAULT"
+                                        )
+                                    )
+                            dc_remove_tree_dict[collection_name][1]["fields"][1][
+                                field_name
+                            ][0].remove(attr)
+                            remove_empty(
+                                dc_remove_tree_dict[collection_name][1]["fields"][1],
+                                field_name,
+                            )
+                    remove_empty(dc_remove_tree_dict[collection_name][1], "fields")
+                    remove_empty(dc_remove_tree_dict, collection_name)
+                case "unique_together":
+                    for fields in data:
+                        result += Helper.get_drop_table_constraint_statement(
+                            collection_name,
+                            HelperGetNames.get_unique_constraint_name(
+                                collection_name,
+                                Helper.split_unique_together_fields(fields),
+                            ),
+                        )
+                        dc_remove_tree_dict[collection_name][1][
+                            "unique_together"
+                        ].remove(fields)
+                        remove_empty(
+                            dc_remove_tree_dict[collection_name][1],
+                            "unique_together",
+                        )
+                    remove_empty(dc_remove_tree_dict, collection_name)
     return result
 
 

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -12,10 +12,12 @@ from openslides_backend.migrations.migration_helper import MigrationHelper
 from openslides_backend.migrations.yaml_diff_generator import (
     CollectionsRemoveList,
     EnumTypesRemoveDict,
+    FieldAttributes,
     RemoveDiffDict,
     dumpjson,
     generate_diff,
 )
+from openslides_backend.shared.exceptions import BadCodingException
 
 """
 This script works in conjunction with the yaml_diff_generator.py.
@@ -382,8 +384,32 @@ def handle_remove_tree(
                                             collection_name, constraint_name
                                         )
                                     )
+                                case "sql":
+                                    result += Helper.get_drop_view_statement(
+                                        collection_name
+                                    )
+                                case "constant":
+                                    result += Helper.get_drop_trigger_statement(
+                                        collection_name,
+                                        HelperGetNames.get_constant_field_trigger_name(
+                                            collection_name, field_name
+                                        ),
+                                    )
+                                case value if (
+                                    value in FieldAttributes.skipped_in_schema
+                                ):
+                                    pass
+                                case "type":
+                                    raise BadCodingException(
+                                        f"{collection_name}/{field_name}: '{attr}' is a required field attribute."
+                                    )
                                 case _:
-                                    continue
+                                    # "to" and "reference" are currently skipped. They can only be removed
+                                    # if type changes to not relational field which is not the case
+                                    # in the foreseeable future.
+                                    raise NotImplementedError(
+                                        f"{collection_name}/{field_name}: {attr}"
+                                    )
                             dc_remove_tree_dict[collection_name][1]["fields"][1][
                                 field_name
                             ][0].remove(attr)

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -35,7 +35,13 @@ def main() -> int:
     if args.dumpjson:
         dumpjson(diff)
 
-    sql = "-- REMOVE SECTION --\n"
+    # Has to happen before remove: field types have to change before dropping the enum
+    sql = "-- EDIT SECTION --\n"
+    edit = diff["edit"]
+    if isinstance(edit, tuple) and isinstance(edit_dict := edit[1], dict):
+        sql += handle_edit_tree(edit_dict, diff_control["edit"][1])
+
+    sql += "\n-- REMOVE SECTION --\n"
     # TODO create generate diff content functions in schema generator.
     # Using a lot of isinstance calls here for pleasing mypy
     remove: RemoveDiffDict | None = diff["remove"]
@@ -54,11 +60,6 @@ def main() -> int:
         sql += generate_new_collection_sql(add[0], diff_control["add"][0])
     if isinstance(add, tuple) and isinstance(add_tree_dict := add[1], dict):
         sql += handle_add_tree(add_tree_dict, diff_control["add"][1])
-
-    sql += "\n-- EDIT SECTION --\n"
-    edit = diff["edit"]
-    if isinstance(edit, tuple) and isinstance(edit_dict := edit[1], dict):
-        sql += handle_edit_tree(edit_dict, diff_control["edit"][1])
 
     # TODO Do this in a sub folder migrations?
     with open(

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -314,7 +314,7 @@ def handle_remove(remove: RemoveDiffDict, dc_remove_dict: dict[str, Any]) -> str
             collection_names := collections_remove_list[0], list
         ) and isinstance(dc_collection_names := dc_remove_dict["collections"][0], list):
             for collection_name in collection_names:
-                result += f"DROP TABLE {collection_name}_t CASCADE;\n"
+                result += Helper.get_drop_table_statement(collection_name)
                 dc_collection_names.remove(collection_name)
         if isinstance(
             remove_tree_dict := collections_remove_list[1], dict
@@ -340,9 +340,7 @@ def handle_remove_tree(
     for collection_name, field_lists in remove_tree_dict.items():
         fields = field_lists[1]["fields"]
         for field_name in fields[0]:
-            result += (
-                f"ALTER TABLE {collection_name}_t DROP COLUMN {field_name} CASCADE;\n"
-            )
+            result += Helper.get_drop_column_statement(collection_name, field_name)
 
             dc_remove_tree_dict[collection_name][1]["fields"][0].remove(field_name)
             # TODO fields[1]
@@ -359,10 +357,9 @@ def handle_remove_enum_types(
     result = ""
     for collection_name, field_names in remove_tree_dict.items():
         for field_name in field_names:
-            enum_name = HelperGetNames.get_enum_name_for_column(
+            result += Helper.get_drop_enum_type_statement_from_collection_and_column(
                 collection_name, field_name
             )
-            result += f"DROP TYPE {enum_name};\n"
             dc_remove_tree_dict[collection_name].remove(field_name)
         remove_empty(dc_remove_tree_dict, collection_name)
     return result

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -444,6 +444,9 @@ def handle_remove_tree(
                                             result += Helper.get_drop_trigger_statement(
                                                 log_trigger["on_table"], trigger_name
                                             )
+                                # case "equal_fields":
+                                #     pass
+                                #     TODO: correctly handle deleted equal_fields
                                 case _:
                                     raise NotImplementedError(
                                         f"{collection_name}/{field_name}: {attr}"

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -404,13 +404,6 @@ def handle_remove_tree(
                                             collection_name, field_name
                                         ),
                                     )
-                                case "sequence_scope":
-                                    result += Helper.get_drop_trigger_statement(
-                                        collection_name,
-                                        HelperGetNames.get_partitioned_sequence_trigger_name(
-                                            collection_name, field_name
-                                        ),
-                                    )
                                 case value if (
                                     value in FieldAttributes.skipped_in_schema
                                 ):
@@ -420,9 +413,9 @@ def handle_remove_tree(
                                         f"{collection_name}/{field_name}: '{attr}' is a required field attribute."
                                     )
                                 case _:
-                                    # "to" and "reference" are currently skipped. They can only be removed
-                                    # if type changes to not relational field which is not the case
-                                    # in the foreseeable future.
+                                    # Skipped as not likely to be removed in the foreseeable future:
+                                    # "to" and "reference": can only be removed if type changes to not relational field
+                                    # "sequence_scope": would turn a sequence field into a regular number field
                                     raise NotImplementedError(
                                         f"{collection_name}/{field_name}: {attr}"
                                     )

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -9,7 +9,13 @@ import simplejson as json
 from meta.dev.src.generate_sql_schema import GenerateCodeBlocks, Helper
 from meta.dev.src.helper_get_names import HelperGetNames
 from openslides_backend.migrations.migration_helper import MigrationHelper
-from openslides_backend.migrations.yaml_diff_generator import dumpjson, generate_diff
+from openslides_backend.migrations.yaml_diff_generator import (
+    CollectionsRemoveList,
+    EnumTypesRemoveDict,
+    RemoveDiffDict,
+    dumpjson,
+    generate_diff,
+)
 
 """
 This script works in conjunction with the yaml_diff_generator.py.
@@ -32,13 +38,9 @@ def main() -> int:
     sql = "-- REMOVE SECTION --\n"
     # TODO create generate diff content functions in schema generator.
     # Using a lot of isinstance calls here for pleasing mypy
-    remove = diff["remove"]
-    if isinstance(remove, list) and isinstance(remove[0], list):
-        for collection_name in remove[0]:
-            sql += f"DROP TABLE {collection_name}_t CASCADE;\n"
-            diff_control["remove"][0].remove(collection_name)
-    if isinstance(remove, list) and isinstance(remove_tree_dict := remove[1], dict):
-        sql += handle_remove_tree(remove_tree_dict, diff_control["remove"][1])
+    remove: RemoveDiffDict | None = diff["remove"]
+    if remove:
+        sql += handle_remove(remove, diff_control["remove"])
 
     sql += "\n-- RENAME SECTION --\n"
     rename = diff["rename"]
@@ -304,9 +306,35 @@ def handle_rename(
     return result
 
 
+def handle_remove(remove: RemoveDiffDict, dc_remove_dict: dict[str, Any]) -> str:
+    result = ""
+    if "collections" in remove:
+        collections_remove_list: CollectionsRemoveList = remove["collections"]
+        if isinstance(
+            collection_names := collections_remove_list[0], list
+        ) and isinstance(dc_collection_names := dc_remove_dict["collections"][0], list):
+            for collection_name in collection_names:
+                result += f"DROP TABLE {collection_name}_t CASCADE;\n"
+                dc_collection_names.remove(collection_name)
+        if isinstance(
+            remove_tree_dict := collections_remove_list[1], dict
+        ) and isinstance(dc_remove_tree_dict := dc_remove_dict["collections"][1], dict):
+            result += handle_remove_tree(remove_tree_dict, dc_remove_tree_dict)
+        remove_empty(dc_remove_dict, "collections")
+
+    if "enum_types" in remove and isinstance(
+        remove_enum_types_dict := remove["enum_types"], dict
+    ):
+        result += handle_remove_enum_types(
+            remove_enum_types_dict, dc_remove_dict["enum_types"]
+        )
+        remove_empty(dc_remove_dict, "enum_types")
+    return result
+
+
 def handle_remove_tree(
-    remove_tree_dict: dict[str, tuple[dict[str, Any], dict[str, Any]]],
-    dc_remove_tree_dict: dict[str, tuple[dict[str, Any], dict[str, Any]]],
+    remove_tree_dict: dict[str, Any],
+    dc_remove_tree_dict: dict[str, Any],
 ) -> str:
     result = ""
     for collection_name, field_lists in remove_tree_dict.items():
@@ -320,6 +348,22 @@ def handle_remove_tree(
             # TODO fields[1]
             # constraints_sql += f"ALTER TABLE {table_name} ALTER COLUMN {field_name} DROP DEFAULT ;\n"
             remove_empty(dc_remove_tree_dict[collection_name][1], "fields")
+        remove_empty(dc_remove_tree_dict, collection_name)
+    return result
+
+
+def handle_remove_enum_types(
+    remove_tree_dict: EnumTypesRemoveDict,
+    dc_remove_tree_dict: EnumTypesRemoveDict,
+) -> str:
+    result = ""
+    for collection_name, field_names in remove_tree_dict.items():
+        for field_name in field_names:
+            enum_name = HelperGetNames.get_enum_name_for_column(
+                collection_name, field_name
+            )
+            result += f"DROP TYPE {enum_name};\n"
+            dc_remove_tree_dict[collection_name].remove(field_name)
         remove_empty(dc_remove_tree_dict, collection_name)
     return result
 

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -395,6 +395,13 @@ def handle_remove_tree(
                                             collection_name, field_name
                                         ),
                                     )
+                                case "sequence_scope":
+                                    result += Helper.get_drop_trigger_statement(
+                                        collection_name,
+                                        HelperGetNames.get_partitioned_sequence_trigger_name(
+                                            collection_name, field_name
+                                        ),
+                                    )
                                 case value if (
                                     value in FieldAttributes.skipped_in_schema
                                 ):

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -13,6 +13,7 @@ from openslides_backend.migrations.yaml_diff_generator import (
     CollectionsRemoveList,
     EnumTypesRemoveDict,
     FieldAttributes,
+    MetaAttributesRemoveList,
     RemoveDiffDict,
     dumpjson,
     generate_diff,
@@ -332,6 +333,14 @@ def handle_remove(remove: RemoveDiffDict, dc_remove_dict: dict[str, Any]) -> str
             remove_enum_types_dict, dc_remove_dict["enum_types"]
         )
         remove_empty(dc_remove_dict, "enum_types")
+
+    if "_meta" in remove and isinstance(
+        remove_meta_attributes_list := remove["_meta"], list
+    ):
+        result += handle_remove_meta_attributes(
+            remove_meta_attributes_list, dc_remove_dict["_meta"]
+        )
+        remove_empty(dc_remove_dict, "_meta")
     return result
 
 
@@ -492,6 +501,28 @@ def handle_remove_enum_types(
             )
             dc_remove_tree_dict[collection_name].remove(field_name)
         remove_empty(dc_remove_tree_dict, collection_name)
+    return result
+
+
+def handle_remove_meta_attributes(
+    remove_meta_attributes_list: MetaAttributesRemoveList,
+    dc_remove_meta_attributes_list: MetaAttributesRemoveList,
+) -> str:
+    result = ""
+    if isinstance(remove_meta_attributes_list[1], dict) and isinstance(
+        dc_remove_meta_attributes_list[1], dict
+    ):
+        for attr, data in remove_meta_attributes_list[1].items():
+            match attr:
+                case "enum_definitions":
+                    for enum in data[0]:
+                        result += Helper.get_drop_type_statement(
+                            HelperGetNames.get_enum_name(enum)
+                        )
+                        dc_remove_meta_attributes_list[1][attr][0].remove(enum)
+                case _:
+                    raise NotImplementedError(f"_meta attribute: {attr}")
+            remove_empty(dc_remove_meta_attributes_list[1], attr)
     return result
 
 

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -424,6 +424,37 @@ def handle_remove_tree(
                                 dc_remove_tree_dict[collection_name][1]["fields"][1],
                                 field_name,
                             )
+                        for attr, attr_data in attrs[1].items():
+                            match attr:
+                                case "log_triggers":
+                                    processed_tables: dict[str, int] = {}
+                                    for log_trigger in attr_data:
+                                        trigger_name_iu, trigger_name_ud, *_ = (
+                                            Helper.get_log_calculated_id_array_trigger_data(
+                                                collection_name,
+                                                field_name,
+                                                log_trigger,
+                                                processed_tables,
+                                            )
+                                        )
+                                        for trigger_name in [
+                                            trigger_name_iu,
+                                            trigger_name_ud,
+                                        ]:
+                                            result += Helper.get_drop_trigger_statement(
+                                                log_trigger["on_table"], trigger_name
+                                            )
+                                case _:
+                                    raise NotImplementedError(
+                                        f"{collection_name}/{field_name}: {attr}"
+                                    )
+                            dc_remove_tree_dict[collection_name][1]["fields"][1][
+                                field_name
+                            ][1].pop(attr)
+                            remove_empty(
+                                dc_remove_tree_dict[collection_name][1]["fields"][1],
+                                field_name,
+                            )
                     remove_empty(dc_remove_tree_dict[collection_name][1], "fields")
                     remove_empty(dc_remove_tree_dict, collection_name)
                 case "unique_together":

--- a/openslides_backend/migrations/sql_diff_generator.py
+++ b/openslides_backend/migrations/sql_diff_generator.py
@@ -338,14 +338,25 @@ def handle_remove_tree(
     dc_remove_tree_dict: dict[str, Any],
 ) -> str:
     result = ""
-    for collection_name, field_lists in remove_tree_dict.items():
-        fields = field_lists[1]["fields"]
-        for field_name in fields[0]:
+    for collection_name, collection_data in remove_tree_dict.items():
+        fields_data = collection_data[1]["fields"]
+        for field_name in fields_data[0]:
             result += Helper.get_drop_column_statement(collection_name, field_name)
-
             dc_remove_tree_dict[collection_name][1]["fields"][0].remove(field_name)
-            # TODO fields[1]
-            # constraints_sql += f"ALTER TABLE {table_name} ALTER COLUMN {field_name} DROP DEFAULT ;\n"
+            remove_empty(dc_remove_tree_dict[collection_name][1], "fields")
+        for field_name, attrs in fields_data[1].items():
+            for attr in attrs[0]:
+                match attr:
+                    case "default":
+                        result += Helper.get_drop_column_attribute_statement(
+                            collection_name, field_name, "DEFAULT"
+                        )
+                dc_remove_tree_dict[collection_name][1]["fields"][1][field_name][
+                    0
+                ].remove(attr)
+                remove_empty(
+                    dc_remove_tree_dict[collection_name][1]["fields"][1], field_name
+                )
             remove_empty(dc_remove_tree_dict[collection_name][1], "fields")
         remove_empty(dc_remove_tree_dict, collection_name)
     return result

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -180,7 +180,11 @@ def create_remove_recursive(
             print(key + " renamed -> skip for remove")
             continue
         if key not in curr_models:
-            if key in [*CollectionAttributes.unique_together, "log_triggers"]:
+            if key in [
+                *CollectionAttributes.unique_together,
+                "log_triggers",
+                "equal_fields",
+            ]:
                 # Old definitions are needed to re-build the trigger difinitions names
                 tree[key] = prev_value
             elif key == "maxLength":

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -24,6 +24,60 @@ PREVIOUS_MODELS_DIR = os.path.join(
 )
 
 
+class FieldAttributes:
+    # TODO: if the list changes, we might need to take the migration index into account
+    skipped_in_schema = [
+        "calculated",
+        "constant_legacy",
+        "deferred",
+        "description",
+        "on_delete",
+        "read_only",
+        "restriction_mode",
+    ]
+    field_attributes = [
+        "default",
+        "maxLength",
+        "maximum",
+        "minLength",
+        "minimum",
+        "required",
+        "type",
+        "unique",
+    ]
+    relational_field_attributes = [
+        "reference",
+        "to",
+    ]
+    view_attributes = [
+        "sql",
+    ]
+    trigger_definitions = [
+        "constant",
+        "equal_fields",
+        "log_triggers",
+        "sequence_scope",
+    ]
+    enum_definitions = [
+        "enum",
+        "items",
+    ]
+    used_in_schema = [
+        *field_attributes,
+        *relational_field_attributes,
+        *view_attributes,
+        *trigger_definitions,
+        *enum_definitions,
+    ]
+
+
+class CollectionAttributes:
+    unique_together = [
+        "unique_together",
+        "unique_together_strict",
+    ]
+
+
 def main() -> int:
     parser = ArgumentParser()
     parser.add_argument("--dumpjson", action="store_true")

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -182,6 +182,8 @@ def create_remove_recursive(
             print(key + " renamed -> skip for remove")
             continue
         if key not in curr_models:
+            if key == "id" or len(path) >= 3 and path[2] == "id":
+                continue
             if key in [
                 *CollectionAttributes.unique_together,
                 "log_triggers",

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -30,6 +30,15 @@ PREVIOUS_MODELS_DIR = os.path.join(
 )
 
 
+def load_models(mig_data_path: str) -> dict[str, Any]:
+    meta_file = os.path.join(mig_data_path, "collection-meta.yml")
+    collections_dir = os.path.join(mig_data_path, "collections")
+    return yaml.safe_load(build_models_yaml_content(meta_file, collections_dir))
+
+
+PREV_MODELS = load_models(PREVIOUS_MODELS_DIR)
+CURR_MODELS = load_models(CURR_MODELS_DIR)
+
 CollectionsRemoveList = list[list[str] | dict[str, Any]]
 EnumTypesRemoveDict = dict[str, list[str]]
 MetaAttributesRemoveList = list[list[str] | dict[str, Any]]
@@ -110,23 +119,21 @@ def dumpjson(diff: dict[str, Any]) -> None:
 
 
 def generate_diff() -> dict[str, Any]:
-    prev_models = load_models(PREVIOUS_MODELS_DIR)
-    curr_models = load_models(CURR_MODELS_DIR)
     directory = MigrationHelper.get_last_migration_directory()
     renames = MigrationHelper.get_migration_class(directory).renames
 
-    validate_renames(prev_models, curr_models, renames)
+    validate_renames(PREV_MODELS, CURR_MODELS, renames)
     # Edits caused by adding or removing field attributes
     secondary_edits: dict[str, Any] = {}
 
     return {
         "rename": renames,
         "remove": create_remove_recursive(
-            prev_models, curr_models, renames, prev_models, secondary_edits
+            PREV_MODELS, CURR_MODELS, renames, secondary_edits
         ),
-        "add": create_add_recursive(prev_models, curr_models, renames),
+        "add": create_add_recursive(PREV_MODELS, CURR_MODELS, renames),
         "edit": create_edit_recursive(
-            prev_models, curr_models, renames, secondary_edits
+            PREV_MODELS, CURR_MODELS, renames, secondary_edits
         ),
     }
 
@@ -169,7 +176,6 @@ def create_remove_recursive(
     prev_models: dict[str, Any],
     curr_models: dict[str, Any],
     renames_dict: dict[str, Any],
-    all_prev_models: dict[str, Any],
     secondary_edits: dict[str, Any],
     enum_tree: EnumTypesRemoveDict = {},
     path: tuple[str, ...] = (),
@@ -217,11 +223,11 @@ def create_remove_recursive(
                         field_def = prev_value
                     else:
                         field_name = path[2]
-                        field_def = all_prev_models[path[0]][path[1]][path[2]]
+                        field_def = PREV_MODELS[path[0]][path[1]][path[2]]
                     if not (
-                        "type" in field_def 
+                        "type" in field_def
                         and is_relational_field(field_def["type"])
-                        and is_view_field(path[0], field_name, field_def, all_prev_models)
+                        and is_view_field(path[0], field_name, field_def)
                     ):
                         missing_entries.append(key)
                 else:
@@ -231,7 +237,6 @@ def create_remove_recursive(
                 prev_value,
                 curr_models.get(key, {}),
                 renames_dict.get(key, {}),
-                all_prev_models,
                 secondary_edits,
                 enum_tree,
                 path + (key,),
@@ -324,12 +329,6 @@ def create_edit_recursive(
         return None
 
 
-def load_models(mig_data_path: str) -> dict[str, Any]:
-    meta_file = os.path.join(mig_data_path, "collection-meta.yml")
-    collections_dir = os.path.join(mig_data_path, "collections")
-    return yaml.safe_load(build_models_yaml_content(meta_file, collections_dir))
-
-
 def is_enum(key: str) -> bool:
     return key in FieldAttributes.enum_definitions
 
@@ -351,22 +350,18 @@ def is_relational_field(field_type: str) -> bool:
 
 
 def is_view_field(
-    collection_name: str,
-    field_name: str,
-    field_data: dict[str, Any],
-    all_prev_models: dict[str, dict[str, Any]],
+    collection_name: str, field_name: str, field_data: dict[str, Any]
 ) -> bool:
-    own = TableFieldType(collection_name, field_name, field_data)
+    own_field = TableFieldType(collection_name, field_name, field_data)
 
-    new_models = InternalHelper.MODELS
-    InternalHelper.MODELS = all_prev_models
+    InternalHelper.MODELS = PREV_MODELS
     foreign_fields = InternalHelper.get_definitions_from_foreign_list(
         field_data.get("to", None),
         field_data.get("reference", None),
     )
-    InternalHelper.MODELS = new_models
+    InternalHelper.MODELS = CURR_MODELS
 
-    state, *_ = InternalHelper.check_relation_definitions(own, foreign_fields)
+    state, *_ = InternalHelper.check_relation_definitions(own_field, foreign_fields)
     return state == FieldSqlErrorType.SQL
 
 

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -42,7 +42,6 @@ class RemoveDiffDict(TypedDict):
 
 
 class FieldAttributes:
-    # TODO: if the list changes, we might need to take the migration index into account
     skipped_in_schema = [
         "calculated",
         "constant_legacy",
@@ -171,10 +170,15 @@ def create_remove_recursive(
     curr_models: dict[str, Any],
     renames_dict: dict[str, Any],
     all_prev_models: dict[str, Any],
-    secondary_edits: dict[str, Any] = {},
+    secondary_edits: dict[str, Any],
     enum_tree: EnumTypesRemoveDict = {},
     path: tuple[str, ...] = (),
 ) -> CollectionsRemoveList | RemoveDiffDict | None:
+    """
+    Parameter `path` is used only internally and describes the path to the node
+    within the tree created inside the outer create_remove_recursive call.
+    Example: (collection_name, "fields", field_name)
+    """
     missing_entries = []
     tree = {}
     for key, prev_value in prev_models.items():

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -180,7 +180,9 @@ def create_remove_recursive(
             print(key + " renamed -> skip for remove")
             continue
         if key not in curr_models:
-            if is_enum(key) and len(path) >= 3:
+            if key in CollectionAttributes.unique_together:
+                tree[key] = prev_value
+            elif is_enum(key) and len(path) >= 3:
                 # Should be processed as type change
                 if "type" in curr_models:
                     update_edits_tree(
@@ -263,6 +265,7 @@ def create_edit_recursive(
     Returns the edited entries on pos 0 and the sub trees on pos 1.
     TODO This has a very similar structure to the add recursive function. Maybe combine with use of lambda or passing additional dict.
     TODO This should only generate diffs for the leafs. Thus the structure should be reconsidered. Maybe flatter or integrating rename info.
+    TODO: changes in lists for `unique_together` and `unique_together_strict` must be processed as add or remove operations.
     """
     edited_entries = {}
     tree = {}

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -1,10 +1,11 @@
 import os
 import sys
 from argparse import ArgumentParser
-from typing import Any
+from typing import Any, TypedDict
 
 import simplejson as json
 import yaml
+from typing_extensions import NotRequired
 
 from meta.dev.src.helper_get_names import ROOT as CURR_MODELS_DIR
 from meta.dev.src.helper_get_names import build_models_yaml_content
@@ -22,6 +23,15 @@ The json diff will be written to 'previous_models/diff.json' if --dumpjson is gi
 PREVIOUS_MODELS_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "previous_models"
 )
+
+
+CollectionsRemoveList = list[list[str] | dict[str, Any]]
+EnumTypesRemoveDict = dict[str, list[str]]
+
+
+class RemoveDiffDict(TypedDict):
+    collections: NotRequired[CollectionsRemoveList]
+    enum_types: NotRequired[EnumTypesRemoveDict]
 
 
 class FieldAttributes:
@@ -139,7 +149,9 @@ def create_remove_recursive(
     prev_models: dict[str, Any],
     curr_models: dict[str, Any],
     renames_dict: dict[str, Any],
-) -> list[list[str] | dict[str, Any]] | None:
+    enum_tree: EnumTypesRemoveDict = {},
+    path: tuple[str, ...] = (),
+) -> CollectionsRemoveList | RemoveDiffDict | None:
     missing_entries = []
     tree = {}
     for key, prev_value in prev_models.items():
@@ -147,18 +159,36 @@ def create_remove_recursive(
             print(key + " renamed -> skip for remove")
             continue
         if key not in curr_models:
-            missing_entries.append(key)
-        elif isinstance(prev_value, dict):
+            if is_enum(key, prev_value) and len(path) >= 3:
+                enum_tree.setdefault(path[0], []).append(path[2])
+            elif curr_models:
+                missing_entries.append(key)
+        if isinstance(prev_value, dict) and key != "items":
             result = create_remove_recursive(
-                prev_value, curr_models[key], renames_dict.get(key, {})
+                prev_value,
+                curr_models.get(key, {}),
+                renames_dict.get(key, {}),
+                enum_tree,
+                path + (key,),
             )
             if result is not None:
                 tree[key] = result
 
+    if path:
+        if missing_entries or tree:
+            return [missing_entries, tree]
+        else:
+            return None
+
+    combined_result: RemoveDiffDict = {}
     if missing_entries or tree:
-        return [missing_entries, tree]
-    else:
-        return None
+        combined_result["collections"] = [missing_entries, tree]
+    if enum_tree:
+        combined_result["enum_types"] = enum_tree
+
+    if combined_result:
+        return combined_result
+    return None
 
 
 def create_add_recursive(
@@ -224,6 +254,13 @@ def load_models(mig_data_path: str) -> dict[str, Any]:
     meta_file = os.path.join(mig_data_path, "collection-meta.yml")
     collections_dir = os.path.join(mig_data_path, "collections")
     return yaml.safe_load(build_models_yaml_content(meta_file, collections_dir))
+
+
+def is_enum(key: str, value: Any) -> bool:
+    return key in FieldAttributes.enum_definitions and (
+        isinstance(value, list)
+        or (isinstance(value, dict) and isinstance(value["enum"], list))
+    )
 
 
 if __name__ == "__main__":

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -189,7 +189,7 @@ def create_remove_recursive(
                 "log_triggers",
                 "equal_fields",
             ]:
-                # Old definitions are needed to re-build the trigger difinitions names
+                # Old definitions are needed to re-build the trigger definitions names
                 tree[key] = prev_value
             elif key == "maxLength":
                 # Should be processed as type change

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -218,12 +218,11 @@ def create_remove_recursive(
                     else:
                         field_name = path[2]
                         field_def = all_prev_models[path[0]][path[1]][path[2]]
-                    if "type" in field_def and is_relational_field(field_def["type"]):
-                        if not is_view_field(
-                            path[0], field_name, field_def, all_prev_models
-                        ):
-                            missing_entries.append(key)
-                    else:
+                    if not (
+                        "type" in field_def 
+                        and is_relational_field(field_def["type"])
+                        and is_view_field(path[0], field_name, field_def, all_prev_models)
+                    ):
                         missing_entries.append(key)
                 else:
                     missing_entries.append(key)

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -8,7 +8,12 @@ import yaml
 from typing_extensions import NotRequired
 
 from meta.dev.src.helper_get_names import ROOT as CURR_MODELS_DIR
-from meta.dev.src.helper_get_names import build_models_yaml_content
+from meta.dev.src.helper_get_names import (
+    FieldSqlErrorType,
+    InternalHelper,
+    TableFieldType,
+    build_models_yaml_content,
+)
 from openslides_backend.migrations.migration_helper import MigrationHelper
 
 """
@@ -116,7 +121,7 @@ def generate_diff() -> dict[str, Any]:
     return {
         "rename": renames,
         "remove": create_remove_recursive(
-            prev_models, curr_models, renames, secondary_edits
+            prev_models, curr_models, renames, prev_models, secondary_edits
         ),
         "add": create_add_recursive(prev_models, curr_models, renames),
         "edit": create_edit_recursive(
@@ -163,6 +168,7 @@ def create_remove_recursive(
     prev_models: dict[str, Any],
     curr_models: dict[str, Any],
     renames_dict: dict[str, Any],
+    all_prev_models: dict[str, Any],
     secondary_edits: dict[str, Any] = {},
     enum_tree: EnumTypesRemoveDict = {},
     path: tuple[str, ...] = (),
@@ -184,12 +190,17 @@ def create_remove_recursive(
                 if is_field_enum(prev_value):
                     enum_tree.setdefault(path[0], []).append(path[2])
             elif curr_models:
-                missing_entries.append(key)
+                if len(path) == 2 and is_relational_field(prev_value["type"]):
+                    if not is_view_field(path[0], key, prev_value, all_prev_models):
+                        missing_entries.append(key)
+                else:
+                    missing_entries.append(key)
         if isinstance(prev_value, dict) and key != "items":
             result = create_remove_recursive(
                 prev_value,
                 curr_models.get(key, {}),
                 renames_dict.get(key, {}),
+                all_prev_models,
                 secondary_edits,
                 enum_tree,
                 path + (key,),
@@ -294,6 +305,35 @@ def is_field_enum(value: Any) -> bool:
     return isinstance(value, list) or (
         isinstance(value, dict) and isinstance(value["enum"], list)
     )
+
+
+def is_relational_field(field_type: str) -> bool:
+    return field_type in [
+        "relation",
+        "generic-relation",
+        "relation-list",
+        "generic-relation-list",
+    ]
+
+
+def is_view_field(
+    collection_name: str,
+    field_name: str,
+    field_data: dict[str, Any],
+    all_prev_models: dict[str, dict[str, Any]],
+) -> bool:
+    own = TableFieldType(collection_name, field_name, field_data)
+
+    new_models = InternalHelper.MODELS
+    InternalHelper.MODELS = all_prev_models
+    foreign_fields = InternalHelper.get_definitions_from_foreign_list(
+        field_data.get("to", None),
+        field_data.get("reference", None),
+    )
+    InternalHelper.MODELS = new_models
+
+    state, *_ = InternalHelper.check_relation_definitions(own, foreign_fields)
+    return state == FieldSqlErrorType.SQL
 
 
 if __name__ == "__main__":

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -185,6 +185,9 @@ def create_remove_recursive(
             elif key == "maxLength":
                 # Should be processed as type change
                 update_edits_tree(secondary_edits, path[0], path[2], "maxLength", None)
+            elif key == "sequence_scope":
+                missing_entries.append(key)
+                tree[key] = prev_value
             elif is_enum(key) and len(path) >= 3:
                 # Should be processed as type change
                 if "type" in curr_models:
@@ -214,6 +217,18 @@ def create_remove_recursive(
                 tree[key] = result
 
     if path:
+        if (
+            tree
+            and len(path) == 1
+            and "fields" in tree
+            and isinstance(tree["fields"], list)
+        ):
+            for field_name, data in tree["fields"][1].items():
+                if sequence_scope := data[1].pop("sequence_scope", None):
+                    tree.setdefault("unique_together", []).append(
+                        f"{field_name}, {sequence_scope}"
+                    )
+
         if missing_entries or tree:
             return [missing_entries, tree]
         else:

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -110,12 +110,18 @@ def generate_diff() -> dict[str, Any]:
     renames = MigrationHelper.get_migration_class(directory).renames
 
     validate_renames(prev_models, curr_models, renames)
+    # Edits caused by adding or removing field attributes
+    secondary_edits: dict[str, Any] = {}
 
     return {
         "rename": renames,
-        "remove": create_remove_recursive(prev_models, curr_models, renames),
+        "remove": create_remove_recursive(
+            prev_models, curr_models, renames, secondary_edits
+        ),
         "add": create_add_recursive(prev_models, curr_models, renames),
-        "edit": create_edit_recursive(prev_models, curr_models, renames),
+        "edit": create_edit_recursive(
+            prev_models, curr_models, renames, secondary_edits
+        ),
     }
 
 
@@ -145,10 +151,19 @@ def validate_renames(
             )
 
 
+def update_edits_tree(
+    edits_tree: dict[str, Any], collection: str, field: str, attr: str, value: Any
+) -> None:
+    edits_tree.setdefault(collection, [{}, {}])[1].setdefault("fields", [{}, {}])[
+        1
+    ].setdefault(field, [{}, {}])[0][attr] = value
+
+
 def create_remove_recursive(
     prev_models: dict[str, Any],
     curr_models: dict[str, Any],
     renames_dict: dict[str, Any],
+    secondary_edits: dict[str, Any] = {},
     enum_tree: EnumTypesRemoveDict = {},
     path: tuple[str, ...] = (),
 ) -> CollectionsRemoveList | RemoveDiffDict | None:
@@ -159,8 +174,15 @@ def create_remove_recursive(
             print(key + " renamed -> skip for remove")
             continue
         if key not in curr_models:
-            if is_enum(key, prev_value) and len(path) >= 3:
-                enum_tree.setdefault(path[0], []).append(path[2])
+            if is_enum(key) and len(path) >= 3:
+                # Should be processed as type change
+                if "type" in curr_models:
+                    update_edits_tree(
+                        secondary_edits, path[0], path[2], "type", curr_models["type"]
+                    )
+                # Delete enum only when it is defined on the field
+                if is_field_enum(prev_value):
+                    enum_tree.setdefault(path[0], []).append(path[2])
             elif curr_models:
                 missing_entries.append(key)
         if isinstance(prev_value, dict) and key != "items":
@@ -168,6 +190,7 @@ def create_remove_recursive(
                 prev_value,
                 curr_models.get(key, {}),
                 renames_dict.get(key, {}),
+                secondary_edits,
                 enum_tree,
                 path + (key,),
             )
@@ -223,6 +246,7 @@ def create_edit_recursive(
     prev_models: dict[str, Any],
     curr_models: dict[str, Any],
     renames_dict: dict[str, Any],
+    secondary_edits: dict[str, Any] = {},
 ) -> tuple[dict[str, Any], dict[str, Any]] | None:
     """
     Returns the edited entries on pos 0 and the sub trees on pos 1.
@@ -244,6 +268,11 @@ def create_edit_recursive(
                 )
                 if result is not None:
                     tree[key] = result
+    if secondary_edits:
+        for collection, collection_data in secondary_edits.items():
+            for field_name, field_data in collection_data[1]["fields"][1].items():
+                for attr, value in field_data[0].items():
+                    update_edits_tree(tree, collection, field_name, attr, value)
     if edited_entries or tree:
         return (edited_entries, tree)
     else:
@@ -256,10 +285,14 @@ def load_models(mig_data_path: str) -> dict[str, Any]:
     return yaml.safe_load(build_models_yaml_content(meta_file, collections_dir))
 
 
-def is_enum(key: str, value: Any) -> bool:
-    return key in FieldAttributes.enum_definitions and (
-        isinstance(value, list)
-        or (isinstance(value, dict) and isinstance(value["enum"], list))
+def is_enum(key: str) -> bool:
+    return key in FieldAttributes.enum_definitions
+
+
+def is_field_enum(value: Any) -> bool:
+    """Checks that enum options are defined directly on the field"""
+    return isinstance(value, list) or (
+        isinstance(value, dict) and isinstance(value["enum"], list)
     )
 
 

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -180,7 +180,8 @@ def create_remove_recursive(
             print(key + " renamed -> skip for remove")
             continue
         if key not in curr_models:
-            if key in CollectionAttributes.unique_together:
+            if key in [*CollectionAttributes.unique_together, "log_triggers"]:
+                # Old definitions are needed to re-build the trigger difinitions names
                 tree[key] = prev_value
             elif key == "maxLength":
                 # Should be processed as type change
@@ -283,7 +284,7 @@ def create_edit_recursive(
     Returns the edited entries on pos 0 and the sub trees on pos 1.
     TODO This has a very similar structure to the add recursive function. Maybe combine with use of lambda or passing additional dict.
     TODO This should only generate diffs for the leafs. Thus the structure should be reconsidered. Maybe flatter or integrating rename info.
-    TODO: changes in lists for `unique_together` and `unique_together_strict` must be processed as add or remove operations.
+    TODO: changes in lists for `unique_together`, `unique_together_strict` and `log_triggers` must be processed as add or remove operations.
     """
     edited_entries = {}
     tree = {}

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -205,12 +205,22 @@ def create_remove_recursive(
                 if is_field_enum(prev_value):
                     enum_tree.setdefault(path[0], []).append(path[2])
             elif curr_models:
-                if (
-                    len(path) == 2
-                    and "type" in prev_value
-                    and is_relational_field(prev_value["type"])
-                ):
-                    if not is_view_field(path[0], key, prev_value, all_prev_models):
+                # TODO: currently `constant` on the reading side of the relation
+                # is being excluded from diff within this check. This has to be changed
+                # after implementing https://github.com/OpenSlides/openslides-meta/issues/542
+                if len(path) >= 2 and key != "sql":
+                    if len(path) == 2:
+                        field_name = key
+                        field_def = prev_value
+                    else:
+                        field_name = path[2]
+                        field_def = all_prev_models[path[0]][path[1]][path[2]]
+                    if "type" in field_def and is_relational_field(field_def["type"]):
+                        if not is_view_field(
+                            path[0], field_name, field_def, all_prev_models
+                        ):
+                            missing_entries.append(key)
+                    else:
                         missing_entries.append(key)
                 else:
                     missing_entries.append(key)

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -182,6 +182,9 @@ def create_remove_recursive(
         if key not in curr_models:
             if key in CollectionAttributes.unique_together:
                 tree[key] = prev_value
+            elif key == "maxLength":
+                # Should be processed as type change
+                update_edits_tree(secondary_edits, path[0], path[2], "maxLength", None)
             elif is_enum(key) and len(path) >= 3:
                 # Should be processed as type change
                 if "type" in curr_models:

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -194,9 +194,6 @@ def create_remove_recursive(
             elif key == "maxLength":
                 # Should be processed as type change
                 update_edits_tree(secondary_edits, path[0], path[2], "maxLength", None)
-            elif key == "sequence_scope":
-                missing_entries.append(key)
-                tree[key] = prev_value
             elif is_enum(key) and len(path) >= 3:
                 # Should be processed as type change
                 if "type" in curr_models:
@@ -240,18 +237,6 @@ def create_remove_recursive(
                 tree[key] = result
 
     if path:
-        if (
-            tree
-            and len(path) == 1
-            and "fields" in tree
-            and isinstance(tree["fields"], list)
-        ):
-            for field_name, data in tree["fields"][1].items():
-                if sequence_scope := data[1].pop("sequence_scope", None):
-                    tree.setdefault("unique_together", []).append(
-                        f"{field_name}, {sequence_scope}"
-                    )
-
         if missing_entries or tree:
             return [missing_entries, tree]
         else:

--- a/openslides_backend/migrations/yaml_diff_generator.py
+++ b/openslides_backend/migrations/yaml_diff_generator.py
@@ -32,11 +32,13 @@ PREVIOUS_MODELS_DIR = os.path.join(
 
 CollectionsRemoveList = list[list[str] | dict[str, Any]]
 EnumTypesRemoveDict = dict[str, list[str]]
+MetaAttributesRemoveList = list[list[str] | dict[str, Any]]
 
 
 class RemoveDiffDict(TypedDict):
     collections: NotRequired[CollectionsRemoveList]
     enum_types: NotRequired[EnumTypesRemoveDict]
+    _meta: NotRequired[MetaAttributesRemoveList]
 
 
 class FieldAttributes:
@@ -203,7 +205,11 @@ def create_remove_recursive(
                 if is_field_enum(prev_value):
                     enum_tree.setdefault(path[0], []).append(path[2])
             elif curr_models:
-                if len(path) == 2 and is_relational_field(prev_value["type"]):
+                if (
+                    len(path) == 2
+                    and "type" in prev_value
+                    and is_relational_field(prev_value["type"])
+                ):
                     if not is_view_field(path[0], key, prev_value, all_prev_models):
                         missing_entries.append(key)
                 else:
@@ -240,6 +246,8 @@ def create_remove_recursive(
             return None
 
     combined_result: RemoveDiffDict = {}
+    if _meta := tree.pop("_meta", None):
+        combined_result["_meta"] = _meta
     if missing_entries or tree:
         combined_result["collections"] = [missing_entries, tree]
     if enum_tree:


### PR DESCRIPTION
Needs https://github.com/OpenSlides/openslides-meta/pull/557

Special handling:
- Skipped from diff.json:
    - relational view fields. @hjanott will view_generation PR deal with deleted view fields or changed `to`?
    - `constant` defined on the view fields. Currently we don't generate triggers for such fields but it will change if we implement https://github.com/OpenSlides/openslides-meta/issues/542;
    - Fields from skipped_in_schema - no need to migrate;
    - `to` and `reference`: sql diff generator will raise `NotImplementedError`. They are required for relational fields and we are not changing type from relational field to something else in the first migrations. So let's skip it for now;
    - `type`: strictly required => will raise `BadCodingException`;
    - `equal_fields`: added a todo. I'll take care of it after rewriting equal_fields in sql generator.
- `edit`-changes triggered by removing lines in the collection-files:
    - Removing enum from the field attributes means changing the type from this enum to the type from the new field definition => `create_remove_recursive` now also updates `edit` section to add this change;
    - Enum can be safely removed only after it is not used as a type in the fields =>  `edit` operations should be executed before `remove`;
    - `maxLength`: removing it should lead to changing the field type => adding this to `diff["edit"]` as well.
- `log_triggers`, `equal_fields`: contain more details in `diff.json` than just the attribute name (needed to build the trigger names);
- `unique_together`, `sequence_scope`: generated separately under `unique_together` next to `fields`;
- changes from `collections-meta.yml`: generated separately under `_meta` next to `collections`;
- Enum types to be dropped that are defined on fields: generated separately under `enum_types` next to `collections`.

Triggers are dropped with `IF EXISTS` -> to avoid errors if trigger was already dropped within the cascade delete of a related column.